### PR TITLE
fix(download): unshare sjmcl client from download tasks

### DIFF
--- a/src-tauri/src/tasks/monitor.rs
+++ b/src-tauri/src/tasks/monitor.rs
@@ -242,9 +242,7 @@ impl TaskMonitor {
           tokio::spawn(async move {
             let r = future.f.await;
             match r {
-              Ok(_) => {
-                info!("Task {task_id} completed");
-              }
+              Ok(_) => {}
               Err(e) => {
                 info!("Task failed: {e:?}");
                 if let Some(group_name) = future.task_group {

--- a/src-tauri/src/utils/web.rs
+++ b/src-tauri/src/utils/web.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 /// * `use_proxy` - Whether to use the proxy settings from the config.
 ///
 /// TODO: support more custom config from reqwest::Config
+/// FIXME: Seems like hyper will panic if this client is shared across threads.
 ///
 /// # Returns
 ///
@@ -78,6 +79,7 @@ impl RetryableStrategy for SJMCLRetryableStrategy {
       Err(error) if matches!(error.status(), Some(StatusCode::FORBIDDEN)) => {
         Some(Retryable::Transient)
       }
+      Err(error) if error.is_request() => Some(Retryable::Transient),
       Err(error) => default_on_request_failure(error),
     }
   }


### PR DESCRIPTION


<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

#622

### Description

> Seems like in https://users.rust-lang.org/t/runtime-dropped-the-dispatch-task/91915 the task will be droped if sjmcl client is shared across runtimes/threads.

Build a sjmcl client whenever a new download task is needed.


