### PR TITLE
fix(backend): support unlisted versions

### DIFF
--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -928,7 +928,10 @@ pub async fn create_instance(
 
   // Download version info
   let mut version_info = client
-    .get(&game.url)
+    .get(&game.url.replace(
+      "zkitefly.github.io/unlisted-versions-of-minecraft",
+      "alist.8mi.tech/d/mirror/unlisted-versions-of-minecraft/Auto",
+    ))
     .send()
     .await
     .map_err(|_| InstanceError::NetworkError)?
@@ -956,8 +959,11 @@ pub async fn create_instance(
     .ok_or(InstanceError::ClientJsonParseError)?;
 
   task_params.push(PTaskParam::Download(DownloadParam {
-    src: Url::parse(&client_download_info.url.clone())
-      .map_err(|_| InstanceError::ClientJsonParseError)?,
+    src: Url::parse(&client_download_info.url.replace(
+      "zkitefly.github.io/unlisted-versions-of-minecraft",
+      "alist.8mi.tech/d/mirror/unlisted-versions-of-minecraft/Auto",
+    ))
+    .map_err(|_| InstanceError::ClientJsonParseError)?,
     dest: instance.version_path.join(format!("{}.jar", name)),
     filename: None,
     sha1: Some(client_download_info.sha1.clone()),

--- a/src-tauri/src/instance/helpers/client_json.rs
+++ b/src-tauri/src/instance/helpers/client_json.rs
@@ -7,7 +7,7 @@ use regex::RegexBuilder;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use serde_with::formats::PreferMany;
-use serde_with::{serde_as, OneOrMany};
+use serde_with::{serde_as, DisplayFromStr, OneOrMany, PickFirst};
 use serialize_skip_none_derive::serialize_skip_none;
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -236,10 +236,12 @@ pub struct AssetIndexInfo {
   pub url: String,
 }
 
+#[serde_as]
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 #[serde(rename_all = "camelCase", default)]
 pub struct DownloadsValue {
   pub sha1: String,
+  #[serde_as(as = "PickFirst<(_, DisplayFromStr)>")]
   pub size: i64,
   pub url: String,
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - closes #1014

### Description

> - 没有更改 versions.txt
> - 未列出版本统一使用 alist.8mi.tech/d/mirror/unlisted-versions-of-minecraft/Auto，这种做法可能需要进一步讨论
> - 某些名字很长的版本（如1_19_deep_dark_experimental_snapshot-1）文字会超出范围，可能需要考虑更名
> - 排序实例时可能出现问题，因为 build_game_version_cmp_fn 的逻辑缺陷（或许可以修正）

