### PR TITLE
fix(frontend): prevent CommonIconButton from stealing focus

### DIFF
--- a/src/components/common/common-icon-button.tsx
+++ b/src/components/common/common-icon-button.tsx
@@ -93,6 +93,11 @@ export const CommonIconButton: React.FC<CommonIconButtonProps> = ({
         aria-label={finalLabel}
         variant="ghost"
         size="sm"
+        onMouseDown={(e) => {
+          e.preventDefault(); // Prevents button from being focused on click
+          e.stopPropagation(); // Prevents click from bubbling up to parent elements
+          props.onMouseDown?.(e);
+        }} // Prevents button from stealing focus
         {...props}
       />
     </Tooltip>


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - fix #834 

### Description

> - Fixes a bug where, in resource pack, schematic, shader, and similar interfaces, closing a popup after clicking the right-side button of a resource item causes the tooltip to reappear even when the mouse is no longer hovering over the button.

### Additional Context

> - Add any other relevant information or screenshots here.

