### PR TITLE
fix(mods): handle cancelled local mod retrieval gracefully

### DIFF
--- a/src/components/game-version-selector.tsx
+++ b/src/components/game-version-selector.tsx
@@ -30,6 +30,7 @@ import {
 import { Section } from "@/components/common/section";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
+import { GetStateFlag } from "@/hooks/get-state";
 import { GameResourceInfo } from "@/models/resource";
 import { ISOToDatetime } from "@/utils/datetime";
 
@@ -54,7 +55,8 @@ export const GameVersionSelector: React.FC<GameVersionSelectorProps> = ({
   const { config, update } = useLauncherConfig();
   const primaryColor = config.appearance.theme.primaryColor;
 
-  const { getGameVersionList } = useGlobalData();
+  const { getGameVersionList, isGameVersionListLoading: isLoading } =
+    useGlobalData();
   const [versions, setVersions] = useState<GameResourceInfo[]>([]);
   const [filteredVersions, setFilteredVersions] = useState<GameResourceInfo[]>(
     []
@@ -64,15 +66,15 @@ export const GameVersionSelector: React.FC<GameVersionSelectorProps> = ({
     new Set(config.states.gameVersionSelector.gameTypes)
   );
   const [searchText, setSearchText] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
   const [mounted, setMounted] = useState(false);
 
   const getGameVersionListWrapper = useCallback(() => {
-    setIsLoading(true);
     getGameVersionList(true)
-      .then((data) => setVersions(data || []))
-      .catch((e) => setVersions([] as GameResourceInfo[]))
-      .finally(() => setIsLoading(false));
+      .then((data) => {
+        if (data === GetStateFlag.Cancelled) return;
+        setVersions(data || []);
+      })
+      .catch((e) => setVersions([] as GameResourceInfo[]));
   }, [getGameVersionList]);
 
   useEffect(() => {

--- a/src/components/instance-widgets.tsx
+++ b/src/components/instance-widgets.tsx
@@ -39,6 +39,7 @@ import Empty from "@/components/common/empty";
 import { OptionItem } from "@/components/common/option-item";
 import { useLauncherConfig } from "@/contexts/config";
 import { useInstanceSharedData } from "@/contexts/instance";
+import { GetStateFlag } from "@/hooks/get-state";
 import { LocalModInfo } from "@/models/instance/misc";
 import { ScreenshotInfo } from "@/models/instance/misc";
 import { WorldInfo } from "@/models/instance/world";
@@ -229,7 +230,7 @@ export const InstanceModsWidget = () => {
     (sync?: boolean) => {
       getLocalModList(sync)
         .then((data) => {
-          if (data === "%CANCELLED%") return; // do not update state if cancelled
+          if (data === GetStateFlag.Cancelled) return; // do not update state if cancelled
           setLocalMods(data || []);
         })
         .catch((e) => setLocalMods([] as LocalModInfo[]));

--- a/src/components/resource-downloader.tsx
+++ b/src/components/resource-downloader.tsx
@@ -34,6 +34,7 @@ import {
   sortByLists,
   worldTagList,
 } from "@/enums/resource";
+import { GetStateFlag } from "@/hooks/get-state";
 import { InstanceSummary } from "@/models/instance/misc";
 import { GameResourceInfo, OtherResourceInfo } from "@/models/resource";
 import { ResourceService } from "@/services/resource";
@@ -398,7 +399,7 @@ const ResourceDownloader: React.FC<ResourceDownloaderProps> = ({
 
   useEffect(() => {
     getGameVersionList().then((list) => {
-      if (list) {
+      if (list && list !== GetStateFlag.Cancelled) {
         const versionList = list
           .filter((version: GameResourceInfo) => version.gameType === "release")
           .map((version: GameResourceInfo) => version.id);

--- a/src/contexts/global-data.tsx
+++ b/src/contexts/global-data.tsx
@@ -7,7 +7,11 @@ import React, {
 } from "react";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
-import { useGetState, usePromisedGetState } from "@/hooks/get-state";
+import {
+  GetStateFlag,
+  useGetState,
+  usePromisedGetState,
+} from "@/hooks/get-state";
 import { AuthServer, Player } from "@/models/account";
 import { InstanceSummary } from "@/models/instance/misc";
 import { GameResourceInfo } from "@/models/resource";
@@ -23,7 +27,8 @@ interface GlobalDataContextType {
   getAuthServerList: (sync?: boolean) => AuthServer[] | undefined;
   getGameVersionList: (
     sync?: boolean
-  ) => Promise<GameResourceInfo[] | undefined>;
+  ) => Promise<GameResourceInfo[] | GetStateFlag | undefined>;
+  isGameVersionListLoading: boolean;
 }
 
 // for frontend-only state update
@@ -145,7 +150,7 @@ export const GlobalDataContextProvider: React.FC<{
     handleRetrieveAuthServerList
   );
 
-  const [getGameVersionList] = usePromisedGetState(
+  const [getGameVersionList, isGameVersionListLoading] = usePromisedGetState(
     gameVersionList,
     handleFetchGameVersionList
   );
@@ -159,6 +164,7 @@ export const GlobalDataContextProvider: React.FC<{
         getInstanceList,
         getAuthServerList,
         getGameVersionList,
+        isGameVersionListLoading,
       }}
     >
       <GlobalDataDispatchContext.Provider

--- a/src/contexts/instance.tsx
+++ b/src/contexts/instance.tsx
@@ -10,10 +10,13 @@ import React, {
 import { useGlobalData, useGlobalDataDispatch } from "@/contexts/global-data";
 import { useToast } from "@/contexts/toast";
 import { InstanceSubdirType } from "@/enums/instance";
-import { useGetState, usePromisedGetState } from "@/hooks/get-state";
+import {
+  GetStateFlag,
+  useGetState,
+  usePromisedGetState,
+} from "@/hooks/get-state";
 import { GameConfig } from "@/models/config";
 import {
-  GetStateCancelFlag,
   InstanceSummary,
   LocalModInfo,
   ResourcePackInfo,
@@ -32,7 +35,7 @@ export interface InstanceContextType {
   getWorldList: (sync?: boolean) => WorldInfo[] | undefined;
   getLocalModList: (
     sync?: boolean
-  ) => Promise<LocalModInfo[] | GetStateCancelFlag | undefined>;
+  ) => Promise<LocalModInfo[] | GetStateFlag | undefined>;
   isLocalModListLoading: boolean;
   getResourcePackList: (sync?: boolean) => ResourcePackInfo[] | undefined;
   getServerResourcePackList: (sync?: boolean) => ResourcePackInfo[] | undefined;
@@ -413,7 +416,7 @@ export const InstanceContextProvider: React.FC<{
   useEffect(() => {
     if (instanceSummary?.id) {
       getLocalModList(true).then((mods) => {
-        if (mods === "%CANCELLED%") return; // do not update state if cancelled
+        if (mods === GetStateFlag.Cancelled) return; // do not update state if cancelled
         setLocalMods(mods);
       });
     }

--- a/src/hooks/get-state.ts
+++ b/src/hooks/get-state.ts
@@ -1,5 +1,8 @@
 import { useCallback, useState } from "react";
-import { GetStateCancelFlag } from "@/models/instance/misc";
+
+export enum GetStateFlag {
+  Cancelled = "%CANCELLED%",
+}
 
 export function useGetState<T>(
   state: T | undefined,
@@ -19,7 +22,7 @@ export function useGetState<T>(
 export function usePromisedGetState<T>(
   state: T | undefined,
   retrieveHandler: () => Promise<any>
-): [(sync?: boolean) => Promise<T | GetStateCancelFlag | undefined>, boolean] {
+): [(sync?: boolean) => Promise<T | GetStateFlag | undefined>, boolean] {
   const [isLoading, setIsLoading] = useState(false);
   const getState = useCallback(
     async (sync = false) => {

--- a/src/models/instance/misc.ts
+++ b/src/models/instance/misc.ts
@@ -41,8 +41,6 @@ export interface LocalModInfo {
   potentialIncompatibility: boolean;
 }
 
-export type GetStateCancelFlag = "%CANCELLED%";
-
 export interface ResourcePackInfo {
   name: string;
   description?: string;

--- a/src/pages/instances/details/[id]/mods.tsx
+++ b/src/pages/instances/details/[id]/mods.tsx
@@ -33,6 +33,7 @@ import { useSharedModals } from "@/contexts/shared-modal";
 import { useToast } from "@/contexts/toast";
 import { InstanceSubdirType, ModLoaderType } from "@/enums/instance";
 import { InstanceError } from "@/enums/service-error";
+import { GetStateFlag } from "@/hooks/get-state";
 import { LocalModInfo } from "@/models/instance/misc";
 import { InstanceService } from "@/services/instance";
 import { base64ImgSrc } from "@/utils/string";
@@ -61,7 +62,7 @@ const InstanceModsPage = () => {
   const getLocalModListWrapper = useCallback(
     (sync?: boolean) => {
       getLocalModList(sync).then((data) => {
-        if (data === "%CANCELLED%") {
+        if (data === GetStateFlag.Cancelled) {
           // this means the user has cancelled the operation.
           return;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - fix #552 

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - 用一个 ref 来同步记录当前的 summary id，确保不会触发 retrieve 函数刷新的同时保持同步
> - 判断 retrieve 前后的 ref 值是否相同，不同就传一个假的 mod 标记回去，告诉前端不要更新。
