### PR TITLE
Add virtual scrolling to screenshots page

### DIFF
--- a/src/components/common/wrap-card-virtual.tsx
+++ b/src/components/common/wrap-card-virtual.tsx
@@ -1,0 +1,213 @@
+import { Box, Card, Center } from "@chakra-ui/react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { BeatLoader } from "react-spinners";
+import {
+  AutoSizer,
+  Grid,
+  GridCellProps,
+  ScrollEventData,
+} from "react-virtualized";
+import { Section, SectionProps } from "@/components/common/section";
+import { WrapCard, WrapCardProps } from "@/components/common/wrap-card";
+import cardStyles from "@/styles/card.module.css";
+
+export { WrapCard };
+export type { WrapCardProps };
+
+export interface VirtualWrapCardGroupProps extends SectionProps {
+  items: (WrapCardProps | React.ReactNode)[];
+  cardMinWidth?: number;
+  spacing?: number;
+  cardAspectRatio?: number;
+  useInfiniteScroll?: boolean;
+  hasMore?: boolean;
+  loadMore?: () => void;
+}
+
+export const VirtualWrapCardGroup: React.FC<VirtualWrapCardGroupProps> = ({
+  items,
+  cardMinWidth = 41.8,
+  spacing = 12,
+  cardAspectRatio = 0,
+  useInfiniteScroll = false,
+  hasMore = false,
+  loadMore = () => {},
+  ...props
+}) => {
+  const gridRef = useRef<Grid>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const resizeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const [isScrolling, setIsScrolling] = useState(false);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [canLoadMore, setCanLoadMore] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  useEffect(() => {
+    if (items.length > 0) {
+      setCanLoadMore(true);
+    }
+  }, [items.length]);
+
+  useEffect(() => {
+    setLoadingMore(false);
+  }, [items]);
+
+  const debouncedLoadMore = useCallback(() => {
+    if (canLoadMore && hasMore && !loadingMore) {
+      setLoadingMore(true);
+      loadMore();
+    }
+  }, [canLoadMore, hasMore, loadingMore, loadMore]);
+
+  const handleScroll = useCallback(
+    ({ clientHeight, scrollHeight, scrollTop }: ScrollEventData) => {
+      if (useInfiniteScroll && scrollTop + clientHeight >= scrollHeight - 300) {
+        debouncedLoadMore();
+      }
+      setIsScrolling(true);
+      if (scrollTimeoutRef.current) {
+        clearTimeout(scrollTimeoutRef.current);
+      }
+      scrollTimeoutRef.current = setTimeout(() => {
+        setIsScrolling(false);
+      }, 150);
+    },
+    [debouncedLoadMore, useInfiniteScroll]
+  );
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const observer = new ResizeObserver((entries) => {
+      const newWidth = entries[0]?.contentRect.width ?? 0;
+      setContainerWidth(newWidth);
+
+      if (resizeTimeoutRef.current) {
+        clearTimeout(resizeTimeoutRef.current);
+      }
+      resizeTimeoutRef.current = setTimeout(() => {
+        gridRef.current?.recomputeGridSize();
+      }, 100);
+    });
+
+    observer.observe(containerRef.current);
+    return () => {
+      if (resizeTimeoutRef.current) {
+        clearTimeout(resizeTimeoutRef.current);
+      }
+      observer.disconnect();
+    };
+  }, []);
+
+  const getColumnCount = useCallback(
+    (width: number): number => {
+      if (width <= 0) return 5;
+      const columnCount = Math.floor(width / (cardMinWidth * 4 + spacing));
+      return Math.max(2, Math.min(5, columnCount));
+    },
+    [cardMinWidth, spacing]
+  );
+
+  const gridConfig = useMemo(() => {
+    const columnCount = getColumnCount(containerWidth);
+    return {
+      columnCount,
+      rowCount: Math.ceil(items.length / columnCount),
+    };
+  }, [containerWidth, items.length, getColumnCount]);
+
+  const isWrapCardProps = (item: any): item is WrapCardProps => {
+    return (
+      (item as WrapCardProps)?.cardContent != null ||
+      (item as WrapCardProps)?.children != null
+    );
+  };
+
+  const cellRenderer = useCallback(
+    ({ columnIndex, rowIndex, key, style }: GridCellProps) => {
+      const index = rowIndex * gridConfig.columnCount + columnIndex;
+
+      if (index >= items.length) {
+        return null;
+      }
+
+      const item = items[index];
+
+      if (isWrapCardProps(item)) {
+        const validColSpan = Math.max(1, Math.floor(item.colSpan || 1));
+        const columnWidth = containerWidth / gridConfig.columnCount;
+        const cellWidth = columnWidth * validColSpan;
+
+        return (
+          <div
+            key={key}
+            style={{
+              ...style,
+              width: cellWidth,
+              padding: `0 ${spacing / 2}px`,
+              boxSizing: "border-box",
+            }}
+          >
+            <WrapCard {...item} p={0} />
+          </div>
+        );
+      }
+
+      return null;
+    },
+    [items, gridConfig.columnCount, containerWidth, spacing]
+  );
+
+  const rowHeight = useMemo(() => {
+    if (cardAspectRatio !== 0 && containerWidth > 0) {
+      const columnWidth = containerWidth / gridConfig.columnCount;
+      return columnWidth / cardAspectRatio;
+    }
+    return 150;
+  }, [cardAspectRatio, containerWidth, gridConfig.columnCount]);
+
+  return (
+    <Section {...props}>
+      {items.length > 0 && (
+        <Card className={cardStyles["card-front"]} h="100%">
+          <Box ref={containerRef} w="100%" h="100%" overflow="hidden">
+            <AutoSizer>
+              {({ width, height }) => {
+                if (width === 0 || height === 0) return null;
+
+                return (
+                  <Grid
+                    ref={gridRef}
+                    width={width}
+                    height={height}
+                    columnCount={gridConfig.columnCount}
+                    columnWidth={width / gridConfig.columnCount}
+                    rowCount={gridConfig.rowCount}
+                    rowHeight={rowHeight}
+                    cellRenderer={cellRenderer}
+                    overscanRowCount={5}
+                    onScroll={handleScroll}
+                    scrolling={isScrolling}
+                    style={{ overflowX: "hidden" }}
+                  />
+                );
+              }}
+            </AutoSizer>
+          </Box>
+          {loadingMore && (
+            <Center key="loading" mt="auto">
+              <BeatLoader size={12} color="gray" />
+            </Center>
+          )}
+        </Card>
+      )}
+    </Section>
+  );
+};

