### PR TITLE
fix(resource): fix bugs in loader parse and game version sort

### DIFF
--- a/src-tauri/src/resource/helpers/curseforge.rs
+++ b/src-tauri/src/resource/helpers/curseforge.rs
@@ -201,7 +201,7 @@ pub fn map_curseforge_file_to_version_pack(
           loader: if loader.is_empty() {
             None
           } else {
-            Some(loader.to_string().to_lowercase())
+            Some(loader.to_string())
           },
         };
 

--- a/src-tauri/src/resource/helpers/curseforge.rs
+++ b/src-tauri/src/resource/helpers/curseforge.rs
@@ -201,7 +201,7 @@ pub fn map_curseforge_file_to_version_pack(
           loader: if loader.is_empty() {
             None
           } else {
-            Some(loader.to_string())
+            Some(loader.to_string().to_lowercase())
           },
         };
 

--- a/src-tauri/src/resource/helpers/modrinth.rs
+++ b/src-tauri/src/resource/helpers/modrinth.rs
@@ -97,7 +97,14 @@ pub fn map_modrinth_file_to_version_pack(
     };
 
     const ALLOWED_LOADERS: &[&str] = &[
-      "forge", "fabric", "neoforge", "vanilla", "iris", "canvas", "optifine",
+      "forge",
+      "fabric",
+      "neoforge",
+      "vanilla",
+      "iris",
+      "canvas",
+      "optifine",
+      "minecraft",
     ];
 
     let loaders = if version.loaders.is_empty() {
@@ -125,10 +132,10 @@ pub fn map_modrinth_file_to_version_pack(
             download_url: file.url.clone(),
             sha1: file.hashes.sha1.clone(),
             file_name: file.filename.clone(),
-            loader: if loader.is_empty() {
+            loader: if loader.is_empty() || loader == "minecraft" {
               None
             } else {
-              Some(loader.to_string())
+              Some(loader.to_string().to_lowercase())
             },
           })
           .collect::<Vec<_>>();

--- a/src-tauri/src/resource/helpers/modrinth.rs
+++ b/src-tauri/src/resource/helpers/modrinth.rs
@@ -135,7 +135,16 @@ pub fn map_modrinth_file_to_version_pack(
             loader: if loader.is_empty() || loader == "minecraft" {
               None
             } else {
-              Some(loader.to_string().to_lowercase())
+              match loader.as_str() {
+                "forge" => Some("Forge".to_string()),
+                "fabric" => Some("Fabric".to_string()),
+                "neoforge" => Some("NeoForge".to_string()),
+                "vanilla" => Some("Vanilla".to_string()),
+                "iris" => Some("Iris".to_string()),
+                "canvas" => Some("Canvas".to_string()),
+                "optifine" => Some("OptiFine".to_string()),
+                _ => Some(loader.clone()),
+              }
             },
           })
           .collect::<Vec<_>>();


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

None

### Description

修复了三个问题：
1.
<img width="1000" height="667" alt="c05cf7468350be19f08c852ce20c43a4" src="https://github.com/user-attachments/assets/a804779f-2517-4ff3-a5d0-b2f12d5793e2" />
Curseforge 特色带 -Snapshot 后缀的版本，之前没做特别适配，导致排的不对（现在会把它排在 1.20.5 后面，1.20.4 前面）；加之现行的排序函数还是在版本名是 loader + version 时代的产物，此 PR 统一做了更新

2.
<img width="996" height="662" alt="b511a9881809e30ffcba99ad84c56820" src="https://github.com/user-attachments/assets/b23ab359-3449-42e5-99be-887f94cd8f87" />
Modrinth 搜资源包什么都搜不出来。因为 Modrinth 对资源包的 loader 是 “minecraft”，之前重构后端那次漏了这里，此 PR 对此也做了修复

3.
<img width="995" height="658" alt="13e0894f6c1b5d1687f975437f7d6955" src="https://github.com/user-attachments/assets/8f006aa5-3ed1-42ca-bc40-7c5e154dbfa2" />
<img width="998" height="663" alt="25192823bed7f6d2785a097f0afd9f2c" src="https://github.com/user-attachments/assets/87f0e9d8-8506-440b-a347-56d523fc86a1" />
Curseforge 和 Modrinth 默认返回的 loader 格式不同，一个全小写，一个首字母大写。因为 rust 无现成的首字母大写函数，所以暂时是统一成了全小写

### Additional Context

None

