### PR TITLE
fix(frontend): auto scroll some content to top when router changes

### DIFF
--- a/src/layouts/instance-details-layout.tsx
+++ b/src/layouts/instance-details-layout.tsx
@@ -225,7 +225,13 @@ const InstanceDetailsLayoutContent: React.FC<{ children: React.ReactNode }> = ({
           ),
         }))}
       />
-      <VStack overflow="auto" align="strench" spacing={4} flex="1">
+      <VStack
+        overflow="auto"
+        align="strench"
+        spacing={4}
+        flex="1"
+        className="scroll-container"
+      >
         {children}
       </VStack>
 

--- a/src/layouts/settings-layout.tsx
+++ b/src/layouts/settings-layout.tsx
@@ -67,7 +67,7 @@ const SettingsLayout: React.FC<SettingsLayoutProps> = ({ children }) => {
           ))}
         </VStack>
       </GridItem>
-      <GridItem className="content-full-y">
+      <GridItem className="content-full-y scroll-container">
         <VStack align="stretch" spacing={4}>
           {children}
         </VStack>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -106,6 +106,18 @@ export default function App({ Component, pageProps }: AppProps) {
   // when switching tabs in game instance page
   // see https://github.com/UNIkeEN/SJMCL/pull/491
 
+  useEffect(() => {
+    const containers = document.querySelectorAll(".scroll-container");
+    containers.forEach((container) => {
+      container.scrollTo({
+        top: 0,
+        behavior: "smooth",
+      });
+    });
+  }, [router.asPath]);
+  // Reset some specific components' scroll position when router.asPath changes (not use router.pathname because dynamic routes)
+  // see https://github.com/UNIkeEN/SJMCL/issues/526
+
   return (
     <ChakraProvider theme={chakraExtendTheme}>
       <ToastContextProvider>

--- a/src/pages/instances/details/[id]/settings/index.tsx
+++ b/src/pages/instances/details/[id]/settings/index.tsx
@@ -170,8 +170,8 @@ const InstanceSettingsPage = () => {
   ];
 
   return (
-    <Box height="100%" overflowY="auto">
-      <VStack overflow="auto" align="strench" spacing={4} flex="1">
+    <Box height="100%" overflowY="auto" className="scroll-container">
+      <VStack align="strench" spacing={4} flex="1">
         {instanceSpecSettingsGroups.map((group, index) => (
           <OptionItemGroup
             title={group.title}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

fix #526 

### Description

除了全局设置界面之间的切换，还包括：实例页面切换、不同实例的设置 / 高级设置等切换

均应用了切换后滚动回顶部的策略

### Additional Context

> - Add any other relevant information or screenshots here.

