### PR TITLE
fix(frontend): fix display bug of wrap-card and option-item

### DIFF
--- a/src/components/common/option-item.tsx
+++ b/src/components/common/option-item.tsx
@@ -52,7 +52,13 @@ export const OptionItem: React.FC<OptionItemProps> = ({
         {prefixElement && (
           <Skeleton isLoaded={!isLoading}>{prefixElement}</Skeleton>
         )}
-        <VStack spacing={0} mr={2} alignItems="start" overflow="hidden">
+        <VStack
+          spacing={0}
+          mr={2}
+          alignItems="start"
+          overflow="hidden"
+          flex="1"
+        >
           <HStack spacing={2} flexWrap="wrap">
             <Skeleton isLoaded={!isLoading}>
               <Text fontSize="xs-sm" className="no-select">

--- a/src/components/common/wrap-card.tsx
+++ b/src/components/common/wrap-card.tsx
@@ -73,9 +73,10 @@ export const WrapCard: React.FC<WrapCardProps> = ({
           ))}
         <Text
           fontSize="xs-sm"
-          className="no-select"
+          className="no-select ellipsis-text"
           fontWeight={isSelected ? "bold" : "normal"}
           mt={image ? 2 : 0}
+          overflow="hidden"
         >
           {title}
         </Text>


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

close #293 

### Description

- 对于 wrap-card，标题被限制为显示一行+省略号
- 对于 option-item，使用 flex="1" 确保正确分配空间

### Additional Context