--- a/src/pages/instances/details/[id]/screenshots.tsx
+++ b/src/pages/instances/details/[id]/screenshots.tsx
@@ -25,14 +25,8 @@ import { ScreenshotInfo } from "@/models/instance/misc";
 const GAP = 12;
 const ASPECT_RATIO = 9 / 16;
 const OVERSCAN_ROW_COUNT = 5;
-
-// 每个截图项的最小宽度，用于计算列数
 const MIN_ITEM_WIDTH = 220;
 
-/**
- * 根据容器宽度计算列数
- * 默认窗口大小下显示5列，窗口缩小时减少列数
- */
 const getColumnCount = (containerWidth: number): number => {
   if (containerWidth <= 0) return 5;
   const columnCount = Math.floor(containerWidth / MIN_ITEM_WIDTH);
@@ -136,6 +130,7 @@ const InstanceScreenshotsPage: React.FC = () => {
     getScreenshotListWrapper();
   }, [getScreenshotListWrapper]);
 
+  // Handle container resize with debounce to avoid excessive re-renders
   useEffect(() => {
     if (!containerRef.current) return;
 
@@ -166,6 +161,7 @@ const InstanceScreenshotsPage: React.FC = () => {
     onClose: onScreenshotPreviewModalClose,
   } = useDisclosure();
 
+  // Open preview modal when screenshot index is in URL query
   useEffect(() => {
     const { screenshotIndex } = router.query;
     if (screenshotIndex) {
@@ -190,6 +186,7 @@ const InstanceScreenshotsPage: React.FC = () => {
     }
   }, [onScreenshotPreviewModalClose]);
 
+  // Track scrolling state for performance optimization
   const handleScroll = useCallback(({ scrollTop }: { scrollTop: number }) => {
     setIsScrolling(true);
     if (scrollTimeoutRef.current) {

--- a/src/pages/instances/details/[id]/screenshots.tsx
+++ b/src/pages/instances/details/[id]/screenshots.tsx
@@ -9,28 +9,113 @@ import {
 } from "@chakra-ui/react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import router from "next/router";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuEllipsis } from "react-icons/lu";
 import { BeatLoader } from "react-spinners";
-import { AutoSizer, Grid, GridCellProps } from "react-virtualized";
-import "react-virtualized/styles.css";
 import Empty from "@/components/common/empty";
 import { Section } from "@/components/common/section";
+import {
+  VirtualWrapCardGroup,
+  WrapCardProps,
+} from "@/components/common/wrap-card-virtual";
 import PreviewScreenshotModal from "@/components/modals/preview-screenshot-modal";
 import { useInstanceSharedData } from "@/contexts/instance";
 import { GetStateFlag } from "@/hooks/get-state";
 import { ScreenshotInfo } from "@/models/instance/misc";
 
-const GAP = 12;
-const ASPECT_RATIO = 9 / 16;
-const OVERSCAN_ROW_COUNT = 5;
-const MIN_ITEM_WIDTH = 220;
+const ASPECT_RATIO = 16 / 9;
 
-const getColumnCount = (containerWidth: number): number => {
-  if (containerWidth <= 0) return 5;
-  const columnCount = Math.floor(containerWidth / MIN_ITEM_WIDTH);
-  return Math.max(2, Math.min(5, columnCount));
+const InstanceScreenshotsPage: React.FC = () => {
+  const { getScreenshotList, isScreenshotListLoading: isLoading } =
+    useInstanceSharedData();
+  const [screenshots, setScreenshots] = useState<ScreenshotInfo[]>([]);
+  const [currentScreenshot, setCurrentScreenshot] =
+    useState<ScreenshotInfo | null>(null);
+
+  const getScreenshotListWrapper = useCallback(
+    (sync?: boolean) => {
+      getScreenshotList(sync)
+        .then((data) => {
+          if (data === GetStateFlag.Cancelled) return;
+          setScreenshots(data || []);
+        })
+        .catch(() => setScreenshots([]));
+    },
+    [getScreenshotList]
+  );
+
+  useEffect(() => {
+    getScreenshotListWrapper();
+  }, [getScreenshotListWrapper]);
+
+  const {
+    isOpen: isScreenshotPreviewModalOpen,
+    onOpen: onScreenshotPreviewModalOpen,
+    onClose: onScreenshotPreviewModalClose,
+  } = useDisclosure();
+
+  useEffect(() => {
+    const { screenshotIndex } = router.query;
+    if (screenshotIndex) {
+      setCurrentScreenshot(screenshots[Number(screenshotIndex)]);
+      onScreenshotPreviewModalOpen();
+    }
+  }, [screenshots, onScreenshotPreviewModalOpen]);
+
+  const handleCloseModal = useCallback(() => {
+    onScreenshotPreviewModalClose();
+    const { id } = router.query;
+    if (id !== undefined) {
+      const instanceId = Array.isArray(id) ? id[0] : id;
+      router.replace(
+        {
+          pathname: `/instances/details/${encodeURIComponent(instanceId)}/screenshots`,
+          query: {},
+        },
+        undefined,
+        { shallow: true }
+      );
+    }
+  }, [onScreenshotPreviewModalClose]);
+
+  const wrapCardItems: WrapCardProps[] = screenshots.map((screenshot) => ({
+    cardContent: (
+      <ScreenshotCell
+        screenshot={screenshot}
+        onPreview={() => {
+          setCurrentScreenshot(screenshot);
+          onScreenshotPreviewModalOpen();
+        }}
+      />
+    ),
+    colSpan: 1,
+  }));
+
+  return (
+    <Section overflow="hidden">
+      {isLoading ? (
+        <Center mt={4}>
+          <BeatLoader size={16} color="gray" />
+        </Center>
+      ) : screenshots.length > 0 ? (
+        <VirtualWrapCardGroup
+          items={wrapCardItems}
+          cardAspectRatio={ASPECT_RATIO}
+          h="calc(100vh - 180px)"
+        />
+      ) : (
+        <Empty withIcon={false} size="sm" />
+      )}
+      {currentScreenshot && (
+        <PreviewScreenshotModal
+          screenshot={currentScreenshot}
+          isOpen={isScreenshotPreviewModalOpen}
+          onClose={handleCloseModal}
+        />
+      )}
+    </Section>
+  );
 };
 
 const ScreenshotCell = ({
@@ -97,197 +182,6 @@ const ScreenshotCell = ({
         </Box>
       )}
     </Box>
-  );
-};
-
-const InstanceScreenshotsPage: React.FC = () => {
-  const { getScreenshotList, isScreenshotListLoading: isLoading } =
-    useInstanceSharedData();
-  const [screenshots, setScreenshots] = useState<ScreenshotInfo[]>([]);
-  const [currentScreenshot, setCurrentScreenshot] =
-    useState<ScreenshotInfo | null>(null);
-
-  const gridRef = useRef<Grid>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const resizeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const [isScrolling, setIsScrolling] = useState(false);
-  const [containerWidth, setContainerWidth] = useState(0);
-
-  const getScreenshotListWrapper = useCallback(
-    (sync?: boolean) => {
-      getScreenshotList(sync)
-        .then((data) => {
-          if (data === GetStateFlag.Cancelled) return;
-          setScreenshots(data || []);
-        })
-        .catch(() => setScreenshots([]));
-    },
-    [getScreenshotList]
-  );
-
-  useEffect(() => {
-    getScreenshotListWrapper();
-  }, [getScreenshotListWrapper]);
-
-  // Handle container resize with debounce to avoid excessive re-renders
-  useEffect(() => {
-    if (!containerRef.current) return;
-
-    const observer = new ResizeObserver((entries) => {
-      const newWidth = entries[0]?.contentRect.width ?? 0;
-      setContainerWidth(newWidth);
-
-      if (resizeTimeoutRef.current) {
-        clearTimeout(resizeTimeoutRef.current);
-      }
-      resizeTimeoutRef.current = setTimeout(() => {
-        gridRef.current?.recomputeGridSize();
-      }, 100);
-    });
-
-    observer.observe(containerRef.current);
-    return () => {
-      if (resizeTimeoutRef.current) {
-        clearTimeout(resizeTimeoutRef.current);
-      }
-      observer.disconnect();
-    };
-  }, []);
-
-  const {
-    isOpen: isScreenshotPreviewModalOpen,
-    onOpen: onScreenshotPreviewModalOpen,
-    onClose: onScreenshotPreviewModalClose,
-  } = useDisclosure();
-
-  // Open preview modal when screenshot index is in URL query
-  useEffect(() => {
-    const { screenshotIndex } = router.query;
-    if (screenshotIndex) {
-      setCurrentScreenshot(screenshots[Number(screenshotIndex)]);
-      onScreenshotPreviewModalOpen();
-    }
-  }, [screenshots, onScreenshotPreviewModalOpen]);
-
-  const handleCloseModal = useCallback(() => {
-    onScreenshotPreviewModalClose();
-    const { id } = router.query;
-    if (id !== undefined) {
-      const instanceId = Array.isArray(id) ? id[0] : id;
-      router.replace(
-        {
-          pathname: `/instances/details/${encodeURIComponent(instanceId)}/screenshots`,
-          query: {},
-        },
-        undefined,
-        { shallow: true }
-      );
-    }
-  }, [onScreenshotPreviewModalClose]);
-
-  // Track scrolling state for performance optimization
-  const handleScroll = useCallback(({ scrollTop }: { scrollTop: number }) => {
-    setIsScrolling(true);
-    if (scrollTimeoutRef.current) {
-      clearTimeout(scrollTimeoutRef.current);
-    }
-    scrollTimeoutRef.current = setTimeout(() => {
-      setIsScrolling(false);
-    }, 150);
-  }, []);
-
-  const gridConfig = useMemo(() => {
-    const columnCount = getColumnCount(containerWidth);
-    return {
-      columnCount,
-      rowCount: Math.ceil(screenshots.length / columnCount),
-    };
-  }, [containerWidth, screenshots.length]);
-
-  const cellRenderer = useCallback(
-    ({ columnIndex, rowIndex, key, style }: GridCellProps) => {
-      const index = rowIndex * gridConfig.columnCount + columnIndex;
-
-      if (index >= screenshots.length) {
-        return null;
-      }
-
-      const screenshot = screenshots[index];
-
-      return (
-        <div
-          key={key}
-          style={{
-            ...style,
-            padding: GAP / 2,
-          }}
-        >
-          <ScreenshotCell
-            screenshot={screenshot}
-            onPreview={() => {
-              setCurrentScreenshot(screenshot);
-              onScreenshotPreviewModalOpen();
-            }}
-          />
-        </div>
-      );
-    },
-    [screenshots, gridConfig.columnCount, onScreenshotPreviewModalOpen]
-  );
-
-  return (
-    <Section overflow="hidden">
-      <Box ref={containerRef} w="100%" h="100%" overflow="hidden">
-        {isLoading ? (
-          <Center mt={4}>
-            <BeatLoader size={16} color="gray" />
-          </Center>
-        ) : screenshots.length > 0 ? (
-          <Box
-            h="calc(100vh - 180px)"
-            minH="400px"
-            overflow="hidden"
-            className="no-scrollbar"
-          >
-            <AutoSizer>
-              {({ width, height }) => {
-                if (width === 0 || height === 0) return null;
-
-                const columnWidth = width / gridConfig.columnCount;
-                const rowHeight = columnWidth * ASPECT_RATIO;
-
-                return (
-                  <Grid
-                    ref={gridRef}
-                    width={width}
-                    height={height}
-                    columnCount={gridConfig.columnCount}
-                    columnWidth={columnWidth}
-                    rowCount={gridConfig.rowCount}
-                    rowHeight={rowHeight}
-                    cellRenderer={cellRenderer}
-                    overscanRowCount={OVERSCAN_ROW_COUNT}
-                    onScroll={handleScroll}
-                    scrolling={isScrolling}
-                    style={{ overflowX: "hidden" }}
-                  />
-                );
-              }}
-            </AutoSizer>
-          </Box>
-        ) : (
-          <Empty withIcon={false} size="sm" />
-        )}
-      </Box>
-      {currentScreenshot && (
-        <PreviewScreenshotModal
-          screenshot={currentScreenshot}
-          isOpen={isScreenshotPreviewModalOpen}
-          onClose={handleCloseModal}
-        />
-      )}
-    </Section>
   );
 };
 

--- a/src/pages/instances/details/[id]/screenshots.tsx
+++ b/src/pages/instances/details/[id]/screenshots.tsx
@@ -1,32 +1,124 @@
 import {
+  Box,
   Center,
   IconButton,
   Image,
+  Skeleton,
   Tooltip,
   useDisclosure,
 } from "@chakra-ui/react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import router from "next/router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuEllipsis } from "react-icons/lu";
 import { BeatLoader } from "react-spinners";
+import { AutoSizer, Grid, GridCellProps } from "react-virtualized";
+import "react-virtualized/styles.css";
 import Empty from "@/components/common/empty";
 import { Section } from "@/components/common/section";
-import { WrapCardGroup } from "@/components/common/wrap-card";
 import PreviewScreenshotModal from "@/components/modals/preview-screenshot-modal";
 import { useInstanceSharedData } from "@/contexts/instance";
 import { GetStateFlag } from "@/hooks/get-state";
 import { ScreenshotInfo } from "@/models/instance/misc";
 
-const InstanceScreenshotsPage: React.FC = () => {
+const GAP = 12;
+const ASPECT_RATIO = 9 / 16;
+const OVERSCAN_ROW_COUNT = 5;
+
+// 每个截图项的最小宽度，用于计算列数
+const MIN_ITEM_WIDTH = 220;
+
+/**
+ * 根据容器宽度计算列数
+ * 默认窗口大小下显示5列，窗口缩小时减少列数
+ */
+const getColumnCount = (containerWidth: number): number => {
+  if (containerWidth <= 0) return 5;
+  const columnCount = Math.floor(containerWidth / MIN_ITEM_WIDTH);
+  return Math.max(2, Math.min(5, columnCount));
+};
+
+const ScreenshotCell = ({
+  screenshot,
+  onPreview,
+}: {
+  screenshot: ScreenshotInfo;
+  onPreview: () => void;
+}) => {
+  const [isHovered, setIsHovered] = useState(false);
+  const [isLoaded, setIsLoaded] = useState(false);
   const { t } = useTranslation();
 
+  return (
+    <Box
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      w="100%"
+      h="100%"
+      position="relative"
+      borderRadius="md"
+      overflow="hidden"
+    >
+      {!isLoaded && (
+        <Skeleton
+          position="absolute"
+          top={0}
+          left={0}
+          right={0}
+          bottom={0}
+          startColor="gray.700"
+          endColor="gray.600"
+          speed={1}
+        />
+      )}
+      <Image
+        src={convertFileSrc(screenshot.filePath)}
+        alt={screenshot.fileName}
+        objectFit="cover"
+        w="100%"
+        h="100%"
+        loading="lazy"
+        onLoad={() => setIsLoaded(true)}
+        style={{
+          opacity: isLoaded ? 1 : 0,
+          transition: "opacity 0.2s ease-in-out",
+        }}
+      />
+      {isHovered && isLoaded && (
+        <Box position="absolute" top={1} right={1}>
+          <Tooltip
+            label={t("InstanceScreenshotsPage.button.details")}
+            placement="auto"
+          >
+            <IconButton
+              icon={<LuEllipsis />}
+              aria-label="details"
+              colorScheme="blackAlpha"
+              variant="solid"
+              size="sm"
+              onClick={onPreview}
+            />
+          </Tooltip>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+const InstanceScreenshotsPage: React.FC = () => {
   const { getScreenshotList, isScreenshotListLoading: isLoading } =
     useInstanceSharedData();
   const [screenshots, setScreenshots] = useState<ScreenshotInfo[]>([]);
   const [currentScreenshot, setCurrentScreenshot] =
     useState<ScreenshotInfo | null>(null);
+
+  const gridRef = useRef<Grid>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const resizeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const [isScrolling, setIsScrolling] = useState(false);
+  const [containerWidth, setContainerWidth] = useState(0);
 
   const getScreenshotListWrapper = useCallback(
     (sync?: boolean) => {
@@ -35,7 +127,7 @@ const InstanceScreenshotsPage: React.FC = () => {
           if (data === GetStateFlag.Cancelled) return;
           setScreenshots(data || []);
         })
-        .catch((e) => setScreenshots([]));
+        .catch(() => setScreenshots([]));
     },
     [getScreenshotList]
   );
@@ -45,9 +137,27 @@ const InstanceScreenshotsPage: React.FC = () => {
   }, [getScreenshotListWrapper]);
 
   useEffect(() => {
-    // This page does not have a refresh button, so we need to fetch the screenshot list when the page is mounted
-    getScreenshotListWrapper(true);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    if (!containerRef.current) return;
+
+    const observer = new ResizeObserver((entries) => {
+      const newWidth = entries[0]?.contentRect.width ?? 0;
+      setContainerWidth(newWidth);
+
+      if (resizeTimeoutRef.current) {
+        clearTimeout(resizeTimeoutRef.current);
+      }
+      resizeTimeoutRef.current = setTimeout(() => {
+        gridRef.current?.recomputeGridSize();
+      }, 100);
+    });
+
+    observer.observe(containerRef.current);
+    return () => {
+      if (resizeTimeoutRef.current) {
+        clearTimeout(resizeTimeoutRef.current);
+      }
+      observer.disconnect();
+    };
   }, []);
 
   const {
@@ -64,7 +174,7 @@ const InstanceScreenshotsPage: React.FC = () => {
     }
   }, [screenshots, onScreenshotPreviewModalOpen]);
 
-  const handleCloseModal = () => {
+  const handleCloseModal = useCallback(() => {
     onScreenshotPreviewModalClose();
     const { id } = router.query;
     if (id !== undefined) {
@@ -78,67 +188,101 @@ const InstanceScreenshotsPage: React.FC = () => {
         { shallow: true }
       );
     }
-  };
+  }, [onScreenshotPreviewModalClose]);
 
-  const ScreenshotsCard = ({ screenshot }: { screenshot: ScreenshotInfo }) => {
-    const [isHovered, setIsHovered] = useState(false);
-    return (
-      <div
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-        style={{ width: "100%", height: "100%" }}
-      >
-        <Image
-          src={convertFileSrc(screenshot.filePath)}
-          alt={screenshot.fileName}
-          objectFit="cover"
-          w="100%"
-          h="100%"
-          position="relative"
-          borderRadius="md"
-        />
-        {isHovered && (
-          <Tooltip
-            label={t("InstanceScreenshotsPage.button.details")}
-            placement="auto"
-          >
-            <IconButton
-              icon={<LuEllipsis />}
-              aria-label="details"
-              colorScheme="blackAlpha"
-              variant="solid"
-              size="xs"
-              position="absolute"
-              top={1}
-              right={1}
-              onClick={() => {
-                setCurrentScreenshot(screenshot);
-                onScreenshotPreviewModalOpen();
-              }}
-            />
-          </Tooltip>
-        )}
-      </div>
-    );
-  };
+  const handleScroll = useCallback(({ scrollTop }: { scrollTop: number }) => {
+    setIsScrolling(true);
+    if (scrollTimeoutRef.current) {
+      clearTimeout(scrollTimeoutRef.current);
+    }
+    scrollTimeoutRef.current = setTimeout(() => {
+      setIsScrolling(false);
+    }, 150);
+  }, []);
+
+  const gridConfig = useMemo(() => {
+    const columnCount = getColumnCount(containerWidth);
+    return {
+      columnCount,
+      rowCount: Math.ceil(screenshots.length / columnCount),
+    };
+  }, [containerWidth, screenshots.length]);
+
+  const cellRenderer = useCallback(
+    ({ columnIndex, rowIndex, key, style }: GridCellProps) => {
+      const index = rowIndex * gridConfig.columnCount + columnIndex;
+
+      if (index >= screenshots.length) {
+        return null;
+      }
+
+      const screenshot = screenshots[index];
+
+      return (
+        <div
+          key={key}
+          style={{
+            ...style,
+            padding: GAP / 2,
+          }}
+        >
+          <ScreenshotCell
+            screenshot={screenshot}
+            onPreview={() => {
+              setCurrentScreenshot(screenshot);
+              onScreenshotPreviewModalOpen();
+            }}
+          />
+        </div>
+      );
+    },
+    [screenshots, gridConfig.columnCount, onScreenshotPreviewModalOpen]
+  );
 
   return (
-    <Section>
-      {isLoading ? (
-        <Center mt={4}>
-          <BeatLoader size={16} color="gray" />
-        </Center>
-      ) : screenshots.length > 0 ? (
-        <WrapCardGroup
-          cardAspectRatio={16 / 9}
-          items={screenshots.map((screenshot) => ({
-            cardContent: <ScreenshotsCard screenshot={screenshot} />,
-            p: 0,
-          }))}
-        />
-      ) : (
-        <Empty withIcon={false} size="sm" />
-      )}
+    <Section overflow="hidden">
+      <Box ref={containerRef} w="100%" h="100%" overflow="hidden">
+        {isLoading ? (
+          <Center mt={4}>
+            <BeatLoader size={16} color="gray" />
+          </Center>
+        ) : screenshots.length > 0 ? (
+          <Box
+            h="calc(100vh - 180px)"
+            minH="400px"
+            overflow="hidden"
+            className="no-scrollbar"
+          >
+            <AutoSizer>
+              {({ width, height }) => {
+                if (width === 0 || height === 0) return null;
+
+                const columnWidth = width / gridConfig.columnCount;
+                const rowHeight = columnWidth * ASPECT_RATIO;
+
+                return (
+                  <Grid
+                    ref={gridRef}
+                    width={width}
+                    height={height}
+                    columnCount={gridConfig.columnCount}
+                    columnWidth={columnWidth}
+                    rowCount={gridConfig.rowCount}
+                    rowHeight={rowHeight}
+                    cellRenderer={cellRenderer}
+                    overscanRowCount={OVERSCAN_ROW_COUNT}
+                    onScroll={handleScroll}
+                    scrolling={isScrolling}
+                    style={{ overflowX: "hidden" }}
+                  />
+                );
+              }}
+            </AutoSizer>
+          </Box>
+        ) : (
+          <Empty withIcon={false} size="sm" />
+        )}
+      </Box>
       {currentScreenshot && (
         <PreviewScreenshotModal
           screenshot={currentScreenshot}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [x] 🛠 Refactoring
- [x] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues
fix #1429

### Description
The screenshots page previously rendered all items at once, causing performance issues when a large number of screenshots were present. This PR implements virtual scrolling so that only visible items are rendered, improving scroll performance.

### Additional Context

