### PR TITLE
fix(instance): modpack branch not provided causing forge installer download error

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7,6 +7,7 @@ name = "SJMCL"
 version = "0.5.1"
 dependencies = [
  "async-speed-limit",
+ "async-trait",
  "axum",
  "base64 0.22.1",
  "cafebabe",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -88,6 +88,7 @@ rsa = "0.9.8"
 axum = "0.8.6"
 tower-http = { version = "0.6.6", features = ["cors"] }
 sha2 = "0.10.9"
+async-trait = "0.1.89"
 
 [target."cfg(windows)".dependencies]
 winreg = "0.55.0"

--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -8,12 +8,9 @@ use crate::instance::helpers::misc::{
   get_instance_game_config, get_instance_subdir_path_by_id, get_instance_subdir_paths,
   refresh_and_update_instances, unify_instance_name,
 };
-use crate::instance::helpers::modpack::curseforge::CurseForgeManifest;
 use crate::instance::helpers::modpack::misc::{
-  extract_overrides, ModpackManifest, ModpackMetaInfo,
+  extract_overrides, get_download_params, ModpackMetaInfo,
 };
-use crate::instance::helpers::modpack::modrinth::ModrinthManifest;
-use crate::instance::helpers::modpack::multimc::MultiMcManifest;
 use crate::instance::helpers::mods::common::{
   add_local_mod_translations, get_mod_info_from_dir, get_mod_info_from_jar,
 };
@@ -979,18 +976,8 @@ pub async fn create_instance(
   if let Some(modpack_path) = modpack_path {
     let path = PathBuf::from(modpack_path);
     let file = fs::File::open(&path).map_err(|_| InstanceError::FileNotFoundError)?;
-    if let Ok(manifest) = CurseForgeManifest::from_archive(&file) {
-      task_params.extend(manifest.get_download_params(&app, &version_path).await?);
-      extract_overrides(&format!("{}/", manifest.overrides), &file, &version_path)?;
-    } else if let Ok(manifest) = ModrinthManifest::from_archive(&file) {
-      task_params.extend(manifest.get_download_params(&app, &version_path).await?);
-      extract_overrides(&String::from("overrides/"), &file, &version_path)?;
-    } else if let Ok(manifest) = MultiMcManifest::from_archive(&file) {
-      let base_path = manifest.base_path;
-      extract_overrides(&format!("{}.minecraft/", base_path), &file, &version_path)?;
-    } else {
-      return Err(InstanceError::ModpackManifestParseError.into());
-    }
+    task_params.extend(get_download_params(&app, &file, &version_path).await?);
+    extract_overrides(&file, &version_path)?;
   }
 
   schedule_progressive_task_group(

--- a/src-tauri/src/instance/helpers/modpack/curseforge.rs
+++ b/src-tauri/src/instance/helpers/modpack/curseforge.rs
@@ -89,8 +89,7 @@ impl ModpackManifest for CurseForgeManifest {
   fn get_mod_loader_type_version(&self) -> SJMCLResult<(ModLoaderType, String)> {
     for loader in self.minecraft.mod_loaders.clone() {
       if loader.primary {
-        let parsed = loader.id.split("-").collect::<Vec<_>>();
-        let [loader, version] = parsed.as_slice() else {
+        let Some((loader, version)) = loader.id.split_once('-') else {
           return Err(InstanceError::ModLoaderVersionParseError.into());
         };
         return Ok((

--- a/src-tauri/src/instance/helpers/modpack/curseforge.rs
+++ b/src-tauri/src/instance/helpers/modpack/curseforge.rs
@@ -3,6 +3,7 @@ use std::io::Read;
 use std::path::Path;
 use std::str::FromStr;
 
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager};
 use tauri_plugin_http::reqwest;
@@ -12,6 +13,7 @@ use crate::error::{SJMCLError, SJMCLResult};
 use crate::instance::helpers::modpack::misc::ModpackManifest;
 use crate::instance::models::misc::{InstanceError, ModLoaderType};
 use crate::resource::helpers::curseforge::misc::CurseForgeProject;
+use crate::resource::models::OtherResourceSource;
 use crate::tasks::download::DownloadParam;
 use crate::tasks::PTaskParam;
 
@@ -69,6 +71,7 @@ pub struct CurseForgeProjectRes {
   pub data: CurseForgeProject,
 }
 
+#[async_trait]
 impl ModpackManifest for CurseForgeManifest {
   fn from_archive(file: &File) -> SJMCLResult<Self> {
     let mut archive = ZipArchive::new(file)?;
@@ -80,6 +83,24 @@ impl ModpackManifest for CurseForgeManifest {
     })?;
 
     Ok(manifest)
+  }
+
+  fn get_meta_info(
+    &self,
+  ) -> (
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+    OtherResourceSource,
+  ) {
+    (
+      self.name.clone(),
+      self.version.clone(),
+      None,
+      Some(self.author.clone()),
+      OtherResourceSource::CurseForge,
+    )
   }
 
   fn get_client_version(&self) -> SJMCLResult<String> {
@@ -186,5 +207,9 @@ impl ModpackManifest for CurseForgeManifest {
       task_params.push(result?);
     }
     Ok(task_params)
+  }
+
+  fn get_overrides_path(&self) -> String {
+    self.overrides.clone()
   }
 }

--- a/src-tauri/src/instance/helpers/modpack/misc.rs
+++ b/src-tauri/src/instance/helpers/modpack/misc.rs
@@ -17,13 +17,11 @@ impl ModLoader {
   pub async fn with_branch(&self, app: &AppHandle, mc_version: String) -> SJMCLResult<Self> {
     let version_list =
       fetch_mod_loader_version_list(app.clone(), mc_version, self.loader_type.clone()).await?;
-    for version in version_list {
-      if version.version == self.version {
-        return Ok(Self {
-          branch: version.branch,
-          ..self.clone()
-        });
-      }
+    if let Some(version) = version_list.iter().find(|v| v.version == self.version) {
+      return Ok(Self {
+        branch: version.branch.clone(),
+        ..self.clone()
+      });
     }
     Err(InstanceError::ModLoaderVersionParseError.into())
   }

--- a/src-tauri/src/instance/helpers/modpack/misc.rs
+++ b/src-tauri/src/instance/helpers/modpack/misc.rs
@@ -6,12 +6,63 @@ use crate::instance::models::misc::{InstanceError, ModLoader, ModLoaderType};
 use crate::resource::commands::fetch_mod_loader_version_list;
 use crate::resource::models::OtherResourceSource;
 use crate::tasks::PTaskParam;
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::fs::File;
 use std::path::Path;
 use tauri::AppHandle;
 use zip::ZipArchive;
+
+#[async_trait]
+pub trait ModpackManifest {
+  fn from_archive(file: &File) -> SJMCLResult<Self>
+  where
+    Self: Sized;
+  fn get_client_version(&self) -> SJMCLResult<String>;
+  fn get_mod_loader_type_version(&self) -> SJMCLResult<(ModLoaderType, String)>;
+  fn get_meta_info(
+    &self,
+  ) -> (
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+    OtherResourceSource,
+  );
+  async fn get_download_params(
+    &self,
+    app: &AppHandle,
+    instance_path: &Path,
+  ) -> SJMCLResult<Vec<PTaskParam>>;
+  fn get_overrides_path(&self) -> String;
+}
+
+type ManifestBox = Box<dyn ModpackManifest + Send + Sync>;
+type Parser = Box<dyn Fn(&File) -> SJMCLResult<ManifestBox> + Send + Sync>;
+
+fn get_parsers() -> Vec<Parser> {
+  vec![
+    Box::new(|f| {
+      CurseForgeManifest::from_archive(f).map(|m| {
+        let b: ManifestBox = Box::new(m);
+        b
+      })
+    }),
+    Box::new(|f| {
+      ModrinthManifest::from_archive(f).map(|m| {
+        let b: ManifestBox = Box::new(m);
+        b
+      })
+    }),
+    Box::new(|f| {
+      MultiMcManifest::from_archive(f).map(|m| {
+        let b: ManifestBox = Box::new(m);
+        b
+      })
+    }),
+  ]
+}
 
 impl ModLoader {
   pub async fn with_branch(&self, app: &AppHandle, mc_version: String) -> SJMCLResult<Self> {
@@ -39,86 +90,60 @@ pub struct ModpackMetaInfo {
   pub mod_loader: ModLoader,
 }
 
-pub trait ModpackManifest {
-  fn from_archive(file: &File) -> SJMCLResult<Self>
-  where
-    Self: Sized;
-  fn get_client_version(&self) -> SJMCLResult<String>;
-  fn get_mod_loader_type_version(&self) -> SJMCLResult<(ModLoaderType, String)>;
-  async fn get_download_params(
-    &self,
-    app: &AppHandle,
-    instance_path: &Path,
-  ) -> SJMCLResult<Vec<PTaskParam>>;
-}
-
 impl ModpackMetaInfo {
   pub async fn from_archive(app: &AppHandle, file: &File) -> SJMCLResult<Self> {
-    if let Ok(manifest) = CurseForgeManifest::from_archive(file) {
-      let client_version = manifest.get_client_version()?;
-      let (loader_type, version) = manifest.get_mod_loader_type_version()?;
-      Ok(ModpackMetaInfo {
-        modpack_source: OtherResourceSource::CurseForge,
-        name: manifest.name,
-        version: manifest.version,
-        description: None,
-        author: Some(manifest.author),
-        client_version: client_version.clone(),
-        mod_loader: ModLoader {
-          loader_type,
-          version,
-          ..Default::default()
-        }
-        .with_branch(app, client_version)
-        .await?,
-      })
-    } else if let Ok(manifest) = ModrinthManifest::from_archive(file) {
-      let client_version = manifest.get_client_version()?;
-      let (loader_type, version) = manifest.get_mod_loader_type_version()?;
-      Ok(ModpackMetaInfo {
-        modpack_source: OtherResourceSource::Modrinth,
-        name: manifest.name,
-        version: manifest.version_id,
-        description: manifest.summary,
-        author: None,
-        client_version: client_version.clone(),
-        mod_loader: ModLoader {
-          loader_type,
-          version,
-          ..Default::default()
-        }
-        .with_branch(app, client_version)
-        .await?,
-      })
-    } else if let Ok(manifest) = MultiMcManifest::from_archive(file) {
-      let client_version = manifest.get_client_version()?;
-      let (loader_type, version) = manifest.get_mod_loader_type_version()?;
-      Ok(ModpackMetaInfo {
-        modpack_source: OtherResourceSource::MultiMc,
-        name: manifest.cfg.get("name").cloned().unwrap_or_default(),
-        version: String::new(),
-        description: None,
-        author: None,
-        client_version: client_version.clone(),
-        mod_loader: ModLoader {
-          loader_type,
-          version,
-          ..Default::default()
-        }
-        .with_branch(app, client_version)
-        .await?,
-      })
-    } else {
-      Err(InstanceError::ModpackManifestParseError.into())
+    for parser in get_parsers() {
+      if let Ok(manifest) = parser(file) {
+        let client_version = manifest.get_client_version()?;
+        let (loader_type, version) = manifest.get_mod_loader_type_version()?;
+        let (name, ver, description, author, modpack_source) = manifest.get_meta_info();
+
+        return Ok(ModpackMetaInfo {
+          modpack_source,
+          name,
+          version: ver,
+          description,
+          author,
+          client_version: client_version.clone(),
+          mod_loader: ModLoader {
+            loader_type,
+            version,
+            ..Default::default()
+          }
+          .with_branch(app, client_version)
+          .await?,
+        });
+      }
     }
+
+    Err(InstanceError::ModpackManifestParseError.into())
   }
 }
 
-pub fn extract_overrides(
-  overrides_path: &String,
+pub async fn get_download_params(
+  app: &AppHandle,
   file: &File,
   instance_path: &Path,
-) -> SJMCLResult<()> {
+) -> SJMCLResult<Vec<PTaskParam>> {
+  for parser in get_parsers() {
+    if let Ok(manifest) = parser(file) {
+      return manifest.get_download_params(app, instance_path).await;
+    }
+  }
+
+  Err(InstanceError::ModpackManifestParseError.into())
+}
+
+pub fn extract_overrides(file: &File, instance_path: &Path) -> SJMCLResult<()> {
+  let get_overrides_path = |file| {
+    for parser in get_parsers() {
+      if let Ok(manifest) = parser(file) {
+        return Some(manifest.get_overrides_path());
+      }
+    }
+    None
+  };
+  let overrides_path = get_overrides_path(file).ok_or(InstanceError::ModpackManifestParseError)?;
   let mut archive = ZipArchive::new(file)?;
   for i in 0..archive.len() {
     let mut file = archive.by_index(i)?;

--- a/src-tauri/src/instance/helpers/modpack/misc.rs
+++ b/src-tauri/src/instance/helpers/modpack/misc.rs
@@ -2,13 +2,32 @@ use crate::error::SJMCLResult;
 use crate::instance::helpers::modpack::curseforge::CurseForgeManifest;
 use crate::instance::helpers::modpack::modrinth::ModrinthManifest;
 use crate::instance::helpers::modpack::multimc::MultiMcManifest;
-use crate::instance::models::misc::{InstanceError, ModLoader};
+use crate::instance::models::misc::{InstanceError, ModLoader, ModLoaderType};
+use crate::resource::commands::fetch_mod_loader_version_list;
 use crate::resource::models::OtherResourceSource;
+use crate::tasks::PTaskParam;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::fs::File;
 use std::path::Path;
+use tauri::AppHandle;
 use zip::ZipArchive;
+
+impl ModLoader {
+  pub async fn with_branch(&self, app: &AppHandle, mc_version: String) -> SJMCLResult<Self> {
+    let version_list =
+      fetch_mod_loader_version_list(app.clone(), mc_version, self.loader_type.clone()).await?;
+    for version in version_list {
+      if version.version == self.version {
+        return Ok(Self {
+          branch: version.branch,
+          ..self.clone()
+        });
+      }
+    }
+    Err(InstanceError::ModLoaderVersionParseError.into())
+  }
+}
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -22,23 +41,38 @@ pub struct ModpackMetaInfo {
   pub mod_loader: ModLoader,
 }
 
+pub trait ModpackManifest {
+  fn from_archive(file: &File) -> SJMCLResult<Self>
+  where
+    Self: Sized;
+  fn get_client_version(&self) -> SJMCLResult<String>;
+  fn get_mod_loader_type_version(&self) -> SJMCLResult<(ModLoaderType, String)>;
+  async fn get_download_params(
+    &self,
+    app: &AppHandle,
+    instance_path: &Path,
+  ) -> SJMCLResult<Vec<PTaskParam>>;
+}
+
 impl ModpackMetaInfo {
-  pub async fn from_archive(file: &File) -> SJMCLResult<Self> {
+  pub async fn from_archive(app: &AppHandle, file: &File) -> SJMCLResult<Self> {
     if let Ok(manifest) = CurseForgeManifest::from_archive(file) {
-      let client_version = manifest.get_client_version();
-      let (loader_type, version) = manifest.get_mod_loader_type_version();
+      let client_version = manifest.get_client_version()?;
+      let (loader_type, version) = manifest.get_mod_loader_type_version()?;
       Ok(ModpackMetaInfo {
         modpack_source: OtherResourceSource::CurseForge,
         name: manifest.name,
         version: manifest.version,
         description: None,
         author: Some(manifest.author),
-        client_version,
+        client_version: client_version.clone(),
         mod_loader: ModLoader {
           loader_type,
           version,
           ..Default::default()
-        },
+        }
+        .with_branch(app, client_version)
+        .await?,
       })
     } else if let Ok(manifest) = ModrinthManifest::from_archive(file) {
       let client_version = manifest.get_client_version()?;
@@ -49,28 +83,32 @@ impl ModpackMetaInfo {
         version: manifest.version_id,
         description: manifest.summary,
         author: None,
-        client_version,
+        client_version: client_version.clone(),
         mod_loader: ModLoader {
           loader_type,
           version,
           ..Default::default()
-        },
+        }
+        .with_branch(app, client_version)
+        .await?,
       })
     } else if let Ok(manifest) = MultiMcManifest::from_archive(file) {
       let client_version = manifest.get_client_version()?;
       let (loader_type, version) = manifest.get_mod_loader_type_version()?;
       Ok(ModpackMetaInfo {
-        modpack_source: OtherResourceSource::Modrinth,
+        modpack_source: OtherResourceSource::MultiMc,
         name: manifest.cfg.get("name").cloned().unwrap_or_default(),
         version: String::new(),
         description: None,
         author: None,
-        client_version,
+        client_version: client_version.clone(),
         mod_loader: ModLoader {
           loader_type,
           version,
           ..Default::default()
-        },
+        }
+        .with_branch(app, client_version)
+        .await?,
       })
     } else {
       Err(InstanceError::ModpackManifestParseError.into())

--- a/src-tauri/src/instance/helpers/modpack/modrinth.rs
+++ b/src-tauri/src/instance/helpers/modpack/modrinth.rs
@@ -3,6 +3,7 @@ use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
 use zip::ZipArchive;
@@ -10,6 +11,7 @@ use zip::ZipArchive;
 use crate::error::SJMCLResult;
 use crate::instance::helpers::modpack::misc::ModpackManifest;
 use crate::instance::models::misc::{InstanceError, ModLoaderType};
+use crate::resource::models::OtherResourceSource;
 use crate::tasks::download::DownloadParam;
 use crate::tasks::PTaskParam;
 
@@ -41,6 +43,7 @@ pub struct ModrinthManifest {
   pub dependencies: HashMap<String, String>,
 }
 
+#[async_trait]
 impl ModpackManifest for ModrinthManifest {
   fn from_archive(file: &File) -> SJMCLResult<Self> {
     let mut archive = ZipArchive::new(file)?;
@@ -51,6 +54,24 @@ impl ModpackManifest for ModrinthManifest {
       eprintln!("{:?}", e);
     })?;
     Ok(manifest)
+  }
+
+  fn get_meta_info(
+    &self,
+  ) -> (
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+    OtherResourceSource,
+  ) {
+    (
+      self.name.clone(),
+      self.version_id.clone(),
+      self.summary.clone(),
+      None,
+      OtherResourceSource::Modrinth,
+    )
   }
 
   fn get_client_version(&self) -> SJMCLResult<String> {
@@ -97,5 +118,9 @@ impl ModpackManifest for ModrinthManifest {
         }))
       })
       .collect::<SJMCLResult<Vec<_>>>()
+  }
+
+  fn get_overrides_path(&self) -> String {
+    "overrides/".to_string()
   }
 }

--- a/src-tauri/src/instance/helpers/modpack/multimc.rs
+++ b/src-tauri/src/instance/helpers/modpack/multimc.rs
@@ -1,7 +1,9 @@
 use crate::error::SJMCLResult;
 use crate::instance::helpers::modpack::misc::ModpackManifest;
 use crate::instance::models::misc::{InstanceError, ModLoaderType};
+use crate::resource::models::OtherResourceSource;
 use crate::tasks::PTaskParam;
+use async_trait::async_trait;
 use config::Config;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -44,6 +46,7 @@ structstruck::strike! {
   }
 }
 
+#[async_trait]
 impl ModpackManifest for MultiMcManifest {
   fn from_archive(file: &File) -> SJMCLResult<Self> {
     let mut archive = ZipArchive::new(file)?;
@@ -94,6 +97,24 @@ impl ModpackManifest for MultiMcManifest {
     Ok(manifest)
   }
 
+  fn get_meta_info(
+    &self,
+  ) -> (
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+    OtherResourceSource,
+  ) {
+    (
+      self.cfg.get("name").cloned().unwrap_or_default(),
+      String::new(),
+      None,
+      None,
+      OtherResourceSource::MultiMc,
+    )
+  }
+
   fn get_client_version(&self) -> SJMCLResult<String> {
     let component = self
       .components
@@ -126,6 +147,10 @@ impl ModpackManifest for MultiMcManifest {
   ) -> SJMCLResult<Vec<PTaskParam>> {
     // MultiMC Manifests do not include download parameters
     Ok(Vec::new())
+  }
+
+  fn get_overrides_path(&self) -> String {
+    format!("{}.minecraft/", self.base_path)
   }
 }
 

--- a/src-tauri/src/resource/commands.rs
+++ b/src-tauri/src/resource/commands.rs
@@ -25,7 +25,7 @@ use crate::tasks::commands::schedule_progressive_task_group;
 use crate::tasks::download::DownloadParam;
 use crate::tasks::PTaskParam;
 use std::sync::Mutex;
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Manager, State};
 use tauri_plugin_http::reqwest;
 
 #[tauri::command]
@@ -59,11 +59,11 @@ pub async fn fetch_mod_loader_version_list(
   app: AppHandle,
   game_version: String,
   mod_loader_type: ModLoaderType,
-  state: State<'_, Mutex<LauncherConfig>>,
 ) -> SJMCLResult<Vec<ModLoaderResourceInfo>> {
   let priority_list = {
-    let state = state.lock()?;
-    get_source_priority_list(&state)
+    let launcher_config_state = app.state::<Mutex<LauncherConfig>>();
+    let launcher_config = launcher_config_state.lock()?;
+    get_source_priority_list(&launcher_config)
   };
   match mod_loader_type {
     ModLoaderType::Forge | ModLoaderType::LegacyForge => {

--- a/src-tauri/src/resource/models.rs
+++ b/src-tauri/src/resource/models.rs
@@ -42,6 +42,7 @@ pub enum OtherResourceSource {
   Unknown,
   CurseForge,
   Modrinth,
+  MultiMc,
 }
 
 impl FromStr for OtherResourceSource {
@@ -51,6 +52,7 @@ impl FromStr for OtherResourceSource {
     match input.to_lowercase().as_str() {
       "curseforge" => Ok(OtherResourceSource::CurseForge),
       "modrinth" => Ok(OtherResourceSource::Modrinth),
+      "multimc" => Ok(OtherResourceSource::MultiMc),
       _ => Err(format!("Unknown resource download type: {}", input)),
     }
   }

--- a/src/components/modals/import-modpack-modal.tsx
+++ b/src/components/modals/import-modpack-modal.tsx
@@ -153,7 +153,9 @@ const ImportModpackModal: React.FC<ImportModpackModalProps> = ({
           },
           {
             title: t("ImportModpackModal.label.modLoader"),
-            children: `${modpack.modLoader.loaderType} ${modpack.modLoader.version}`,
+            children: `${modpack.modLoader.loaderType} ${modpack.modLoader.version} ${
+              modpack.modLoader.branch ? `(${modpack.modLoader.branch})` : ""
+            }`,
           },
           {
             title: t("ImportModpackModal.label.gameVersion"),
@@ -202,6 +204,7 @@ const ImportModpackModal: React.FC<ImportModpackModalProps> = ({
         {
           loaderType: modpack.modLoader.loaderType,
           version: modpack.modLoader.version,
+          branch: modpack.modLoader.branch,
           description: "",
           stable: true,
         } as ModLoaderResourceInfo,

--- a/src/models/instance/misc.ts
+++ b/src/models/instance/misc.ts
@@ -9,6 +9,13 @@ export enum ModLoaderStatus {
   Installed = "Installed",
 }
 
+export interface ModLoader {
+  status: ModLoaderStatus;
+  loaderType: ModLoaderType;
+  version?: string;
+  branch?: string;
+}
+
 export interface InstanceSummary {
   id: string;
   iconSrc: string;
@@ -19,11 +26,7 @@ export interface InstanceSummary {
   versionPath: string;
   version: string;
   majorVersion: string;
-  modLoader: {
-    loaderType: ModLoaderType;
-    version?: string;
-    status: ModLoaderStatus;
-  };
+  modLoader: ModLoader;
   supportQuickPlay: boolean;
   useSpecGameConfig: boolean;
   isVersionIsolated: boolean;
@@ -36,10 +39,7 @@ export interface ModpackMetaInfo {
   description?: string;
   modpackType: OtherResourceSource;
   clientVersion: string;
-  modLoader: {
-    loaderType: ModLoaderType;
-    version: string;
-  };
+  modLoader: ModLoader;
 }
 
 export interface GameServerInfo {


### PR DESCRIPTION
…

<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🐞 Bug fix

### Related Issues

> - fix #1089 

### Description

> - 解决使用 BMCL API 下载 forge 整合包时，forge installer 因为 branch 信息不对而无法正确下载的问题。
> - 小重构了一下 modpack manifest 部分，加了 trait 约束。

### Additional Context

> - Add any other relevant information or screenshots here.

