### PR TITLE
fix(backend): duplicate lib check for classpath generation

### DIFF
--- a/src-tauri/src/instance/helpers/loader/common.rs
+++ b/src-tauri/src/instance/helpers/loader/common.rs
@@ -13,7 +13,7 @@ use crate::instance::helpers::loader::forge::{install_forge_loader, InstallProfi
 use crate::instance::helpers::loader::neoforge::install_neoforge_loader;
 use crate::instance::helpers::misc::get_instance_game_config;
 use crate::instance::models::misc::{Instance, InstanceError, ModLoader, ModLoaderType};
-use crate::launch::helpers::file_validator::{parse_library_name, LibraryParts};
+use crate::launch::helpers::file_validator::add_library_smart;
 use crate::launch::helpers::jre_selector::select_java_runtime;
 use crate::launcher_config::models::JavaInfo;
 use crate::resource::models::SourceType;
@@ -24,36 +24,11 @@ pub fn add_library_entry(
   lib_path: &str,
   params: Option<LibrariesValue>,
 ) -> SJMCLResult<()> {
-  let LibraryParts {
-    path,
-    pack_name,
-    pack_version: _pack_version,
-    classifier,
-    extension,
-  } = parse_library_name(lib_path, None)?;
-
-  if let Some(pos) = libraries.iter().position(|item| {
-    if let Ok(parts) = parse_library_name(&item.name, None) {
-      parts.path == path
-        && parts.pack_name == pack_name
-        && parts.classifier == classifier
-        && parts.extension == extension
-    } else {
-      false
-    }
-  }) {
-    libraries[pos] = LibrariesValue {
-      name: lib_path.to_string(),
-      ..params.unwrap_or_default()
-    }
-  } else {
-    libraries.push(LibrariesValue {
-      name: lib_path.to_string(),
-      ..params.unwrap_or_default()
-    });
-  }
-
-  Ok(())
+  let new_library = LibrariesValue {
+    name: lib_path.to_string(),
+    ..params.unwrap_or_default()
+  };
+  add_library_smart(libraries, new_library)
 }
 
 pub async fn install_mod_loader(


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

Sometimes version.json contains duplicate libs, e.g. the one generated by PCL for fabric. SJMCL will do duplicate lib check when generating version.json, but not when generating classpath for launch command.

### Description

Do duplicate lib check for classpath generation; reuse the code if possible.

### Additional Context

Also write a simple version comparison for lib selection, which may be refined.

