### PR TITLE
fix(backend): fix JRE judge logic, return empty when unknown

### DIFF
--- a/src-tauri/src/launcher_config/helpers/java.rs
+++ b/src-tauri/src/launcher_config/helpers/java.rs
@@ -69,7 +69,11 @@ pub async fn refresh_and_update_javas(app: &AppHandle) {
       major_version,
       is_lts,
       exec_path: java_exec_path.clone(),
-      vendor,
+      vendor: if java_exec_path.contains("runtime/java-") {
+        "Microsoft".to_string()
+      } else {
+        vendor
+      },
       is_user_added,
     };
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

fix #1268 

### Description

<img width="912" height="662" alt="截屏2026-01-17 11 03 51" src="https://github.com/user-attachments/assets/af17af93-28e6-4e1a-902a-2a82d6856aa3" />

修复了 Bellsoft 分发显示为 Oracle 的错误，先运行第一套从 release 文件读取、第二套是运行 java --version，在两套逻辑都失效时返回空值

### Additional Context

> - Add any other relevant information or screenshots here.

