### PR TITLE
fix(scripts): recursively check for missing keys in target locale

### DIFF
--- a/scripts/locale/genplaceholder.js
+++ b/scripts/locale/genplaceholder.js
@@ -21,6 +21,28 @@ function addTodoPlaceholder(value) {
   return value;
 }
 
+function mergeWithPlaceholder(source, target) {
+  const result = { ...target };
+  for (const key in source) {
+    // If key doesn't exist in target, add it with placeholder
+    if (!(key in target)) {
+      result[key] = addTodoPlaceholder(source[key]);
+    }
+    // If both are objects, recursively merge them
+    else if (
+      typeof source[key] === "object" &&
+      source[key] !== null &&
+      !Array.isArray(source[key]) &&
+      typeof target[key] === "object" &&
+      target[key] !== null &&
+      !Array.isArray(target[key])
+    ) {
+      result[key] = mergeWithPlaceholder(source[key], target[key]);
+    }
+  }
+  return result;
+}
+
 function generatePlaceholder(source, target) {
   // Define paths for source and target locale files
   const sourceFile = path.join(
@@ -88,15 +110,10 @@ function generatePlaceholder(source, target) {
             process.exit(1);
           }
 
-          // Create a new object to hold the updated locale data
-          const updatedData = { ...targetLocaleData };
-
-          // Process the source data to add placeholders for missing keys
-          for (const key in sourceLocaleData) {
-            if (!(key in targetLocaleData)) {
-              updatedData[key] = addTodoPlaceholder(sourceLocaleData[key]);
-            }
-          }
+          const updatedData = mergeWithPlaceholder(
+            sourceLocaleData,
+            targetLocaleData
+          );
 
           // Write the updated JSON to the target file
           fs.writeFile(


### PR DESCRIPTION
fix(scripts): recursively check for missing keys in target locale

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

#308 

### Description

modified genplaceholder.js so that it recursively checks for missing keys in target locale.

### Additional Context

> 应该在保持顺序的情况下，对相对于 source 缺失的字段添加 %TODO，对和 source 一致的字段不做处理，对比 source 多的字段也不做处理

目前的处理逻辑似乎是按首字母顺序写入
我试图对一个新生成的locale json删除AboutSettingsPage.about.title，重新运行脚本后这一键值重新出现，但它出现在AboutSettingPage.about.settings后
![image](https://github.com/user-attachments/assets/0c6f761c-d7ef-4088-af30-27dd8d43988f)
![image](https://github.com/user-attachments/assets/9f793c1b-cec6-4c9e-93d2-5d2d80b5217b)


