### PR TITLE
fix(ci/cd): use 0.0.0 version number for nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -92,20 +92,20 @@ jobs:
         with:
           node-version: lts/*
 
-      - name: Bump version to nightly
+      - name: Bump version to 0.0.0
         if: steps.check-changes.outputs.should_build == 'true'
         run: |
-          echo "Bumping version to nightly..."
-          npm run version bump nightly
+          echo "Bumping version to 0.0.0..."
+          npm run version bump 0.0.0
           
           # Commit the version change to nightly branch
           git add .
-          git commit -m "bump: version to nightly for statistics server" || echo "No changes to commit"
+          git commit -m "bump: version to 0.0.0 for statistics server" || echo "No changes to commit"
           
           # Push the updated nightly branch with version bump
           git push origin refs/heads/nightly:refs/heads/nightly
           
-          echo "Version bumped to nightly and committed"
+          echo "Version bumped to 0.0.0 and committed"
 
       - name: Generate nightly version
         id: version


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

close #598 

### Description

Rust does not accept "nightly" as the version number string (since it is not a legitimate semantic version string).
Thus switch to 0.0.0 for nightly versions.

### Additional Context

None

