### PR TITLE
fix(frontend): rewrite the mod list sync / cache logic

### DIFF
--- a/src/contexts/instance.tsx
+++ b/src/contexts/instance.tsx
@@ -30,6 +30,7 @@ export interface InstanceContextType {
   gameConfig: GameConfig | undefined;
   getWorldList: (sync?: boolean) => WorldInfo[] | undefined;
   getLocalModList: (sync?: boolean) => Promise<LocalModInfo[] | undefined>;
+  isLocalModListLoading: boolean;
   getResourcePackList: (sync?: boolean) => ResourcePackInfo[] | undefined;
   getServerResourcePackList: (sync?: boolean) => ResourcePackInfo[] | undefined;
   getSchematicList: (sync?: boolean) => SchematicInfo[] | undefined;
@@ -387,10 +388,19 @@ export const InstanceContextProvider: React.FC<{
 
   const getWorldList = useGetState(worlds, handleRetrieveWorldList);
 
-  const getLocalModList = usePromisedGetState(
+  const [getLocalModList, isLocalModListLoading] = usePromisedGetState(
     localMods,
     handleRetrieveLocalModList
   );
+
+  useEffect(() => {
+    if (instanceSummary?.id) {
+      getLocalModList(true).then((mods) => {
+        setLocalMods(mods);
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [instanceSummary?.id]);
 
   const getResourcePackList = useGetState(
     resourcePacks,
@@ -427,6 +437,7 @@ export const InstanceContextProvider: React.FC<{
         gameConfig: instanceGameConfig,
         getWorldList,
         getLocalModList,
+        isLocalModListLoading,
         getResourcePackList,
         getServerResourcePackList,
         getSchematicList,

--- a/src/hooks/get-state.ts
+++ b/src/hooks/get-state.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 export function useGetState<T>(
   state: T | undefined,
@@ -18,16 +18,24 @@ export function useGetState<T>(
 export function usePromisedGetState<T>(
   state: T | undefined,
   retrieveHandler: () => Promise<any>
-): (sync?: boolean) => Promise<T | undefined> {
+): [(sync?: boolean) => Promise<T | undefined>, boolean] {
+  const [isLoading, setIsLoading] = useState(false);
   const getState = useCallback(
     async (sync = false) => {
       if (sync || state === undefined) {
-        const data = await retrieveHandler();
-        return data;
+        setIsLoading(true);
+        try {
+          const data = await retrieveHandler();
+          return data;
+        } catch (_) {
+          return undefined;
+        } finally {
+          setIsLoading(false);
+        }
       } else return state;
     },
     [state, retrieveHandler]
   );
 
-  return getState;
+  return [getState, isLoading];
 }

--- a/src/pages/instances/details/[id]/mods.tsx
+++ b/src/pages/instances/details/[id]/mods.tsx
@@ -45,6 +45,7 @@ const InstanceModsPage = () => {
     handleOpenInstanceSubdir,
     handleImportResource,
     getLocalModList,
+    isLocalModListLoading: isLoading,
   } = useInstanceSharedData();
   const { config, update } = useLauncherConfig();
   const { openSharedModal } = useSharedModals();
@@ -55,16 +56,11 @@ const InstanceModsPage = () => {
   const [filteredMods, setFilteredMods] = useState<LocalModInfo[]>([]);
   const [query, setQuery] = useState("");
   const [isSearching, setIsSearching] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   const getLocalModListWrapper = useCallback(
     (sync?: boolean) => {
-      setIsLoading(true);
-      getLocalModList(sync)
-        .then((data) => setLocalMods(data || []))
-        .catch((e) => setLocalMods([] as LocalModInfo[]))
-        .finally(() => setIsLoading(false));
+      getLocalModList(sync).then((data) => setLocalMods(data || []));
     },
     [getLocalModList]
   );
@@ -241,9 +237,11 @@ const InstanceModsPage = () => {
         isAccordion
         initialIsOpen={accordionStates[1]}
         titleExtra={
-          <CountTag
-            count={`${query.trim() ? `${filteredMods.length} / ` : ""}${localMods.length}`}
-          />
+          !isLoading && (
+            <CountTag
+              count={`${query.trim() ? `${filteredMods.length} / ` : ""}${localMods.length}`}
+            />
+          )
         }
         onAccordionToggle={(isOpen) => {
           update(


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - fix #552 

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - 思路：改为在 `context` 中的 `useEffect` 判断是否发生了实例 `summary id` 变更，是则 `sync=true` 向后端更新。其他情况（如：当 `nav menu` 切换时）由组件中的 `useEffect` 调用 `sync=false` 请求缓存。
> - 由于有两级的更新，因此把 `isLoading` 的状态也塞进 `usePromisedGetState` 钩子里，方便处理。

