### PR TITLE
fix(download): reuse sjmcl_client for connection reuse

### DIFF
--- a/src-tauri/src/tasks/download.rs
+++ b/src-tauri/src/tasks/download.rs
@@ -12,7 +12,7 @@ use std::future::Future;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-use tauri::{AppHandle, Url};
+use tauri::{AppHandle, Manager, Url};
 use tauri_plugin_http::reqwest;
 use tauri_plugin_http::reqwest::header::{ACCEPT_ENCODING, RANGE};
 use tokio::io::AsyncSeekExt;
@@ -127,7 +127,8 @@ impl DownloadTask {
     current: i64,
     param: &DownloadParam,
   ) -> SJMCLResult<reqwest::Response> {
-    let client = with_retry(build_sjmcl_client(app_handle, true, false));
+    let state = app_handle.state::<reqwest::Client>();
+    let client = with_retry(state.inner().clone());
     let request = if current == 0 {
       client
         .get(param.src.clone())

--- a/src-tauri/src/tasks/monitor.rs
+++ b/src-tauri/src/tasks/monitor.rs
@@ -13,9 +13,9 @@ use std::future::Future;
 use std::sync::atomic::AtomicU32;
 use std::sync::{Arc, Mutex, RwLock};
 use std::vec::Vec;
+use tauri::async_runtime::JoinHandle;
 use tauri::AppHandle;
 use tokio::sync::Semaphore;
-use tokio::task::JoinHandle;
 
 use super::events::TEvent;
 use super::SJMCLFuture;
@@ -254,7 +254,7 @@ impl TaskMonitor {
 
       self.tasks.lock().unwrap().insert(
         future.task_id,
-        tokio::spawn(async move {
+        tauri::async_runtime::spawn(async move {
           // Move the permit into the spawned task
           let _permit = permit;
 


### PR DESCRIPTION
Seems like previous cross-runtime issues are fixed by previous optimized downloads. reuse the sjmcl_client.

<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - e.g. close #xxxx, fix #xxxx

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

