### PR TITLE
refactor(backend): adjust default download cache dir to `app_cache_dir` and create it if not exist

### DIFF
--- a/src-tauri/src/launcher_config/commands.rs
+++ b/src-tauri/src/launcher_config/commands.rs
@@ -1,6 +1,7 @@
 use super::models::{LauncherConfig, MemoryInfo};
 use crate::storage::Storage;
 use crate::{error::SJMCLResult, partial::PartialUpdate};
+use std::fs;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use systemstat::{saturating_sub_bytes, Platform};
@@ -39,9 +40,13 @@ pub fn restore_launcher_config(
 ) -> SJMCLResult<LauncherConfig> {
   let mut state = state.lock()?;
   *state = LauncherConfig::default();
+  // Set and create default download cache dir
   state.download.cache.directory = app
     .path()
-    .resolve::<PathBuf>("Download".into(), BaseDirectory::Cache)?;
+    .resolve::<PathBuf>("Download".into(), BaseDirectory::AppCache)?;
+  if !state.download.cache.directory.exists() {
+    fs::create_dir_all(&state.download.cache.directory).unwrap();
+  }
   state.save()?;
   Ok(state.clone())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod partial;
 mod storage;
 mod utils;
 
+use std::fs;
 use std::path::PathBuf;
 use std::sync::{LazyLock, Mutex};
 
@@ -60,12 +61,17 @@ pub async fn run() {
       // Set the launcher config
       let mut launcher_config: LauncherConfig = LauncherConfig::load().unwrap_or_default();
 
+      // Set default download cache dir if not exists, create dir
       if launcher_config.download.cache.directory == PathBuf::default() {
         launcher_config.download.cache.directory = app
           .handle()
           .path()
-          .resolve::<PathBuf>("Download".into(), BaseDirectory::Cache)
+          .resolve::<PathBuf>("Download".into(), BaseDirectory::AppCache)
           .unwrap();
+      }
+
+      if !launcher_config.download.cache.directory.exists() {
+        fs::create_dir_all(&launcher_config.download.cache.directory).unwrap();
       }
 
       launcher_config.version = version.clone();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "SJMCL",
   "version": "0.0.0",
-  "identifier": "com.sjmc.launcher",
+  "identifier": "SJMCL",
   "build": {
     "frontendDist": "../out",
     "devUrl": "http://localhost:3000",


### PR DESCRIPTION
…er, create dir if not exists

<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - e.g. close #xxxx, fix #xxxx

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

我认为需要在启动 / 重置设置时保证下载缓存目录的存在性，避免尚未下载时点击“打开目录”的操作遇到错误

### Additional Context

> - Add any other relevant information or screenshots here.

