### PR TITLE
fix(ci/cd): do not fail the whole job on macos codesign failure

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -171,7 +171,7 @@ jobs:
 
   Create-Nightly-Release:
     needs: [Check-and-Prepare, Build-Nightly, Sign-macOS-Artifacts]
-    if: needs.Check-and-Prepare.outputs.should_build == 'true'
+    if: always() && needs.Check-and-Prepare.outputs.should_build == 'true' && needs.Build-Nightly.result == 'success'
     runs-on: ubuntu-latest
     
     steps:
@@ -184,13 +184,22 @@ jobs:
         with:
           path: artifacts
 
-      - name: Remove unsigned macOS artifacts to avoid conflicts
+      - name: Organize macOS artifacts based on signing status
+        env:
+          SIGNING_SUCCESS: ${{ needs.Sign-macOS-Artifacts.result == 'success' }}
         run: |
-          echo "Removing unsigned macOS artifacts to prevent filename conflicts..."
-          # Remove unsigned macOS artifacts since we have signed versions
-          rm -rf ./artifacts/SJMCL_*_macos_aarch64/
-          rm -rf ./artifacts/SJMCL_*_macos_x86_64/
-          echo "Unsigned macOS artifacts removed"
+          if [ "${{ env.SIGNING_SUCCESS }}" = "true" ]; then
+            echo "Using signed macOS artifacts"
+            # Remove unsigned macOS artifacts since we have signed versions
+            rm -rf ./artifacts/SJMCL_*_macos_aarch64/
+            rm -rf ./artifacts/SJMCL_*_macos_x86_64/
+            echo "Unsigned macOS artifacts removed"
+          else
+            echo "⚠️ WARNING: macOS signing failed or was skipped, using unsigned artifacts"
+            # Remove signed artifact directories if they exist (likely empty or failed)
+            rm -rf ./artifacts/SJMCL_*_macos_*_signed/
+            echo "Using unsigned macOS artifacts"
+          fi
           
           echo "Remaining artifacts:"
           ls -la ./artifacts/*/*
@@ -212,6 +221,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NIGHTLY_VERSION: ${{ needs.Check-and-Prepare.outputs.nightly_version }}
           COMMIT_HASH: ${{ needs.Check-and-Prepare.outputs.commit_hash }}
+          SIGNING_SUCCESS: ${{ needs.Sign-macOS-Artifacts.result == 'success' }}
         run: |
           # Create release notes
           cat > release_notes.md << 'EOF'
@@ -228,6 +238,14 @@ jobs:
           - Features may change or be removed without notice
 
           EOF
+          
+          # Add warning if macOS signing failed
+          if [ "${{ env.SIGNING_SUCCESS }}" != "true" ]; then
+            echo "" >> release_notes.md
+            echo "---" >> release_notes.md
+            echo "" >> release_notes.md
+            echo "⚠️ **Note:** macOS artifacts in this nightly build are **not code-signed**. macOS users may see security warnings when running the application." >> release_notes.md
+          fi
           
           echo "Creating nightly pre-release..."
           ls -la ./artifacts/*/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
 
   Create-Release:
     needs: [Version-Check, Build-and-Release, Code-Sign-macOS]
+    if: always() && needs.Build-and-Release.result == 'success'
     runs-on: ubuntu-latest
     
     steps:
@@ -97,6 +98,7 @@ jobs:
           merge-multiple: true
 
       - name: Download signed macOS artifacts
+        if: needs.Code-Sign-macOS.result == 'success'
         uses: actions/download-artifact@v4
         with:
           pattern: 'SJMCL_${{ needs.Version-Check.outputs.version }}_macos_*_signed'
@@ -106,6 +108,7 @@ jobs:
       - name: Organize release artifacts
         env:
           VERSION: ${{ needs.Version-Check.outputs.version }}
+          SIGNING_SUCCESS: ${{ needs.Code-Sign-macOS.result == 'success' }}
         run: |
           mkdir -p release-artifacts
           
@@ -113,13 +116,21 @@ jobs:
           find artifacts -name "SJMCL_${{ env.VERSION }}_windows_*" -exec cp {} release-artifacts/ \;
           find artifacts -name "SJMCL_${{ env.VERSION }}_linux_*" -exec cp {} release-artifacts/ \;
           
