### PR TITLE
fix(frontend): improve spotlight search result handling and highlighting

### DIFF
--- a/src/components/modals/spotlight-search-modal.tsx
+++ b/src/components/modals/spotlight-search-modal.tsx
@@ -418,16 +418,7 @@ const SpotlightSearchModal: React.FC<Omit<ModalProps, "children">> = ({
           }
           description={
             <Text fontSize="xs" className="secondary-text">
-              <Highlight
-                query={
-                  res.resourceType
-                    ? []
-                    : queryText.trim().toLowerCase().split(/\s+/)
-                } // only highlight when not an online resource
-                styles={{ bg: "yellow.200" }}
-              >
-                {(showZhTrans && res.translatedDescription) || res.description}
-              </Highlight>
+              {(showZhTrans && res.translatedDescription) || res.description}
             </Text>
           }
           prefixElement={


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues


### Description

- modrinth 也用热度优先来进行聚合搜索（modrinth 并没有直接的“按热度”这个选项，实际上是“按下载量”）
- 在搜索网络资源的时候，搜出来的资源的简介不再高亮（本地搜到的结果的简介仍然会高亮，维持原来的效果）
- 对于部分注释进行了优化
- 修了个刚刚才发现的很难绷的问题，就是之前一共才会返回三个结果，正确的做法是 cf 和 mr 各返回三个
