### PR TITLE
fix(frontend): keep some macOS shortkey, forbid shortkey of Edge task manager

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -50,11 +50,11 @@ export default function App({ Component, pageProps }: AppProps) {
     document.addEventListener("keydown", (event) => {
       const disabledShortcuts =
         ["F3", "F5", "F7"].includes(event.key) ||
+        (event.shiftKey && event.key === "Escape") || // forbid Edge task manager
         (event.altKey && ["ArrowLeft", "ArrowRight"].includes(event.key)) ||
+        (event.ctrlKey && ["H", "Q"].includes(event.key.toUpperCase())) ||
         ((event.ctrlKey || event.metaKey) &&
-          ["F", "G", "H", "J", "P", "Q", "R", "U"].includes(
-            event.key.toUpperCase()
-          ));
+          ["F", "G", "J", "P", "R", "U"].includes(event.key.toUpperCase()));
       disabledShortcuts && event.preventDefault();
     });
   }, []);


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

close #1172 

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

