### PR TITLE
fix(dep): fix remark gfm regex breaks in Safari versions < 16.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,5 +81,13 @@
     "lint-staged": "^15.2.10",
     "prettier": "^3.4.1",
     "typescript": "^5"
+  },
+  "overrides": {
+    "mdast-util-gfm-autolink-literal": "2.0.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "mdast-util-gfm-autolink-literal": "2.0.0"
+    }
   }
 }


### PR DESCRIPTION

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

close #995 

### Description

https://github.com/syntax-tree/mdast-util-gfm-autolink-literal/issues/10

上游傻逼开发者追求技术为王，不干人事，背叛用户，浪费开发者时间

### Additional Context

