### PR TITLE
fix(backend): hide console when running `where` on Windows

### DIFF
--- a/src-tauri/src/launcher_config/helpers.rs
+++ b/src-tauri/src/launcher_config/helpers.rs
@@ -9,6 +9,8 @@ use tauri::{AppHandle, Manager};
 
 #[cfg(target_os = "windows")]
 use std::error::Error;
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
 
 use super::models::{GameDirectory, LauncherConfig};
 
@@ -106,7 +108,11 @@ pub fn get_java_paths() -> Vec<String> {
 
   // List java paths from System PATH variable
   #[cfg(target_os = "windows")]
-  let command_output = Command::new("where").arg("java").output();
+  let command_output = Command::new("where")
+    .arg("java")
+    // See https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
+    .creation_flags(0x08000000) // CREATE_NO_WINDOW
+    .output();
 
   #[cfg(any(target_os = "macos", target_os = "linux"))]
   let command_output = Command::new("which").args(["-a", "java"]).output();


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🐞 Bug fix

### Related Issues

fix #165 

### Description

通过在新建进程时指定CREATE_NO_WINDOW FLAG以让where进程不会弹出控制台窗口。

http://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags

### Additional Context


