### PR TITLE
fix: adjusting the behavior when texts are too long in multiple components

### DIFF
--- a/src/components/common/option-item.tsx
+++ b/src/components/common/option-item.tsx
@@ -8,6 +8,7 @@ import {
   HStack,
   Skeleton,
   Text,
+  TextProps,
   VStack,
   Wrap,
   useColorModeValue,
@@ -28,6 +29,9 @@ export interface OptionItemProps extends Omit<BoxProps, "title"> {
   isFullClickZone?: boolean;
   children?: React.ReactNode;
   childrenOnHover?: boolean;
+  titleFlex?: boolean;
+  maxTitleLines?: number;
+  maxDescriptionLines?: number;
 }
 
 export interface OptionItemGroupProps extends SectionProps {
@@ -48,16 +52,35 @@ export const OptionItem: React.FC<OptionItemProps> = ({
   isFullClickZone = false,
   children,
   childrenOnHover = false,
+  titleFlex = false,
+  maxTitleLines = undefined,
+  maxDescriptionLines = undefined,
   ...boxProps
 }) => {
   const [isHovered, setIsHovered] = useState(false);
 
   const palettes = useColorModeValue([100, 200, 300], [900, 800, 700]);
 
+  const titleLineClampProps: TextProps = {
+    noOfLines: maxTitleLines,
+    sx: {
+      wordBreak: "break-all",
+    },
+  };
+
+  const descriptionLineClampProps: TextProps = {
+    noOfLines: maxDescriptionLines,
+    sx: {
+      wordBreak: "break-all",
+    },
+  };
+
   const _title =
     typeof title === "string" ? (
       <Skeleton isLoaded={!isLoading}>
-        <Text fontSize="xs-sm">{title}</Text>
+        <Text fontSize="xs-sm" {...(maxTitleLines ? titleLineClampProps : {})}>
+          {title}
+        </Text>
       </Skeleton>
     ) : (
       title
@@ -94,16 +117,18 @@ export const OptionItem: React.FC<OptionItemProps> = ({
       p={0.5}
       {...boxProps}
     >
-      <HStack spacing={2.5} overflowY="hidden">
+      <HStack spacing={2.5} overflow="hidden">
         {prefixElement && (
-          <Skeleton isLoaded={!isLoading}>{prefixElement}</Skeleton>
+          <Skeleton isLoaded={!isLoading} flex="0 0 auto">
+            {prefixElement}
+          </Skeleton>
         )}
         <VStack
           spacing={0}
           mr={2}
           alignItems="start"
           overflow="hidden"
-          flex="1"
+          flex={titleFlex ? "1 1 auto" : "0 0 auto"}
         >
           {titleLineWrap ? (
             <Wrap spacingX={2} spacingY={0.5}>
@@ -120,7 +145,11 @@ export const OptionItem: React.FC<OptionItemProps> = ({
           {description &&
             (typeof description === "string" ? (
               <Skeleton isLoaded={!isLoading}>
-                <Text fontSize="xs" className="secondary-text">
+                <Text
+                  fontSize="xs"
+                  className="secondary-text"
+                  {...(maxDescriptionLines ? descriptionLineClampProps : {})}
+                >
                   {description}
                 </Text>
               </Skeleton>

--- a/src/components/common/section.tsx
+++ b/src/components/common/section.tsx
@@ -7,6 +7,7 @@ import {
   Icon,
   IconButton,
   Text,
+  TextProps,
   VStack,
   useDisclosure,
 } from "@chakra-ui/react";
@@ -24,6 +25,7 @@ export interface SectionProps extends Omit<BoxProps, "children"> {
   withBackButton?: boolean;
   backRoutePath?: string;
   children?: React.ReactNode;
+  maxTitleLines?: number;
 }
 
 export const Section: React.FC<SectionProps> = ({
@@ -35,6 +37,7 @@ export const Section: React.FC<SectionProps> = ({
   initialIsOpen = true,
   onAccordionToggle,
   withBackButton = false,
+  maxTitleLines = undefined,
   backRoutePath = "",
   children,
   ...props
@@ -43,10 +46,16 @@ export const Section: React.FC<SectionProps> = ({
     defaultIsOpen: initialIsOpen,
   });
   const router = useRouter();
+  const lineClampProps: TextProps = {
+    noOfLines: maxTitleLines,
+    sx: {
+      wordBreak: "break-all",
+    },
+  };
   return (
     <Box {...props}>
       {(isAccordion || title || description || titleExtra || headExtra) && (
-        <Flex alignItems="flex-start" flexShrink={0} mb={isOpen ? 2.5 : 0}>
+        <Flex alignItems="stretch" flexShrink={0} mb={isOpen ? 2.5 : 0}>
           <HStack spacing={1}>
             {withBackButton && (
               <IconButton
@@ -88,7 +97,11 @@ export const Section: React.FC<SectionProps> = ({
             <VStack spacing={0} align="start">
               <HStack spacing={2}>
                 {title && (
-                  <Text fontWeight="bold" fontSize="sm">
+                  <Text
+                    fontWeight="bold"
+                    fontSize="sm"
+                    {...(maxTitleLines ? lineClampProps : {})}
+                  >
                     {title}
                   </Text>
                 )}

--- a/src/components/instances-view.tsx
+++ b/src/components/instances-view.tsx
@@ -9,7 +9,10 @@ import {
 } from "@chakra-ui/react";
 import { FaStar } from "react-icons/fa6";
 import Empty from "@/components/common/empty";
-import { OptionItemGroup } from "@/components/common/option-item";
+import {
+  OptionItemGroup,
+  OptionItemProps,
+} from "@/components/common/option-item";
 import { WrapCardGroup } from "@/components/common/wrap-card";
 import InstanceMenu from "@/components/instance-menu";
 import { useLauncherConfig } from "@/contexts/config";
@@ -40,7 +43,7 @@ const InstancesView: React.FC<InstancesViewProps> = ({
     onSelectCallback();
   };
 
-  const listItems = instances.map((instance) => ({
+  const listItems: OptionItemProps[] = instances.map((instance) => ({
     title: instance.name,
     description: [generateInstanceDesc(instance), instance.description]
       .filter(Boolean)
@@ -48,6 +51,9 @@ const InstancesView: React.FC<InstancesViewProps> = ({
     ...{
       titleExtra: instance.starred && <Icon as={FaStar} color="yellow.500" />,
     },
+    titleFlex: true,
+    maxTitleLines: 1,
+    maxDescriptionLines: 2,
     prefixElement: (
       <HStack spacing={2.5}>
         <Radio

--- a/src/components/resource-downloader.tsx
+++ b/src/components/resource-downloader.tsx
@@ -179,7 +179,7 @@ const ResourceDownloaderList: React.FC<ResourceDownloaderListProps> = ({
       </Text>
     ),
     titleExtra: (
-      <HStack spacing={1}>
+      <HStack spacing={1} flex="0 0 auto">
         {(() => {
           const translatedTags = item.tags
             .map((t) => translateTag(t, item.type, item.source))
@@ -210,6 +210,7 @@ const ResourceDownloaderList: React.FC<ResourceDownloaderListProps> = ({
       </HStack>
     ),
     titleLineWrap: false,
+    titleFlex: true,
     description: (
       <VStack
         fontSize="xs"

--- a/src/layouts/instance-details-layout.tsx
+++ b/src/layouts/instance-details-layout.tsx
@@ -190,6 +190,7 @@ const InstanceDetailsLayoutContent: React.FC<{ children: React.ReactNode }> = ({
           </Button>
         </HStack>
       }
+      maxTitleLines={1}
     >
       <NavMenu
         flexWrap="wrap"

--- a/src/layouts/instance-details-layout.tsx
+++ b/src/layouts/instance-details-layout.tsx
@@ -161,6 +161,7 @@ const InstanceDetailsLayoutContent: React.FC<{ children: React.ReactNode }> = ({
           size="xs"
           fontSize="sm"
           h={21}
+          marginInlineEnd="0.5rem"
         />
       }
       headExtra={

--- a/src/pages/instances/details/[id]/settings/index.tsx
+++ b/src/pages/instances/details/[id]/settings/index.tsx
@@ -84,6 +84,7 @@ const InstanceSettingsPage = () => {
               formErrMsgProps={{ fontSize: "xs-sm" }}
               checkError={checkDirNameError}
               localeKey="InstanceSettingsPage.errorMessage"
+              flex={1}
             />
           ),
         },
@@ -98,6 +99,7 @@ const InstanceSettingsPage = () => {
               }}
               textProps={{ className: "secondary-text", fontSize: "xs-sm" }}
               inputProps={{ fontSize: "xs-sm" }}
+              flex={1}
             />
           ),
         },

--- a/src/pages/settings/download.tsx
+++ b/src/pages/settings/download.tsx
@@ -308,7 +308,15 @@ const DownloadSettingsPage = () => {
       items: [
         {
           title: t("DownloadSettingPage.cache.settings.directory.title"),
-          description: downloadConfigs.cache.directory,
+          description: (
+            <Text
+              fontSize="xs"
+              className="secondary-text"
+              wordBreak="break-all"
+            >
+              {downloadConfigs.cache.directory}
+            </Text>
+          ),
           children: (
             <HStack>
               <Button
@@ -329,6 +337,7 @@ const DownloadSettingsPage = () => {
               </Button>
             </HStack>
           ),
+          titleFlex: true,
         },
         {
           title: t("DownloadSettingPage.cache.settings.clear.title"),

--- a/src/pages/settings/java.tsx
+++ b/src/pages/settings/java.tsx
@@ -203,6 +203,7 @@ const JavaSettingsPage = () => {
                     </HStack>
                   </Flex>
                 }
+                titleFlex={true}
               >
                 <HStack spacing={0}>
                   {javaItemMenuOperations(java).map((item, index) => (


### PR DESCRIPTION
### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

close #438 

### Description




### Additional Context

<img width="1604" height="1199" alt="image" src="https://github.com/user-attachments/assets/3776a7fd-253e-4249-bc5b-3725048ee204" />
<img width="1604" height="1199" alt="image" src="https://github.com/user-attachments/assets/cd5e9d21-aeac-4ab0-adb6-c4a11fc6c3d8" />
<img width="1604" height="1199" alt="image" src="https://github.com/user-attachments/assets/c61ed814-ebbc-4440-bd2c-5fc7b992ffb1" />
<img width="1604" height="1199" alt="image" src="https://github.com/user-attachments/assets/a68f532d-9363-49dd-bf8a-7b0faa91599d" />
<img width="1604" height="1199" alt="image" src="https://github.com/user-attachments/assets/4bcbad10-f9fa-4b0f-849b-6ee16fb44b09" />
<img width="1604" height="1199" alt="image" src="https://github.com/user-attachments/assets/0d9c9d8f-be70-49b4-922c-a5bd503c7580" />
