### PR TITLE
fix(ci/cd): sort versions by version id string if exist two versions with same releaseTime

### DIFF
--- a/scripts/game/fetch_version_list.js
+++ b/scripts/game/fetch_version_list.js
@@ -25,17 +25,20 @@ https
     res.on("end", () => {
       try {
         const json = JSON.parse(data);
-        const versions = json.versions.sort((a, b) => {
-          const releaseTimeA = new Date(a.releaseTime);
-          const releaseTimeB = new Date(b.releaseTime);
-          if (releaseTimeA.getTime() === releaseTimeB.getTime()) {
-            // If release times are the same, sort by "id" in ascending order
-            return a.id.localeCompare(b.id);
-          } else {
-            // Otherwise, sort by release time in ascending order
-            return releaseTimeA - releaseTimeB;
-          }
-        });
+        const versions = json.versions
+          .map((v) => ({
+            id: v.id,
+            timestamp: new Date(v.releaseTime).getTime(),
+          }))
+          .sort((a, b) => {
+            if (a.timestamp === b.timestamp) {
+              // If release times are the same, sort by "id" in ascending order
+              return a.id.localeCompare(b.id);
+            } else {
+              // Otherwise, sort by release time in ascending order
+              return a.timestamp - b.timestamp;
+            }
+          });
         const versionIds = versions.map((v) => v.id);
         const text = versionIds.join("\n") + '\n';
 


### PR DESCRIPTION

<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

None

### Description

As observed in #468 , the data from Mojang's version list API is not consistent; since 1.4.5 and 1.4.6 have the same releaseTime, their order is not stable.
This PR updates the script used to update the version list to sort versions by version id string if exist two versions with same releaseTime

### Additional Context

None

