### PR TITLE
fix(frontend): fix switch type and button avaliability logic in add-player-modal

### DIFF
--- a/src-tauri/src/instance/helpers/mods/forge.rs
+++ b/src-tauri/src/instance/helpers/mods/forge.rs
@@ -17,6 +17,7 @@ pub struct NewforgeModMetadata {
   pub loader_version: String,
   pub license: String,
   pub mods: Vec<NewforgeModSubItem>,
+  // some non-standard mods write logo_file field in toml meta section.
   pub logo_file: Option<String>,
   // not in file, added by sjmcl
   pub valid_logo_file: Option<ImageWrapper>,

--- a/src-tauri/src/instance/helpers/mods/neoforge.rs
+++ b/src-tauri/src/instance/helpers/mods/neoforge.rs
@@ -17,6 +17,7 @@ pub struct NeoforgeModMetadata {
   pub loader_version: String,
   pub license: String,
   pub mods: Vec<NeoforgeModSubItem>,
+  // some non-standard mods write logo_file field in toml meta section.
   pub logo_file: Option<String>,
   // not in file, added by sjmcl
   pub valid_logo_file: Option<ImageWrapper>,

--- a/src/components/modals/add-player-modal.tsx
+++ b/src/components/modals/add-player-modal.tsx
@@ -135,11 +135,15 @@ const AddPlayerModal: React.FC<AddPlayerModalProps> = ({
   useEffect(() => {
     setPassword("");
     initialRef.current?.focus();
+    setShowAdvancedOptions(false);
+    setUuid("");
   }, [playerType]);
 
   useEffect(() => {
     setPlayername("");
     setPassword("");
+    setShowAdvancedOptions(false);
+    setUuid("");
   }, [modalProps.isOpen]);
 
   useEffect(() => {
@@ -539,7 +543,9 @@ const AddPlayerModal: React.FC<AddPlayerModalProps> = ({
                 isLoading={isLoading}
                 isDisabled={
                   !playername ||
-                  (playerType === "offline" && !isOfflinePlayernameValid) ||
+                  (playerType === "offline" &&
+                    !isOfflinePlayernameValid(playername)) ||
+                  (uuid && !isUuidValid(uuid)) ||
                   (playerType === "3rdparty" &&
                     authServerList.length > 0 &&
                     (!authServer || !password))


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🐞 Bug fix

### Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - e.g. close #xxxx, fix #xxxx

### Description

* 修复离线模式下确定按钮的可用性条件
* 切换 playerType 时清空 UUID 文本框并收起高级选项（否则切换再切回会出现 UUID 上方 spacing 丢失）
* 补充：每次打开 modal 时清空 UUID 文本框

