### PR TITLE
fix(updater): using Windows environment variable to avoid spaces in the path

### DIFF
--- a/src-tauri/src/launcher_config/helpers/updater.rs
+++ b/src-tauri/src/launcher_config/helpers/updater.rs
@@ -206,6 +206,7 @@ pub async fn install_update_windows(
     let restart_flag = if restart { "1" } else { "0" };
 
     // write and execute a bash script to wait -> replace -> start -> cleanup
+    // NOTES: In Windows, we generate script in temp_dir and use `set` vars to avoid path quoting issues (see PR #1037)
     let script_name = format!(
       "update_{}.cmd",
       uuid::Uuid::new_v4().to_string()[..8].to_string()
@@ -214,6 +215,7 @@ pub async fn install_update_windows(
       .path()
       .resolve(script_name.clone(), BaseDirectory::Temp)?;
     let script_path_cmd = PathBuf::from(format!("%TMP%\\{}", script_name));
+
     let script_content = format!(
       r#"@echo off
 setlocal enableextensions
@@ -317,6 +319,7 @@ pub async fn install_update_macos(
   let restart_flag = if restart { "1" } else { "0" };
 
   // write and execute a bash script to wait -> replace -> start -> cleanup
+  // NOTES: In macOS, we pass paths as args to avoid quoting issues in bash (see PR #918)
   let script_path = app
     .path()
     .resolve::<PathBuf>("update.sh".to_string().into(), BaseDirectory::AppCache)?;


### PR DESCRIPTION

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

close #1013

### Description

- 改用 Windows 临时目录存放脚本，便于系统清理，更符合 Windows 应用程序的风格
- 使用随机文件名避免冲突
- 利用 CMD 对百分号的解析，`%TMP%` 指向 TMP 环境变量，此变量为系统自带
- `env::temp_dir()` 调用 GetTempPath2（https://doc.rust-lang.org/stable/std/env/fn.temp_dir.html），后者优先获取环境变量中的 TMP，与 CMD 行为对齐

### Additional Context

