### PR TITLE
fix(instance): retrying mod loader download causes duplicate launch args

### DIFF
--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -985,7 +985,7 @@ pub async fn finish_mod_loader_install(app: AppHandle, instance_id: String) -> S
 
   match instance.mod_loader.status {
     // prevent duplicated installation
-    ModLoaderStatus::NotDownloaded => {
+    ModLoaderStatus::DownloadFailed => {
       return Err(InstanceError::ProcessorExecutionFailed.into());
     }
     ModLoaderStatus::Installing => {

--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -997,6 +997,15 @@ pub async fn finish_mod_loader_install(app: AppHandle, instance_id: String) -> S
     _ => {}
   }
 
+  {
+    let binding = app.state::<Mutex<HashMap<String, Instance>>>();
+    let mut state = binding.lock()?;
+    let instance = state
+      .get_mut(&instance_id)
+      .ok_or(InstanceError::InstanceNotFoundByID)?;
+    instance.mod_loader.status = ModLoaderStatus::Installing;
+  };
+
   let client_info_dir = instance
     .version_path
     .join(format!("{}.json", instance.name));

--- a/src-tauri/src/instance/models/misc.rs
+++ b/src-tauri/src/instance/models/misc.rs
@@ -71,10 +71,12 @@ impl ModLoaderType {
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Clone, Serialize, Default)]
 pub enum ModLoaderStatus {
-  NotDownloaded,
-  DownloadFailed,
-  Downloading,
-  Installing,
+  NotDownloaded, // mod loader's library has not been downloaded
+  DownloadFailed, /* mod loader's library download process failed (including processor installation failed)
+                  Only when SJMCL restart, it will try to re-download library while making no changes to client info JSON (is_retry = true),
+                  and do following steps */
+  Downloading, // mod loader's library download process is ongoing
+  Installing,  // mod loader's library has been downloaded, and installation processors are working
   #[default]
   Installed,
 }

--- a/src-tauri/src/instance/models/misc.rs
+++ b/src-tauri/src/instance/models/misc.rs
@@ -72,6 +72,7 @@ impl ModLoaderType {
 #[derive(Debug, PartialEq, Eq, Deserialize, Clone, Serialize, Default)]
 pub enum ModLoaderStatus {
   NotDownloaded,
+  DownloadFailed,
   Downloading,
   Installing,
   #[default]

--- a/src/models/instance/misc.ts
+++ b/src/models/instance/misc.ts
@@ -4,6 +4,7 @@ import { OtherResourceSource } from "@/enums/resource";
 export enum ModLoaderStatus {
   NotDownloaded = "NotDownloaded",
   Downloading = "Downloading",
+  DownloadFailed = "DownloadFailed",
   Installing = "Installing",
   Installed = "Installed",
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - fix #857 

### Description

> - 解决了上次模组加载器安装失败后，启动器再次启动重试安装时，出现的 Forge/NeoForge 重复安装问题。

### Additional Context

> - Add any other relevant information or screenshots here.

