### PR TITLE
fix(ci/cd): run `pnpm import` before build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,7 @@ jobs:
       - name: Install frontend dependencies
         run: |
           npm install -g pnpm
+          pnpm import
           pnpm install
 
       - name: Remove Font files (MacOS)


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [x] ❓ Other (Please specify below)

### Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - e.g. close #xxxx, fix #xxxx

### Description

在build workflow中，安装依赖前执行`pnpm import`

1. 为什么要执行`pnpm import`？因为pnpm有自己的lock文件，默认情况下不会遵守package-lock.json，需要先使用`pnpm import`从package-lock.json生成pnpm-lock.yaml
2. 为什么之前不这么做？因为之前仓库里根本没有package-lock.json
3. 为什么要用pnpm而不是直接用npm？遗留问题，详见 https://github.com/UNIkeEN/SJMCL/pull/173

### Additional Context

> - Add any other relevant information or screenshots here.

