### PR TITLE
fix(download): loosen sha1 requirement

### DIFF
--- a/src-tauri/src/tasks/download.rs
+++ b/src-tauri/src/tasks/download.rs
@@ -25,7 +25,7 @@ use super::*;
 pub struct DownloadParam {
   src: Url,
   dest: PathBuf,
-  sha1: String,
+  sha1: Option<String>,
 }
 
 pub struct DownloadTask {
@@ -153,16 +153,21 @@ impl DownloadTask {
       .unwrap();
     let mut hasher = Sha1::new();
     std::io::copy(&mut f, &mut hasher).unwrap();
-    let sha1 = hex::encode(hasher.finalize());
-    if sha1 != param.sha1 {
-      Err(SJMCLError(format!(
-        "SHA1 mismatch for {}: expected {}, got {}",
-        dest_path.display(),
-        param.sha1,
-        sha1
-      )))
-    } else {
-      Ok(())
+    match param.sha1 {
+      Some(truth) => {
+        let sha1 = hex::encode(hasher.finalize());
+        if sha1 != truth {
+          Err(SJMCLError(format!(
+            "SHA1 mismatch for {}: expected {}, got {}",
+            dest_path.display(),
+            truth,
+            sha1
+          )))
+        } else {
+          Ok(())
+        }
+      }
+      None => Ok(()),
     }
   }
 


### PR DESCRIPTION
Remove mandatory sha1 checksuming in download.

<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

None

### Description

Loosen the checksum requirement of download tasks


