### PR TITLE
fix(locales): 始终使用当前年份渲染版权信息

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -58,7 +58,7 @@
       "settings": {
         "copyright": {
           "title": "Copyright",
-          "description": "Copyright © 2024-2025 SJMCL Team."
+          "description": "Copyright © 2024-{{currentYear}} SJMCL Team."
         },
         "userAgreement": {
           "title": "User Agreement",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -58,7 +58,7 @@
       "settings": {
         "copyright": {
           "title": "Droits d'auteur",
-          "description": "Copyright © 2024-2025 Équipe de développement SJMCL."
+          "description": "Copyright © 2024-{{currentYear}} Équipe de développement SJMCL."
         },
         "userAgreement": {
           "title": "Accord d'utilisateur",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -58,7 +58,7 @@
       "settings": {
         "copyright": {
           "title": "コピーライト",
-          "description": "© 2024-2025 SJMCL 開発チーム"
+          "description": "© 2024-{{currentYear}} SJMCL 開発チーム"
         },
         "userAgreement": {
           "title": "利用規約",

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -58,7 +58,7 @@
       "settings": {
         "copyright": {
           "title": "版权",
-          "description": "版权所有 © 2024-2025 SJMCL 开发团队."
+          "description": "版权所有 © 2024-{{currentYear}} SJMCL 开发团队."
         },
         "userAgreement": {
           "title": "用户协议",

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -58,7 +58,7 @@
       "settings": {
         "copyright": {
           "title": "版權",
-          "description": "版權所有 © 2024-2025 SJMCL 開發團隊."
+          "description": "版權所有 © 2024-{{currentYear}} SJMCL 開發團隊."
         },
         "userAgreement": {
           "title": "使用者協議",

--- a/src/pages/settings/about.tsx
+++ b/src/pages/settings/about.tsx
@@ -185,7 +185,8 @@ const AboutSettingsPage = () => {
         {
           title: t("AboutSettingsPage.legalInfo.settings.copyright.title"),
           description: t(
-            "AboutSettingsPage.legalInfo.settings.copyright.description"
+            "AboutSettingsPage.legalInfo.settings.copyright.description",
+            { currentYear: new Date().getFullYear() }
           ),
           children: <></>,
         },


### PR DESCRIPTION

### Checklist


- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [x] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

### Description

自动根据当前年份渲染版权信息

<img width="1130" height="376" alt="image" src="https://github.com/user-attachments/assets/43f7180e-db6c-48fa-8307-dc109e04cd9b" />


### Additional Context

locale检查会失败，但是和这个PR无关：
```
Comparing fr to en:
3 missing, 5 extra keys
  Missing:   CopyOrMoveModal.content
  Missing:   GeneralSettingsPage.functions.settings.discoverPage.openNotice.content
  Missing:   InstanceSettingsPage.tipsToGlobal.content
  Extra:     CopyOrMoveModal.body
  Extra:     GeneralSettingsPage.functions.settings.discoverPage.openNotice.part-1
  Extra:     GeneralSettingsPage.functions.settings.discoverPage.openNotice.part-2
  Extra:     InstanceSettingsPage.tipsToGlobal.part-1
  Extra:     InstanceSettingsPage.tipsToGlobal.part-2
```