-          # Copy signed macOS artifacts (rename to remove _signed suffix)
-          find artifacts-signed -name "SJMCL_${{ env.VERSION }}_macos_*" -type f | while read file; do
-            basename=$(basename "$file")
-            # Remove _signed suffix before the file extension
-            newname=$(echo "$basename" | sed 's/_signed\./\./')
-            cp "$file" "release-artifacts/$newname"
-          done
+          # Copy macOS artifacts (signed if available, unsigned otherwise)
+          if [ "${{ env.SIGNING_SUCCESS }}" = "true" ] && [ -d artifacts-signed ]; then
+            echo "Using signed macOS artifacts"
+            # Copy signed macOS artifacts (rename to remove _signed suffix)
+            find artifacts-signed -name "SJMCL_${{ env.VERSION }}_macos_*" -type f | while read file; do
+              basename=$(basename "$file")
+              # Remove _signed suffix before the file extension
+              newname=$(echo "$basename" | sed 's/_signed\./\./')
+              cp "$file" "release-artifacts/$newname"
+            done
+          else
+            echo "⚠️ WARNING: Using unsigned macOS artifacts (signing failed or was skipped)"
+            # Copy unsigned macOS artifacts
+            find artifacts -name "SJMCL_${{ env.VERSION }}_macos_*" -exec cp {} release-artifacts/ \;
+          fi
           
           echo "Final release artifacts:"
           ls -la release-artifacts/
@@ -135,9 +146,19 @@ jobs:
 
       - name: Generate Changelog
         id: changelog
+        env:
+          SIGNING_SUCCESS: ${{ needs.Code-Sign-macOS.result == 'success' }}
         run: |
           pip install requests packaging
           python scripts/release/generate_changelog_draft.py > release-notes.md
+          
+          # Add warning if macOS signing failed
+          if [ "${{ env.SIGNING_SUCCESS }}" != "true" ]; then
+            echo "" >> release-notes.md
+            echo "---" >> release-notes.md
+            echo "" >> release-notes.md
+            echo "⚠️ **Note:** macOS artifacts in this release are **not code-signed**. macOS users may see security warnings when running the application." >> release-notes.md
+          fi
         shell: bash
 
       - name: Create Release

--- a/.github/workflows/sign-macos.yml
+++ b/.github/workflows/sign-macos.yml
@@ -12,22 +12,22 @@ on:
     secrets:
       MACOS_CERT_P12_BASE64:
         description: 'Base64 encoded p12 certificate'
-        required: true
+        required: false
       MACOS_CERT_P12_PASSWORD:
         description: 'Password for p12 certificate'
-        required: true
+        required: false
       MACOS_SIGNING_IDENTITY:
         description: 'Code signing identity'
-        required: true
+        required: false
       MACOS_NOTARY_APPLE_ID:
         description: 'Apple ID for notarization'
-        required: true
+        required: false
       MACOS_NOTARY_PASSWORD:
         description: 'App-specific password for notarization'
-        required: true
+        required: false
       MACOS_NOTARY_TEAM_ID:
         description: 'Team ID for notarization'
-        required: true
+        required: false
 
 jobs:
   sign-macos:
@@ -37,6 +37,38 @@ jobs:
         arch: [aarch64, x86_64]
     
     steps:
+      - name: Validate signing secrets
+        id: validate
+        run: |
+          MISSING_SECRETS=()
+          
+          if [ -z "${{ secrets.MACOS_CERT_P12_BASE64 }}" ]; then
+            MISSING_SECRETS+=("MACOS_CERT_P12_BASE64")
+          fi
+          if [ -z "${{ secrets.MACOS_CERT_P12_PASSWORD }}" ]; then
+            MISSING_SECRETS+=("MACOS_CERT_P12_PASSWORD")
+          fi
+          if [ -z "${{ secrets.MACOS_SIGNING_IDENTITY }}" ]; then
+            MISSING_SECRETS+=("MACOS_SIGNING_IDENTITY")
+          fi
+          if [ -z "${{ secrets.MACOS_NOTARY_APPLE_ID }}" ]; then
+            MISSING_SECRETS+=("MACOS_NOTARY_APPLE_ID")
+          fi
+          if [ -z "${{ secrets.MACOS_NOTARY_PASSWORD }}" ]; then
+            MISSING_SECRETS+=("MACOS_NOTARY_PASSWORD")
+          fi
+          if [ -z "${{ secrets.MACOS_NOTARY_TEAM_ID }}" ]; then
+            MISSING_SECRETS+=("MACOS_NOTARY_TEAM_ID")
+          fi
+          
+          if [ ${#MISSING_SECRETS[@]} -gt 0 ]; then
+            echo "::warning::⚠️ macOS code signing will be skipped - missing secrets: ${MISSING_SECRETS[*]}"
+            echo "The release will continue with unsigned macOS artifacts."
+            exit 1
+          fi
+          
+          echo "✅ All required secrets are present"
+
       - uses: actions/checkout@v4
 
       - name: Download macOS artifacts


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

close #920 

### Description

Added a fallback so the nightly / release job will continue and create release with UNSIGNED macOS artifacts if macOS codesign fails.
<img width="2063" height="850" alt="image" src="https://github.com/user-attachments/assets/e5d6e31b-9298-48ad-afd3-f02eba6d5dc6" />
<img width="1973" height="1031" alt="image" src="https://github.com/user-attachments/assets/3ce40c0f-a9ed-4664-899b-e753544059e9" />


### Additional Context

None

