### PR TITLE
fix(launch): handle manually cancelled launches without showing error window

### DIFF
--- a/src-tauri/src/launch/commands.rs
+++ b/src-tauri/src/launch/commands.rs
@@ -306,11 +306,12 @@ pub async fn launch_game(
 pub fn cancel_launch_process(
   launching_queue_state: State<'_, Mutex<Vec<LaunchingState>>>,
 ) -> SJMCLResult<()> {
-  let launching_queue = launching_queue_state.lock()?;
+  let mut launching_queue = launching_queue_state.lock()?;
 
   // kill process if pid exists
-  if let Some(launching) = launching_queue.last() {
+  if let Some(launching) = launching_queue.last_mut() {
     if launching.pid != 0 {
+      launching.current_step = 0; // mark as manually cancelled to avoid game error window popping up
       kill_process(launching.pid)?;
     }
   }


### PR DESCRIPTION

<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - fix #760 

### Description

> - 在 `cancel_process` 中将 `current_step` 标注为 `0` 后再 `kill`，这样当 `process_monitor` 检测到错误时先对比 `current_step`，若为 `0` 则将其从队列移除且不触发 `game_error` 窗口。

### Additional Context

> - Add any other relevant information or screenshots here.

