### PR TITLE
feat: support older version multiplayer quickplay, optimize game version comparision

### DIFF
--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -3,7 +3,7 @@ use super::{
     copy_whole_dir, generate_unique_filename, get_files_with_regex, get_subdirectories,
   },
   helpers::{
-    game_version::get_major_game_version,
+    game_version::{compare_game_versions, get_major_game_version},
     misc::{
       get_instance_game_config, get_instance_subdir_path_by_id, refresh_and_update_instances,
       unify_instance_name,
@@ -85,10 +85,15 @@ pub async fn retrieve_instance_list(app: AppHandle) -> SJMCLResult<Vec<InstanceS
       icon_src: instance.icon_src.clone(),
       starred: instance.starred,
       play_time: instance.play_time,
-      version: instance.version.clone(),
-      major_version: get_major_game_version(&app, &instance.version).await,
       version_path: instance.version_path.clone(),
+      version: instance.version.clone(),
       mod_loader: instance.mod_loader.clone(),
+      // skip fallback remote fetch in `get_major_game_version` and `compare_game_versions` to avoid instance list load delay.
+      // ref: https://github.com/UNIkeEN/SJMCL/pull/799
+      major_version: get_major_game_version(&app, &instance.version, false).await,
+      support_quick_play: compare_game_versions(&app, &instance.version, "23w14a", false)
+        .await
+        .is_ge(),
       use_spec_game_config: instance.use_spec_game_config,
       is_version_isolated,
     });

