### PR TITLE
fix(resource): fallback to all when detected version is not among version list in download specific resource modal

### DIFF
--- a/src/components/modals/download-specific-resource-modal.tsx
+++ b/src/components/modals/download-specific-resource-modal.tsx
@@ -110,9 +110,7 @@ const DownloadSpecificResourceModal: React.FC<
 
   const [gameVersionList, setGameVersionList] = useState<string[]>([]);
   const [versionLabels, setVersionLabels] = useState<string[]>([]);
-  const [selectedVersionLabel, setSelectedVersionLabel] = useState<string>(
-    curInstanceMajorVersion || "All"
-  );
+  const [selectedVersionLabel, setSelectedVersionLabel] = useState<string>("");
   const [selectedModLoader, setSelectedModLoader] = useState<
     ModLoaderType | "All"
   >(curInstanceModLoader || "All");
@@ -338,7 +336,7 @@ const DownloadSpecificResourceModal: React.FC<
   );
 
   const reFetchVersionPacks = useCallback(() => {
-    if (!resource.id || !resource.source) return;
+    if (!resource.id || !resource.source || !selectedVersionLabel) return;
 
     handleFetchResourceVersionPacks(
       resource.id,
@@ -454,8 +452,16 @@ const DownloadSpecificResourceModal: React.FC<
 
   useEffect(() => {
     setSelectedModLoader(curInstanceModLoader || "All");
-    setSelectedVersionLabel(curInstanceMajorVersion || "All");
-  }, [curInstanceModLoader, curInstanceMajorVersion]);
+  }, [curInstanceModLoader]);
+
+  useEffect(() => {
+    const initialVersion = curInstanceMajorVersion || "All";
+    if (versionLabels.length > 0 && versionLabels.includes(initialVersion)) {
+      setSelectedVersionLabel(initialVersion);
+    } else {
+      setSelectedVersionLabel("All");
+    }
+  }, [curInstanceMajorVersion, versionLabels]);
 
   useEffect(() => {
     fetchVersionLabels();


### PR DESCRIPTION
among version list in download specific resource modal

<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

fix #782 

### Description

这种修复办法应该可以避免无意义的 api 调用

### Additional Context

> - Add any other relevant information or screenshots here.

