### PR TITLE
feat(ci/cd): add dmg artifact in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,14 +126,15 @@ jobs:
           workspaces: "./src-tauri -> target"
           key: ${{ matrix.platform }}-${{ matrix.target }}
 
-      - name: Build the app
-        run: pnpm run tauri build --target ${{ matrix.target }}
+      - name: Build the app and the DMG image (MacOS)
+        if: matrix.platform == 'macos'
+        run: pnpm run tauri build --bundles app,dmg --target ${{ matrix.target }}
         env:
           SJMCL_MICROSOFT_CLIENT_SECRET: ${{ secrets.SJMCL_MICROSOFT_CLIENT_SECRET }}
 
-      - name: Build DMG image
-        if: matrix.platform == 'macos'
-        run: pnpm run tauri build --bundles dmg --target ${{ matrix.target }}
+      - name: Build the app
+        if: matrix.platform != 'macos'
+        run: pnpm run tauri build --target ${{ matrix.target }}
         env:
           SJMCL_MICROSOFT_CLIENT_SECRET: ${{ secrets.SJMCL_MICROSOFT_CLIENT_SECRET }}
 
@@ -151,6 +152,7 @@ jobs:
             mv "src-tauri/target/${{ matrix.target }}/release/bundle/msi/"*.msi artifacts/"$ARTIFACT_NAME".msi
             ls -la artifacts
           elif [ "${{ matrix.platform }}" = "macos" ]; then
+            ls src-tauri/target/${{ matrix.target }}/release/bundle/macos
             # For MacOS, compress the .app folder
             tar -cvzf artifacts/"$ARTIFACT_NAME".app.tar.gz -C "src-tauri/target/${{ matrix.target }}/release/bundle/macos" "SJMCL.app"
             # And copy the DMG files


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

None

### Description

Added DMG artifacts to the macos workflow.

### Additional Context

Points worth noticing:
* `pnpm run tauri build --bundles dmg` actually does the following steps:
  * builds the app
  * runs a script to package the app into a dmg file
  * removes the app file
Thus the macOS build workflow is separated from Windows and Linux, using `--bundles app,dmg` to reduce resource usage.

