### PR TITLE
fix(frontend): optimize dirname check, adjust code style of editable

### DIFF
--- a/src/components/common/editable.tsx
+++ b/src/components/common/editable.tsx
@@ -48,7 +48,6 @@ const Editable: React.FC<EditableProps> = ({
   ...boxProps
 }) => {
   const [isEditing, setIsEditing] = useState(false);
-  const [isInvalid, setIsInvalid] = useState(true);
   const [tempValue, setTempValue] = useState(value);
 
   const ref = useRef<HTMLElement | HTMLInputElement | HTMLTextAreaElement>(
@@ -68,9 +67,9 @@ const Editable: React.FC<EditableProps> = ({
             variant="ghost"
             h={18}
             aria-label="submit"
-            isDisabled={isInvalid}
+            isDisabled={checkError(tempValue) !== 0}
             onClick={() => {
-              if (isInvalid) return;
+              if (checkError(tempValue)) return;
               if (tempValue !== value) onEditSubmit(tempValue);
               setIsEditing(false);
             }}
@@ -87,7 +86,6 @@ const Editable: React.FC<EditableProps> = ({
             onClick={() => {
               setTempValue(value);
               setIsEditing(false);
-              setIsInvalid(false);
             }}
           />
         </Tooltip>
@@ -119,7 +117,8 @@ const Editable: React.FC<EditableProps> = ({
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter") {
       e.preventDefault();
-      if (checkError(tempValue) !== 0) return;
+      if (checkError(tempValue)) return;
+
       if (tempValue !== value) onEditSubmit(tempValue);
       setIsEditing(false);
     }
@@ -129,20 +128,17 @@ const Editable: React.FC<EditableProps> = ({
     <Box {...boxProps}>
       {isEditing ? (
         isTextArea ? (
-          <FormControl pb={5} isInvalid={isInvalid && isEditing}>
+          <FormControl
+            pb={5}
+            isInvalid={checkError(tempValue) !== 0 && isEditing}
+          >
             <Textarea
               ref={ref as React.RefObject<HTMLTextAreaElement>}
               value={tempValue}
               placeholder={placeholder}
               onChange={(e) => setTempValue(e.target.value)}
-              onBlur={() => {
-                setIsInvalid(checkError(tempValue) !== 0);
-                onBlur();
-              }}
-              onFocus={() => {
-                setIsInvalid(false);
-                onFocus();
-              }}
+              onBlur={onBlur}
+              onFocus={onFocus}
               onKeyDown={onKeyDown}
               focusBorderColor={`${primaryColor}.500`}
               {...(inputProps as TextareaProps)}
@@ -150,7 +146,7 @@ const Editable: React.FC<EditableProps> = ({
             <HStack>
               <FormErrorMessage {...formErrMsgProps}>
                 {localeKey &&
-                  (isInvalid && isEditing
+                  (checkError(tempValue) && isEditing
                     ? t(`${localeKey}.error-${checkError(tempValue)}`)
                     : "")}
               </FormErrorMessage>
@@ -160,21 +156,15 @@ const Editable: React.FC<EditableProps> = ({
             </HStack>
           </FormControl>
         ) : (
-          <FormControl isInvalid={isInvalid && isEditing}>
+          <FormControl isInvalid={checkError(tempValue) !== 0 && isEditing}>
             <HStack>
               <Input
                 ref={ref as React.RefObject<HTMLInputElement>}
                 value={tempValue}
                 placeholder={placeholder}
                 onChange={(e) => setTempValue(e.target.value)}
-                onBlur={() => {
-                  setIsInvalid(checkError(tempValue) !== 0);
-                  onBlur();
-                }}
-                onFocus={() => {
-                  setIsInvalid(false);
-                  onFocus();
-                }}
+                onBlur={onBlur}
+                onFocus={onFocus}
                 onKeyDown={onKeyDown}
                 focusBorderColor={`${primaryColor}.500`}
                 {...(inputProps as InputProps)}
@@ -183,7 +173,7 @@ const Editable: React.FC<EditableProps> = ({
             </HStack>
             <FormErrorMessage {...formErrMsgProps}>
               {localeKey &&
-                (isInvalid && isEditing
+                (checkError(tempValue) && isEditing
                   ? t(`${localeKey}.error-${checkError(tempValue)}`)
                   : "")}
             </FormErrorMessage>

--- a/src/components/instance-basic-settings.tsx
+++ b/src/components/instance-basic-settings.tsx
@@ -11,6 +11,7 @@ import { InstanceIconSelectorPopover } from "@/components/instance-icon-selector
 import { useLauncherConfig } from "@/contexts/config";
 import { GameDirectory } from "@/models/config";
 import { getGameDirName } from "@/utils/instance";
+import { isSanitized } from "@/utils/string";
 
 interface InstanceBasicSettingsProps {
   name: string;
@@ -41,6 +42,13 @@ export const InstanceBasicSettings: React.FC<InstanceBasicSettingsProps> = ({
     }
   }, [config, setGameDirectory]);
 
+  const checkDirNameError = (value: string): number => {
+    if (value.trim() === "") return 1;
+    if (!isSanitized(value)) return 2;
+    if (value.length > 255) return 3;
+    return 0;
+  };
+
   const instanceSpecSettingsGroups: OptionItemGroupProps[] = [
     {
       items: [
@@ -50,11 +58,11 @@ export const InstanceBasicSettings: React.FC<InstanceBasicSettingsProps> = ({
             <Editable
               isTextArea={false}
               value={name}
-              onEditSubmit={(value) => setName(value.trim())}
+              onEditSubmit={setName}
               textProps={{ className: "secondary-text", fontSize: "xs-sm" }}
               inputProps={{ fontSize: "xs-sm" }}
               formErrMsgProps={{ fontSize: "xs-sm" }}
-              checkError={(value) => (value.trim() === "" ? 1 : 0)}
+              checkError={checkDirNameError}
               localeKey="InstanceSettingsPage.errorMessage"
             />
           ),

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -960,7 +960,8 @@
     "restore": "Restore",
     "errorMessage": {
       "error-1": "Instance name cannot be empty",
-      "error-2": "Instance name contains invalid characters or system-reserved words"
+      "error-2": "Instance name is invalid",
+      "error-3": "Instance name is too long"
     }
   },
   "InstanceShaderPacksPage": {

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -960,7 +960,8 @@
     "restore": "重置",
     "errorMessage": {
       "error-1": "实例名称不能为空",
-      "error-2": "实例名称存在非法字符"
+      "error-2": "实例名称不合法",
+      "error-3": "实例名称太长"
     }
   },
   "InstanceShaderPacksPage": {

--- a/src/pages/instances/details/[id]/settings/index.tsx
+++ b/src/pages/instances/details/[id]/settings/index.tsx
@@ -42,6 +42,13 @@ const InstanceSettingsPage = () => {
   } = useInstanceSharedData();
   const useSpecGameConfig = summary?.useSpecGameConfig || false;
 
+  const checkDirNameError = (value: string): number => {
+    if (value.trim() === "") return 1;
+    if (!isSanitized(value)) return 2;
+    if (value.length > 255) return 3;
+    return 0;
+  };
+
   const handleRenameInstance = useCallback(
     (name: string) => {
       if (!instanceId) return;
@@ -69,15 +76,11 @@ const InstanceSettingsPage = () => {
             <Editable
               isTextArea={false}
               value={summary?.name || ""}
-              onEditSubmit={(value) => {
-                handleRenameInstance(value);
-              }}
+              onEditSubmit={handleRenameInstance}
               textProps={{ className: "secondary-text", fontSize: "xs-sm" }}
               inputProps={{ fontSize: "xs-sm" }}
               formErrMsgProps={{ fontSize: "xs-sm" }}
-              checkError={(value) =>
-                value.trim() === "" ? 1 : isSanitized(value) ? 0 : 2
-              }
+              checkError={checkDirNameError}
               localeKey="InstanceSettingsPage.errorMessage"
             />
           ),

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -44,7 +44,12 @@ export const formatDisplayCount = (count: number): string => {
 
 export const isSanitized = (str: string): boolean => {
   const forbiddenChars = /[\\/:*?"<>|]/;
-  const reservedNames = /^(con|prn|aux|nul|com\d|lpt\d)$/i;
+  const reservedNames = /^(con|prn|aux|nul|com[0-9]|lpt[0-9])$/i;
+  const startsOrEndsWithInvalid = /^\s|\s$|^\.+|^\.+$|.*\.$/;
 
-  return !forbiddenChars.test(str) && !reservedNames.test(str);
+  return (
+    !forbiddenChars.test(str) &&
+    !reservedNames.test(str) &&
+    !startsOrEndsWithInvalid.test(str)
+  );
 };


### PR DESCRIPTION
component

<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

close #495 

### Description

首先很抱歉这个 issue 有第二条修复的 pr

这个 commit 主要做了这么几件事：
- 修改了目录名称的检查逻辑，除了 teru 老师说的末尾不能有空格以外，其实末尾也不能有“.” （体现在 `string.ts` 的 isSanitized 函数中）；考虑到其他系统可能 . 开头的文件夹会被隐藏，我这里采用了更严格的检测，头尾都不能有空格和点
- 增加了长度检定（大部分系统貌似都是 255 长限制）
- 把这些修改同步应用到了创建实例时的名称修改组件
- 优化了 editable 组件的逻辑，顺带解决了 teru 老师检查出的问题（名称不合法时按回车没反应）

### Additional Context

无