--- a/src-tauri/src/instance/helpers/client_json.rs
+++ b/src-tauri/src/instance/helpers/client_json.rs
@@ -392,7 +392,9 @@ pub async fn replace_native_libraries(
 
   #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
   {
-    if compare_game_versions(app, instance.version.as_str(), "1.20.1").await == Ordering::Greater {
+    if compare_game_versions(app, instance.version.as_str(), "1.20.1", true).await
+      == Ordering::Greater
+    {
       return Ok(());
     }
   }

--- a/src-tauri/src/instance/models/misc.rs
+++ b/src-tauri/src/instance/models/misc.rs
@@ -117,10 +117,11 @@ pub struct InstanceSummary {
   pub icon_src: String,
   pub starred: bool,
   pub play_time: u128,
+  pub version_path: PathBuf,
   pub version: String,
   pub major_version: String,
-  pub version_path: PathBuf,
   pub mod_loader: ModLoader,
+  pub support_quick_play: bool,
   pub use_spec_game_config: bool,
   pub is_version_isolated: bool,
 }

--- a/src-tauri/src/launch/commands.rs
+++ b/src-tauri/src/launch/commands.rs
@@ -233,6 +233,7 @@ pub async fn launch_game(
   app: AppHandle,
   launching_queue_state: State<'_, Mutex<Vec<LaunchingState>>>,
   quick_play_singleplayer: Option<String>,
+  quick_play_multiplayer: Option<String>,
 ) -> SJMCLResult<()> {
   let (id, selected_java, game_config, instance) = {
     let mut launching_queue = launching_queue_state.lock()?;
@@ -259,7 +260,7 @@ pub async fn launch_game(
   let LaunchCommand {
     class_paths,
     args: cmd_args,
-  } = generate_launch_command(&app, quick_play_singleplayer)?;
+  } = generate_launch_command(&app, quick_play_singleplayer, quick_play_multiplayer).await?;
   let mut cmd_base = Command::new(selected_java.exec_path.clone());
 
   let full_cmd = export_full_launch_command(&class_paths, &cmd_args, &selected_java.exec_path);

--- a/src-tauri/src/launch/helpers/command_generator.rs
+++ b/src-tauri/src/launch/helpers/command_generator.rs
@@ -353,7 +353,7 @@ pub async fn generate_launch_command(
 
   // quick into server (for old version)
   if !quickplay_server_url.is_empty()
-    && compare_game_versions(app, &selected_instance.name, "23w14a", false)
+    && compare_game_versions(app, &selected_instance.version, "23w14a", false)
       .await
       .is_lt()
   {

--- a/src-tauri/src/launch/helpers/jre_selector.rs
+++ b/src-tauri/src/launch/helpers/jre_selector.rs
@@ -48,20 +48,22 @@ pub async fn select_java_runtime(
 /// Get minimum java version requirement by game client version
 /// ref: https://zh.minecraft.wiki/w/Java%E7%89%88?variant=zh-cn#%E8%BD%AF%E4%BB%B6%E9%9C%80%E6%B1%82
 async fn get_minimum_java_version_by_game(app: &AppHandle, instance: &Instance) -> i32 {
+  // only allow fallback remote fetch here in the launch process, as Java selection and command generation are used sequentially.
+  // ref: https://github.com/UNIkeEN/SJMCL/pull/799
   // 1.20.5(24w14a)+
-  if compare_game_versions(app, &instance.version, "24w14a").await >= Ordering::Equal {
+  if compare_game_versions(app, &instance.version, "24w14a", true).await >= Ordering::Equal {
     return 21;
   }
   // 1.18(1.18-pre2)+
-  if compare_game_versions(app, &instance.version, "1.18-pre2").await >= Ordering::Equal {
+  if compare_game_versions(app, &instance.version, "1.18-pre2", false).await >= Ordering::Equal {
     return 17;
   }
   // 1.17(21w19a)+
-  if compare_game_versions(app, &instance.version, "21w19a").await >= Ordering::Equal {
+  if compare_game_versions(app, &instance.version, "21w19a", false).await >= Ordering::Equal {
     return 16;
   }
   // 1.12(17w13a)+
-  if compare_game_versions(app, &instance.version, "17w13a").await >= Ordering::Equal {
+  if compare_game_versions(app, &instance.version, "17w13a", false).await >= Ordering::Equal {
     return 8;
   }
   0

--- a/src/components/instance-widgets.tsx
+++ b/src/components/instance-widgets.tsx
@@ -399,27 +399,29 @@ export const InstanceLastPlayedWidget = () => {
               </VStack>
             </Box>
           </HStack>
-          <HStack spacing={1.5} position="absolute" left={2} bottom={2}>
-            <Button
-              size="xs"
-              variant="ghost"
-              colorScheme={primaryColor}
-              justifyContent="flex-start"
-              onClick={() => {
-                openSharedModal("launch", {
-                  instanceId: summary?.id,
-                  ...(lastPlayedWorld?.dirPath && {
-                    quickPlaySingleplayer: lastPlayedWorld.dirPath,
-                  }),
-                });
-              }}
-            >
-              <HStack spacing={1.5}>
-                <Icon as={LuArrowRight} />
-                <Text>{t("InstanceWidgets.lastPlayed.continuePlaying")}</Text>
-              </HStack>
-            </Button>
-          </HStack>
+          {summary?.supportQuickPlay && (
+            <HStack spacing={1.5} position="absolute" left={2} bottom={2}>
+              <Button
+                size="xs"
+                variant="ghost"
+                colorScheme={primaryColor}
+                justifyContent="flex-start"
+                onClick={() => {
+                  openSharedModal("launch", {
+                    instanceId: summary?.id,
+                    ...(lastPlayedWorld?.dirPath && {
+                      quickPlaySingleplayer: lastPlayedWorld.dirPath,
+                    }),
+                  });
+                }}
+              >
+                <HStack spacing={1.5}>
+                  <Icon as={LuArrowRight} />
+                  <Text>{t("InstanceWidgets.lastPlayed.continuePlaying")}</Text>
+                </HStack>
+              </Button>
+            </HStack>
+          )}
         </VStack>
       ) : (
         <Empty withIcon={false} size="sm" />

--- a/src/models/instance/misc.ts
+++ b/src/models/instance/misc.ts
@@ -17,13 +17,14 @@ export interface InstanceSummary {
   versionPath: string;
   version: string;
   majorVersion: string;
-  isVersionIsolated: boolean;
   modLoader: {
     loaderType: ModLoaderType;
     version?: string;
     status: ModLoaderStatus;
   };
+  supportQuickPlay: boolean;
   useSpecGameConfig: boolean;
+  isVersionIsolated: boolean;
 }
 
 export interface GameServerInfo {

--- a/src/services/launch.ts
+++ b/src/services/launch.ts
@@ -42,15 +42,19 @@ export class LaunchService {
 
   /**
    * Launching Step 4: generate command args, launch the game instance.
-   * If `quickPlaySingleplayer` is provided, the game will directly enter the specified singleplayer world after launch.
    * @param {string} [quickPlaySingleplayer] - Optional name of the singleplayer world to auto-enter.
+   * @param {string} [quickPlayMultiplayer] - Optional address of multiplayer server to auto-join.
    * @returns {Promise<InvokeResponse<void>>}
    */
   @responseHandler("launch")
   static async launchGame(
-    quickPlaySingleplayer?: string
+    quickPlaySingleplayer?: string,
+    quickPlayMultiplayer?: string
   ): Promise<InvokeResponse<void>> {
-    return await invoke("launch_game", { quickPlaySingleplayer });
+    return await invoke("launch_game", {
+      quickPlaySingleplayer,
+      quickPlayMultiplayer,
+    });
   }
 
   /**


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

close #797 

### Description

* 对旧版本（< 1.20.1）支持快速进入服务器
* 对旧版本，在前端不显示“继续上次游玩的存档”的按钮
* 优化不必要的版本列表获取（见下一节）

### Additional Context

由于 1.20.1 以下的版本没有快速进入单人档的替代方案，我选择为实例信息增加新的字段，以对于老版本（需要执行版本比较函数`compare_game_versions`）、在前端不显示快速进入单人档的相关按钮。

但是如果有版本存在被修改的版本号或最新版本号，版本比较函数会联网获取 cache，这一步受网络原因可能较慢。测试时发现用户可能会因此在启动界面先显示一两秒“未选中实例”后才正确显示（原因是 `refresh_instance_list` 受到了新引入的 `compare_game_versions` 的时间影响）。

出于以下考量：
* client.json 版本号被错误修改本身少见
* 旧版本几乎已经固定，而新版本肯定支持 quick_play（除非未来哪天 mojang 又弃用这个参数），未见过的版本自动被视为新版本
* 即使 quick_play 判断错误，添加了快速进入的参数，游戏也能正常打开（只是无法直接进入世界）不会崩溃

所以我们为 `compare_game_versions` 和 `get_major_game_version` 增加了 `fallback_fetch_remote` 参数，并在 `refresh_instance_list` 内关闭了这个选项）

```rust
#[tauri::command]
pub async fn retrieve_instance_list(app: AppHandle) -> SJMCLResult<Vec<InstanceSummary>> {
  refresh_and_update_instances(&app, false).await; // firstly refresh and update
  ...
    summary_list.push(InstanceSummary {
      ...
      // skip fallback remote fetch in `get_major_game_version` and `compare_game_versions` to avoid instance list load delay.
      major_version: get_major_game_version(&app, &instance.version, false).await,
      support_quick_play: compare_game_versions(&app, &instance.version, "1.20", false)
        .await
        .is_ge(),
      use_spec_game_config: instance.use_spec_game_config,
      is_version_isolated,
    });
  }
  Ok(summary_list)
}
```

另外，再增加了这个参数后，进一步测试，如果有一个实例版本号被错误修改（为列表中肯定不存在的版本），在启动流程中会多次尝试 fetch cache，大大增加延迟，比如以下代码在之前的版本可能会 fetch 四次，现在只有第一次允许 fetch、之后几次马上执行，几乎可以认为最新版本列表没有发生变化：

```rust
/// Get minimum java version requirement by game client version
/// ref: https://zh.minecraft.wiki/w/Java%E7%89%88?variant=zh-cn#%E8%BD%AF%E4%BB%B6%E9%9C%80%E6%B1%82
async fn get_minimum_java_version_by_game(app: &AppHandle, instance: &Instance) -> i32 {
  // only allow fallback remote fetch here in the launch process, as Java selection and command generation are used sequentially.
  // 1.20.5(24w14a)+
  if compare_game_versions(app, &instance.version, "24w14a", true).await >= Ordering::Equal {
    return 21;
  }
  // 1.18(1.18-pre2)+
  if compare_game_versions(app, &instance.version, "1.18-pre2", false).await >= Ordering::Equal {
    return 17;
  }
  // 1.17(21w19a)+
  if compare_game_versions(app, &instance.version, "21w19a", false).await >= Ordering::Equal {
    return 16;
  }
  // 1.12(17w13a)+
  if compare_game_versions(app, &instance.version, "17w13a", false).await >= Ordering::Equal {
    return 8;
  }
  0
}
```

Java 选择 和 生成启动命令（`generate_launch_command`）只在 launching process 里出现且前后串行，所以后者的 `compare_game_versions` 也关闭了 fetch cache；但启动第二步——文件验证的相关函数在创建实例等处也会使用，所以保持为开
