### PR TITLE
refactor(backend): refactor logic of pre-defined game directory, set is_portable as static const

### DIFF
--- a/src-tauri/src/account/constants.rs
+++ b/src-tauri/src/account/constants.rs
@@ -1,1 +1,3 @@
+pub const ACCOUNTS_FILE_NAME: &str = "sjmcl.account.json";
+
 pub const TEXTURE_ROLES: [&str; 2] = ["steve", "alex"];

--- a/src-tauri/src/account/models.rs
+++ b/src-tauri/src/account/models.rs
@@ -1,4 +1,7 @@
-use super::helpers::{authlib_injector::constants::PRESET_AUTH_SERVERS, skin::draw_avatar};
+use super::{
+  constants::ACCOUNTS_FILE_NAME,
+  helpers::{authlib_injector::constants::PRESET_AUTH_SERVERS, skin::draw_avatar},
+};
 use crate::{storage::Storage, utils::image::ImageWrapper, APP_DATA_DIR};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -228,7 +231,7 @@ impl AccountInfo {
 
 impl Storage for AccountInfo {
   fn file_path() -> PathBuf {
-    APP_DATA_DIR.get().unwrap().join("sjmcl.account.json")
+    APP_DATA_DIR.get().unwrap().join(ACCOUNTS_FILE_NAME)
   }
 }
 

--- a/src-tauri/src/launcher_config/constants.rs
+++ b/src-tauri/src/launcher_config/constants.rs
@@ -1,1 +1,3 @@
+pub const LAUNCHER_CFG_FILE_NAME: &str = "sjmcl.conf.json";
+
 pub const CONFIG_PARTIAL_UPDATE_EVENT: &str = "config:partial-update";

--- a/src-tauri/src/launcher_config/models.rs
+++ b/src-tauri/src/launcher_config/models.rs
@@ -1,9 +1,9 @@
 use crate::{
-  launcher_config::constants::CONFIG_PARTIAL_UPDATE_EVENT,
+  launcher_config::constants::{CONFIG_PARTIAL_UPDATE_EVENT, LAUNCHER_CFG_FILE_NAME},
   partial::PartialUpdate,
   storage::Storage,
   utils::{string::snake_to_camel_case, sys_info},
-  APP_DATA_DIR,
+  APP_DATA_DIR, EXE_DIR, IS_PORTABLE,
 };
 use partial_derive::Partial;
 use serde::{Deserialize, Serialize};
@@ -307,8 +307,11 @@ impl LauncherConfig {
 
 impl Storage for LauncherConfig {
   fn file_path() -> PathBuf {
-    // EXE_DIR.join("sjmcl.conf.json")
-    APP_DATA_DIR.get().unwrap().join("sjmcl.conf.json")
+    if *IS_PORTABLE {
+      EXE_DIR.join(LAUNCHER_CFG_FILE_NAME)
+    } else {
+      APP_DATA_DIR.get().unwrap().join(LAUNCHER_CFG_FILE_NAME)
+    }
   }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,7 +26,7 @@ use std::{collections::HashMap, sync::OnceLock};
 use storage::Storage;
 use tasks::monitor::TaskMonitor;
 use tauri_plugin_log::{Target, TargetKind};
-use utils::web::build_sjmcl_client;
+use utils::{portable::is_portable, web::build_sjmcl_client};
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 use tauri::menu::MenuBuilder;
@@ -39,6 +39,8 @@ static EXE_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
     .unwrap()
     .to_path_buf()
 });
+
+static IS_PORTABLE: LazyLock<bool> = LazyLock::new(|| is_portable().unwrap_or(false));
 
 static APP_DATA_DIR: OnceLock<PathBuf> = OnceLock::new();
 

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -1,5 +1,5 @@
 use crate::error::{SJMCLError, SJMCLResult};
-use crate::utils::portable::is_portable;
+use crate::IS_PORTABLE;
 use regex::Regex;
 use sha1::{Digest, Sha1};
 use std::ffi::OsStr;
@@ -196,9 +196,7 @@ pub fn get_app_resource_filepath(
   app: &AppHandle,
   relative_path: &str,
 ) -> Result<PathBuf, io::Error> {
-  let portable = is_portable().unwrap_or(false);
-
-  let dir = if portable {
+  let dir = if *IS_PORTABLE {
     BaseDirectory::AppData
   } else {
     BaseDirectory::Resource


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [x] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

解决 #759 近期目标（远期如 portable 迁移提醒还没做）



### Description

* portable 和非 portable 的 conf 位置区分
* portable 和非 portable 默认游戏文件夹区分
* 如果有 CURRENT_DIR，目前在启动时强制修改为当前文件夹

### Additional Context

macOS 没有 portable，需要 windows 测试 portable（bundle 脚本在 `scripts/`)

