### PR TITLE
feat(optifine): allow change optifine version

### DIFF
--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -1324,7 +1324,8 @@ pub async fn check_change_mod_loader_availablity(
 pub async fn change_mod_loader(
   app: AppHandle,
   instance_id: String,
-  new_mod_loader: ModLoaderResourceInfo,
+  new_mod_loader: Option<ModLoaderResourceInfo>,
+  optifine: Option<OptiFineResourceInfo>,
   is_install_fabric_api: Option<bool>,
   is_install_qf_api: Option<bool>,
 ) -> SJMCLResult<()> {
@@ -1355,19 +1356,6 @@ pub async fn change_mod_loader(
     .cloned()
     .ok_or(InstanceError::NotSupportChangeModLoader)?;
 
-  let mod_loader = ModLoader {
-    loader_type: new_mod_loader.loader_type,
-    version: new_mod_loader.version.clone(),
-    status: if matches!(
-      new_mod_loader.loader_type,
-      ModLoaderType::Unknown | ModLoaderType::Fabric | ModLoaderType::Quilt
-    ) {
-      ModLoaderStatus::Installed
-    } else {
-      ModLoaderStatus::NotDownloaded
-    },
-    branch: new_mod_loader.branch.clone(),
-  };
   let game_version = instance.version.clone();
   let subdirs = get_instance_subdir_paths(
     &app,
@@ -1378,16 +1366,20 @@ pub async fn change_mod_loader(
   let [libraries_dir, mods_dir] = subdirs.as_slice() else {
     return Err(InstanceError::InstanceNotFoundByID.into());
   };
-  // Remove Fabric API / QFAPI mods if switching from Fabric or Quilt modloader
-  if matches!(
-    instance.mod_loader.loader_type,
-    ModLoaderType::Fabric | ModLoaderType::Quilt
-  ) && version_isolation
-  {
-    remove_fabric_api_mods(mods_dir).await?;
+
+  if let Some(new_loader) = &new_mod_loader {
+    // Remove Fabric API / QFAPI mods if switching from Fabric or Quilt modloader
+    if matches!(
+      instance.mod_loader.loader_type,
+      ModLoaderType::Fabric | ModLoaderType::Quilt
+    ) && instance.mod_loader.loader_type != new_loader.loader_type
+      && version_isolation
+    {
+      remove_fabric_api_mods(mods_dir).await?;
+    }
   }
+
   // construct new version info
-  instance.mod_loader = mod_loader.clone();
   let mut version_info: McClientInfo = vanilla_info.clone();
   version_info.id = current_info.id.clone();
   version_info.jar = Some(instance.name.clone());
@@ -1395,32 +1387,69 @@ pub async fn change_mod_loader(
   version_info.client_version = Some(instance.version.clone());
   version_info.patches = vec![vanilla_info];
 
-  // install new mod loader
   let mut task_params: Vec<PTaskParam> = Vec::new();
-  install_mod_loader(
-    app.clone(),
-    &priority_list,
-    &game_version,
-    &mod_loader,
-    libraries_dir.to_path_buf(),
-    mods_dir.to_path_buf(),
-    &mut version_info,
-    &mut task_params,
-    is_install_fabric_api,
-    is_install_qf_api,
-  )
-  .await?;
 
-  schedule_progressive_task_group(
-    app.clone(),
-    format!(
-      "change-mod-loader?{} {}",
-      mod_loader.loader_type, mod_loader.version
-    ),
-    task_params,
-    true,
-  )
-  .await?;
+  // install new mod loader
+  if let Some(new_mod_loader) = new_mod_loader {
+    let mod_loader = ModLoader {
+      loader_type: new_mod_loader.loader_type,
+      version: new_mod_loader.version.clone(),
+      status: if matches!(
+        new_mod_loader.loader_type,
+        ModLoaderType::Unknown | ModLoaderType::Fabric | ModLoaderType::Quilt
+      ) {
+        ModLoaderStatus::Installed
+      } else {
+        ModLoaderStatus::NotDownloaded
+      },
+      branch: new_mod_loader.branch.clone(),
+    };
+
+    instance.mod_loader = mod_loader.clone();
+
+    install_mod_loader(
+      app.clone(),
+      &priority_list,
+      &game_version,
+      &mod_loader,
+      libraries_dir.to_path_buf(),
+      mods_dir.to_path_buf(),
+      &mut version_info,
+      &mut task_params,
+      is_install_fabric_api,
+      is_install_qf_api,
+    )
+    .await?;
+  }
+
+  // install new OptiFine
+  if let Some(optifine) = optifine {
+    let optifine_info = OptiFine {
+      filename: optifine.filename.clone(),
+      version: format!("{}_{}", optifine.r#type, optifine.patch),
+      status: ModLoaderStatus::NotDownloaded,
+    };
+
+    instance.optifine = Some(optifine_info);
+
+    download_optifine_installer(
+      &instance.version,
+      &optifine,
+      libraries_dir.to_path_buf(),
+      &mut task_params,
+    )
+    .await?;
+  }
+
+  if !task_params.is_empty() {
+    schedule_progressive_task_group(
+      app.clone(),
+      "change-instance-setup".to_string(),
+      task_params,
+      true,
+    )
+    .await?;
+  }
 
   save_json_async(&version_info, &json_path).await?;
   instance

--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -1325,7 +1325,7 @@ pub async fn change_mod_loader(
   app: AppHandle,
   instance_id: String,
   new_mod_loader: Option<ModLoaderResourceInfo>,
-  optifine: Option<OptiFineResourceInfo>,
+  new_optifine: Option<OptiFineResourceInfo>,
   is_install_fabric_api: Option<bool>,
   is_install_qf_api: Option<bool>,
 ) -> SJMCLResult<()> {
@@ -1423,7 +1423,7 @@ pub async fn change_mod_loader(
   }
 
   // install new OptiFine
-  if let Some(optifine) = optifine {
+  if let Some(optifine) = new_optifine {
     let optifine_info = OptiFine {
       filename: optifine.filename.clone(),
       version: format!("{}_{}", optifine.r#type, optifine.patch),

--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -1337,19 +1337,23 @@ pub async fn change_mod_loader(
       .ok_or(InstanceError::InstanceNotFoundByID)?
       .clone()
   };
+  let original_optifine_config = instance.optifine.clone();
   let version_isolation = get_instance_game_config(&app, &instance).version_isolation;
-  // Get priority list
   let priority_list = {
     let launcher_config_state = app.state::<Mutex<LauncherConfig>>();
     let launcher_config = launcher_config_state.lock()?;
     get_source_priority_list(&launcher_config)
   };
-
-  // load current version info
   let json_path = instance
     .version_path
     .join(format!("{}.json", instance.name));
   let current_info: McClientInfo = load_json_async(&json_path).await?;
+  let original_optifine_patch = current_info
+    .patches
+    .iter()
+    .find(|p| p.id.to_lowercase().contains("optifine"))
+    .cloned();
+
   let vanilla_info = current_info
     .patches
     .first()
@@ -1357,6 +1361,7 @@ pub async fn change_mod_loader(
     .ok_or(InstanceError::NotSupportChangeModLoader)?;
 
   let game_version = instance.version.clone();
+  let old_optifine = instance.optifine.clone();
   let subdirs = get_instance_subdir_paths(
     &app,
     &instance,
@@ -1379,19 +1384,20 @@ pub async fn change_mod_loader(
     }
   }
 
-  // construct new version info
-  let mut version_info: McClientInfo = vanilla_info.clone();
-  version_info.id = current_info.id.clone();
-  version_info.jar = Some(instance.name.clone());
-  version_info.java_version = current_info.java_version.clone();
-  version_info.client_version = Some(instance.version.clone());
-  version_info.patches = vec![vanilla_info];
+  let mut version_info: McClientInfo = current_info.clone();
+  if let Some(ref new_loader) = new_mod_loader {
+    if instance.mod_loader.loader_type != new_loader.loader_type
+      || instance.mod_loader.version != new_loader.version
+    {
+      version_info.patches = vec![vanilla_info.clone()];
+    }
+  }
 
   let mut modloader_task_params: Vec<PTaskParam> = Vec::new();
   let mut optifine_task_params: Vec<PTaskParam> = Vec::new();
 
   // install new mod loader
-  if let Some(new_mod_loader) = new_mod_loader {
+  if let Some(ref new_mod_loader) = new_mod_loader {
     let mod_loader = ModLoader {
       loader_type: new_mod_loader.loader_type,
       version: new_mod_loader.version.clone(),
@@ -1421,7 +1427,17 @@ pub async fn change_mod_loader(
       is_install_qf_api,
     )
     .await?;
+    if new_optifine.is_none() {
+      instance.optifine = original_optifine_config;
 
+      if instance.optifine.is_some() {
+        if let Some(patch) = original_optifine_patch.as_ref() {
+          if !version_info.patches.iter().any(|p| p.id == patch.id) {
+            version_info.patches.push(patch.clone());
+          }
+        }
+      }
+    }
     if !modloader_task_params.is_empty() {
       schedule_progressive_task_group(
         app.clone(),
@@ -1434,6 +1450,8 @@ pub async fn change_mod_loader(
       )
       .await?;
     }
+  } else {
+    instance.optifine = original_optifine_config;
   }
 
   // install new OptiFine
@@ -1462,6 +1480,16 @@ pub async fn change_mod_loader(
         true,
       )
       .await?;
+    }
+  } else {
+    instance.optifine = old_optifine;
+
+    if instance.optifine.is_some() {
+      if let Some(patch) = original_optifine_patch {
+        if !version_info.patches.iter().any(|p| p.id == patch.id) {
+          version_info.patches.push(patch);
+        }
+      }
     }
   }
 

--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -1387,7 +1387,8 @@ pub async fn change_mod_loader(
   version_info.client_version = Some(instance.version.clone());
   version_info.patches = vec![vanilla_info];
 
-  let mut task_params: Vec<PTaskParam> = Vec::new();
+  let mut modloader_task_params: Vec<PTaskParam> = Vec::new();
+  let mut optifine_task_params: Vec<PTaskParam> = Vec::new();
 
   // install new mod loader
   if let Some(new_mod_loader) = new_mod_loader {
@@ -1415,11 +1416,24 @@ pub async fn change_mod_loader(
       libraries_dir.to_path_buf(),
       mods_dir.to_path_buf(),
       &mut version_info,
-      &mut task_params,
+      &mut modloader_task_params,
       is_install_fabric_api,
       is_install_qf_api,
     )
     .await?;
+
+    if !modloader_task_params.is_empty() {
+      schedule_progressive_task_group(
+        app.clone(),
+        format!(
+          "change-mod-loader?{} {}",
+          instance.mod_loader.loader_type, instance.mod_loader.version
+        ),
+        modloader_task_params,
+        true,
+      )
+      .await?;
+    }
   }
 
   // install new OptiFine
@@ -1436,19 +1450,19 @@ pub async fn change_mod_loader(
       &instance.version,
       &optifine,
       libraries_dir.to_path_buf(),
-      &mut task_params,
+      &mut optifine_task_params,
     )
     .await?;
-  }
 
-  if !task_params.is_empty() {
-    schedule_progressive_task_group(
-      app.clone(),
-      "change-instance-setup".to_string(),
-      task_params,
-      true,
-    )
-    .await?;
+    if !optifine_task_params.is_empty() {
+      schedule_progressive_task_group(
+        app.clone(),
+        format!("change-optifine?{}", optifine.filename),
+        optifine_task_params,
+        true,
+      )
+      .await?;
+    }
   }
 
   save_json_async(&version_info, &json_path).await?;

--- a/src/components/loader-selector.tsx
+++ b/src/components/loader-selector.tsx
@@ -31,8 +31,6 @@ import {
 import { ResourceService } from "@/services/resource";
 import { ISOToDatetime } from "@/utils/datetime";
 
-export type LoaderSelectorMode = "modloader" | "optifine" | "all";
-
 export const modLoaderTypes: ModLoaderType[] = [
   ModLoaderType.Forge,
   ModLoaderType.Fabric,
@@ -49,21 +47,21 @@ export const modLoaderTypesToIcon: Record<string, string> = {
 };
 
 interface LoaderSelectorProps {
-  mode?: LoaderSelectorMode;
   selectedGameVersion: GameClientResourceInfo;
   selectedModLoader: ModLoaderResourceInfo;
   onSelectModLoader: (v: ModLoaderResourceInfo) => void;
   selectedOptiFine?: OptiFineResourceInfo | undefined;
   onSelectOptiFine?: (v: OptiFineResourceInfo | undefined) => void;
+  mode?: "all" | "optifine";
 }
 
 export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
-  mode = "all",
   selectedGameVersion,
   selectedModLoader,
   onSelectModLoader,
   selectedOptiFine,
   onSelectOptiFine,
+  mode = "all",
   ...props
 }) => {
   const { t } = useTranslation();
@@ -73,22 +71,31 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
   const [versionList, setVersionList] = useState<OptionItemProps[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [selectedType, setSelectedType] = useState<ModLoaderType | "OptiFine">(
-    mode === "optifine" ? "OptiFine" : ModLoaderType.Unknown
+    ModLoaderType.Unknown
   );
   const [selectedId, setSelectedId] = useState("");
 
   const selectableCardListRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (mode === "optifine") return;
-
-    if (
-      selectedModLoader.loaderType !== ModLoaderType.Unknown &&
-      selectedType !== selectedModLoader.loaderType
-    ) {
-      setSelectedType(selectedModLoader.loaderType);
+    if (mode === "optifine") {
+      setSelectedType("OptiFine");
+      setSelectedId(selectedOptiFine?.filename || "");
+      return;
     }
-  }, [selectedModLoader.loaderType, selectedType, mode]);
+    const externalType = selectedModLoader.loaderType;
+    if (
+      externalType !== ModLoaderType.Unknown &&
+      selectedType !== externalType
+    ) {
+      setSelectedType(externalType);
+
+      if (selectedModLoader.version) {
+        setSelectedId(selectedModLoader.version);
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, selectedModLoader.loaderType]);
 
   function isModLoaderResourceInfo(
     version: ModLoaderResourceInfo | OptiFineResourceInfo
@@ -100,10 +107,9 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
     (
       version: ModLoaderResourceInfo | OptiFineResourceInfo
     ): OptionItemProps => {
-      const title = isModLoaderResourceInfo(version)
+      let title = isModLoaderResourceInfo(version)
         ? version.version
-        : version.filename;
-
+        : version?.filename;
       return {
         title,
         description: isModLoaderResourceInfo(version) && version.description,
@@ -111,11 +117,7 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
           <HStack spacing={2.5}>
             <Radio value={title} colorScheme={primaryColor} />
             <Image
-              src={`/images/icons/${
-                isModLoaderResourceInfo(version)
-                  ? modLoaderTypesToIcon[version.loaderType]
-                  : "OptiFine.png"
-              }`}
+              src={`/images/icons/${isModLoaderResourceInfo(version) ? modLoaderTypesToIcon[version.loaderType] : "OptiFine.png"}`}
               alt={title}
               boxSize="28px"
               borderRadius="4px"
@@ -129,6 +131,7 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
             )}
           </Tag>
         ),
+        children: <></>,
         isFullClickZone: true,
         onClick: () => {
           if (isModLoaderResourceInfo(version)) {
@@ -138,7 +141,6 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
           }
           setSelectedId(title);
         },
-        children: <></>,
       };
     },
     [primaryColor, t, onSelectModLoader, onSelectOptiFine]
@@ -194,35 +196,114 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
       .finally(() => setIsLoading(false));
   }, [selectedGameVersion.id, buildOptionItems, toast]);
 
+  let selectableCardItems = modLoaderTypes.map(
+    (type): SelectableCardProps => ({
+      title: type,
+      iconSrc: `/images/icons/${modLoaderTypesToIcon[type]}`,
+      description:
+        selectedModLoader.loaderType !== ModLoaderType.Unknown
+          ? selectedModLoader.loaderType === type
+            ? selectedModLoader.version || t("LoaderSelector.noVersionSelected")
+            : t("LoaderSelector.notCompatibleWith", {
+                item: selectedModLoader.loaderType,
+              })
+          : t("LoaderSelector.noVersionSelected"),
+      displayMode: "selector",
+      isLoading,
+      isSelected: type === selectedModLoader.loaderType,
+      isChevronShown: selectedType !== type,
+      onSelect: () => {
+        setSelectedType(type);
+        if (selectedModLoader.loaderType !== type) {
+          onSelectModLoader({
+            loaderType: type,
+            version: "",
+            description: "",
+            stable: false,
+          });
+          setSelectedId("");
+        } else {
+          setSelectedId(selectedModLoader.version);
+        }
+        if (
+          type !== ModLoaderType.Forge ||
+          (selectedOptiFine && !selectedOptiFine.filename)
+        ) {
+          // When OptiFine is not compatible with the selected mod loader, or selected without a version, clear it
+          onSelectOptiFine?.(undefined);
+        }
+      },
+      onCancel: () => {
+        if (selectedType === type) {
+          if (!!selectedOptiFine) {
+            setSelectedType("OptiFine");
+            setSelectedId(selectedOptiFine!.filename);
+          } else {
+            setSelectedType(ModLoaderType.Unknown);
+            setSelectedId("");
+          }
+        }
+        onSelectModLoader(defaultModLoaderResourceInfo);
+      },
+    })
+  );
+
+  if (typeof onSelectOptiFine === "function") {
+    selectableCardItems.push({
+      title: "OptiFine",
+      iconSrc: "/images/icons/OptiFine.png",
+      description: selectedOptiFine
+        ? selectedOptiFine.type + " " + selectedOptiFine.patch
+        : selectedModLoader.loaderType === ModLoaderType.Forge ||
+            selectedModLoader.loaderType === ModLoaderType.Unknown
+          ? t("LoaderSelector.noVersionSelected")
+          : t("LoaderSelector.notCompatibleWith", {
+              item: selectedModLoader.loaderType,
+            }),
+      displayMode: "selector",
+      isLoading,
+      isSelected: !!selectedOptiFine,
+      isDisabled: !(
+        selectedModLoader.loaderType === ModLoaderType.Forge ||
+        selectedModLoader.loaderType === ModLoaderType.Unknown
+      ),
+      isChevronShown: selectedType !== "OptiFine",
+      onSelect: () => {
+        setSelectedType("OptiFine");
+        if (!selectedOptiFine) {
+          onSelectOptiFine?.({ filename: "", patch: "", type: "" });
+          setSelectedId("");
+        } else {
+          setSelectedId(selectedOptiFine.filename);
+        }
+        if (
+          selectedModLoader.loaderType !== ModLoaderType.Unknown &&
+          !selectedModLoader.version
+        ) {
+          onSelectModLoader(defaultModLoaderResourceInfo);
+        }
+      },
+      onCancel: () => {
+        const hasValidModLoader =
+          selectedModLoader.loaderType !== ModLoaderType.Unknown &&
+          !!selectedModLoader.version;
+
+        if (selectedType === "OptiFine") {
+          if (hasValidModLoader) {
+            setSelectedType(selectedModLoader.loaderType);
+            setSelectedId(selectedModLoader.version);
+          } else {
+            setSelectedType(ModLoaderType.Unknown);
+            setSelectedId("");
+            onSelectModLoader(defaultModLoaderResourceInfo);
+          }
+        }
+        onSelectOptiFine?.(undefined);
+      },
+    });
+  }
+
   useEffect(() => {
-    if (mode === "optifine") {
-      setSelectedId(selectedOptiFine?.filename || "");
-      return;
-    }
-
-    if (selectedOptiFine) {
-      setSelectedId(selectedOptiFine.filename);
-    } else {
-      setSelectedId(selectedModLoader.version);
-    }
-  }, [selectedModLoader, selectedOptiFine, mode]);
-
-  useEffect(() => {
-    if (mode === "optifine") {
-      setSelectedType("OptiFine");
-    } else if (mode === "modloader") {
-      if (selectedType === "OptiFine") {
-        setSelectedType(ModLoaderType.Unknown);
-      }
-    }
-  }, [selectedType, mode]);
-
-  useEffect(() => {
-    if (mode === "optifine") {
-      handleFetchOptiFineVersionList();
-      return;
-    }
-
     if (selectedType === "OptiFine") {
       handleFetchOptiFineVersionList();
     } else if (selectedType !== ModLoaderType.Unknown) {
@@ -231,71 +312,9 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
       setVersionList([]);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedType, mode]);
+  }, [selectedType]);
 
-  let selectableCardItems: SelectableCardProps[] = [];
-
-  if (mode !== "optifine") {
-    selectableCardItems.push(
-      ...modLoaderTypes.map((type) => ({
-        title: type,
-        iconSrc: `/images/icons/${modLoaderTypesToIcon[type]}`,
-        description:
-          selectedModLoader.loaderType === type
-            ? selectedModLoader.version || t("LoaderSelector.noVersionSelected")
-            : t("LoaderSelector.noVersionSelected"),
-        displayMode: "selector" as const,
-        isLoading,
-        isSelected: type === selectedModLoader.loaderType,
-        isChevronShown: selectedType !== type,
-        onSelect: () => {
-          setSelectedType(type);
-          onSelectModLoader({
-            loaderType: type,
-            version: "",
-            description: "",
-            stable: false,
-          });
-          setSelectedId("");
-          onSelectOptiFine?.(undefined);
-        },
-        onCancel: () => {
-          setSelectedType(ModLoaderType.Unknown);
-          setSelectedId("");
-          onSelectModLoader(defaultModLoaderResourceInfo);
-        },
-      }))
-    );
-  }
-
-  if (mode !== "modloader" && onSelectOptiFine) {
-    selectableCardItems.push({
-      title: "OptiFine",
-      iconSrc: "/images/icons/OptiFine.png",
-      description: selectedOptiFine
-        ? selectedOptiFine.type + " " + selectedOptiFine.patch
-        : t("LoaderSelector.noVersionSelected"),
-      displayMode: "selector",
-      isLoading,
-      isSelected: !!selectedOptiFine,
-      isChevronShown: selectedType !== "OptiFine",
-      onSelect: () => {
-        setSelectedType("OptiFine");
-        onSelectOptiFine({
-          filename: "",
-          patch: "",
-          type: "",
-        });
-        setSelectedId("");
-      },
-      onCancel: () => {
-        setSelectedType(ModLoaderType.Unknown);
-        setSelectedId("");
-        onSelectOptiFine(undefined);
-      },
-    });
-  }
-
+  // Scroll selected item into view when version list changes or selected item changes
   useEffect(() => {
     const list = selectableCardListRef.current;
     if (!list) return;
@@ -307,11 +326,12 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
     const frame = requestAnimationFrame(() => {
       selectedCard.scrollIntoView({
         block: "nearest",
+        inline: "nearest",
       });
     });
 
     return () => cancelAnimationFrame(frame);
-  }, [selectedType, selectedOptiFine, selectedModLoader]);
+  }, [selectedModLoader.loaderType, selectedOptiFine?.filename, selectedType]);
 
   return (
     <HStack {...props} w="100%" h="100%" spacing={4} overflow="hidden">

--- a/src/components/loader-selector.tsx
+++ b/src/components/loader-selector.tsx
@@ -230,12 +230,8 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
     } else {
       setVersionList([]);
     }
-  }, [
-    selectedType,
-    mode,
-    handleFetchModLoaderVersionList,
-    handleFetchOptiFineVersionList,
-  ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedType, mode]);
 
   let selectableCardItems: SelectableCardProps[] = [];
 

--- a/src/components/loader-selector.tsx
+++ b/src/components/loader-selector.tsx
@@ -52,6 +52,7 @@ interface LoaderSelectorProps {
   onSelectModLoader: (v: ModLoaderResourceInfo) => void;
   selectedOptiFine?: OptiFineResourceInfo | undefined;
   onSelectOptiFine?: (v: OptiFineResourceInfo | undefined) => void;
+  onlyOptifine?: boolean;
 }
 
 export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
@@ -60,6 +61,7 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
   onSelectModLoader,
   selectedOptiFine,
   onSelectOptiFine,
+  onlyOptifine,
   ...props
 }) => {
   const { t } = useTranslation();
@@ -69,23 +71,25 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
   const [versionList, setVersionList] = useState<OptionItemProps[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [selectedType, setSelectedType] = useState<ModLoaderType | "OptiFine">(
-    ModLoaderType.Unknown
+    onlyOptifine ? "OptiFine" : ModLoaderType.Unknown
   );
   const [selectedId, setSelectedId] = useState("");
 
   const selectableCardListRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    if (onlyOptifine) {
+      setSelectedId(selectedOptiFine?.filename || "");
+      return;
+    }
+
     if (selectedOptiFine) {
-      setSelectedType("OptiFine");
-      setSelectedId(selectedOptiFine ? selectedOptiFine.filename : "");
+      setSelectedId(selectedOptiFine.filename);
     } else {
-      setSelectedType(selectedModLoader.loaderType);
       setSelectedId(selectedModLoader.version);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedModLoader.loaderType]);
-
+  }, [selectedModLoader.loaderType, selectedOptiFine, onlyOptifine]);
   function isModLoaderResourceInfo(
     version: ModLoaderResourceInfo | OptiFineResourceInfo
   ): version is ModLoaderResourceInfo {
@@ -285,17 +289,26 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
 
   useEffect(() => {
     if (selectedType === "OptiFine") {
-      handleFetchOptiFineVersionList();
+      if (versionList.length === 0) {
+        handleFetchOptiFineVersionList();
+      }
     } else if (selectedType !== ModLoaderType.Unknown) {
       handleFetchModLoaderVersionList(selectedType);
     } else {
       setVersionList([]);
     }
   }, [
+    selectedType,
+    versionList.length,
     handleFetchModLoaderVersionList,
     handleFetchOptiFineVersionList,
-    selectedType,
   ]);
+
+  useEffect(() => {
+    if (onlyOptifine && selectedType !== "OptiFine") {
+      setSelectedType("OptiFine");
+    }
+  }, [onlyOptifine, selectedType]);
 
   // Scroll selected item into view when version list changes or selected item changes
   useEffect(() => {
@@ -326,15 +339,16 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
         flexShrink={0}
         ref={selectableCardListRef}
       >
-        {selectableCardItems.map((item, index) => (
-          <SelectableCard
-            key={index}
-            {...item}
-            minW="3xs"
-            w="100%"
-            data-loader-selected={item.isSelected ? "true" : undefined}
-          />
-        ))}
+        {!onlyOptifine &&
+          selectableCardItems.map((item, index) => (
+            <SelectableCard
+              key={index}
+              {...item}
+              minW="3xs"
+              w="100%"
+              data-loader-selected={item.isSelected ? "true" : undefined}
+            />
+          ))}
       </VStack>
       <Section overflow="auto" flexGrow={1} w="100%" h="100%">
         {isLoading ? (

--- a/src/components/loader-selector.tsx
+++ b/src/components/loader-selector.tsx
@@ -31,6 +31,8 @@ import {
 import { ResourceService } from "@/services/resource";
 import { ISOToDatetime } from "@/utils/datetime";
 
+export type LoaderSelectorMode = "modloader" | "optifine" | "all";
+
 export const modLoaderTypes: ModLoaderType[] = [
   ModLoaderType.Forge,
   ModLoaderType.Fabric,
@@ -47,21 +49,21 @@ export const modLoaderTypesToIcon: Record<string, string> = {
 };
 
 interface LoaderSelectorProps {
+  mode?: LoaderSelectorMode;
   selectedGameVersion: GameClientResourceInfo;
   selectedModLoader: ModLoaderResourceInfo;
   onSelectModLoader: (v: ModLoaderResourceInfo) => void;
   selectedOptiFine?: OptiFineResourceInfo | undefined;
   onSelectOptiFine?: (v: OptiFineResourceInfo | undefined) => void;
-  onlyOptifine?: boolean;
 }
 
 export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
+  mode = "all",
   selectedGameVersion,
   selectedModLoader,
   onSelectModLoader,
   selectedOptiFine,
   onSelectOptiFine,
-  onlyOptifine,
   ...props
 }) => {
   const { t } = useTranslation();
@@ -71,25 +73,23 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
   const [versionList, setVersionList] = useState<OptionItemProps[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [selectedType, setSelectedType] = useState<ModLoaderType | "OptiFine">(
-    onlyOptifine ? "OptiFine" : ModLoaderType.Unknown
+    mode === "optifine" ? "OptiFine" : ModLoaderType.Unknown
   );
   const [selectedId, setSelectedId] = useState("");
 
   const selectableCardListRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (onlyOptifine) {
-      setSelectedId(selectedOptiFine?.filename || "");
-      return;
-    }
+    if (mode === "optifine") return;
 
-    if (selectedOptiFine) {
-      setSelectedId(selectedOptiFine.filename);
-    } else {
-      setSelectedId(selectedModLoader.version);
+    if (
+      selectedModLoader.loaderType !== ModLoaderType.Unknown &&
+      selectedType !== selectedModLoader.loaderType
+    ) {
+      setSelectedType(selectedModLoader.loaderType);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedModLoader.loaderType, selectedOptiFine, onlyOptifine]);
+  }, [selectedModLoader.loaderType, selectedType, mode]);
+
   function isModLoaderResourceInfo(
     version: ModLoaderResourceInfo | OptiFineResourceInfo
   ): version is ModLoaderResourceInfo {
@@ -100,9 +100,10 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
     (
       version: ModLoaderResourceInfo | OptiFineResourceInfo
     ): OptionItemProps => {
-      let title = isModLoaderResourceInfo(version)
+      const title = isModLoaderResourceInfo(version)
         ? version.version
-        : version?.filename;
+        : version.filename;
+
       return {
         title,
         description: isModLoaderResourceInfo(version) && version.description,
@@ -110,7 +111,11 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
           <HStack spacing={2.5}>
             <Radio value={title} colorScheme={primaryColor} />
             <Image
-              src={`/images/icons/${isModLoaderResourceInfo(version) ? modLoaderTypesToIcon[version.loaderType] : "OptiFine.png"}`}
+              src={`/images/icons/${
+                isModLoaderResourceInfo(version)
+                  ? modLoaderTypesToIcon[version.loaderType]
+                  : "OptiFine.png"
+              }`}
               alt={title}
               boxSize="28px"
               borderRadius="4px"
@@ -124,7 +129,6 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
             )}
           </Tag>
         ),
-        children: <></>,
         isFullClickZone: true,
         onClick: () => {
           if (isModLoaderResourceInfo(version)) {
@@ -134,6 +138,7 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
           }
           setSelectedId(title);
         },
+        children: <></>,
       };
     },
     [primaryColor, t, onSelectModLoader, onSelectOptiFine]
@@ -189,109 +194,37 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
       .finally(() => setIsLoading(false));
   }, [selectedGameVersion.id, buildOptionItems, toast]);
 
-  let selectableCardItems = modLoaderTypes.map(
-    (type): SelectableCardProps => ({
-      title: type,
-      iconSrc: `/images/icons/${modLoaderTypesToIcon[type]}`,
-      description:
-        selectedModLoader.loaderType !== ModLoaderType.Unknown
-          ? selectedModLoader.loaderType === type
-            ? selectedModLoader.version || t("LoaderSelector.noVersionSelected")
-            : t("LoaderSelector.notCompatibleWith", {
-                item: selectedModLoader.loaderType,
-              })
-          : t("LoaderSelector.noVersionSelected"),
-      displayMode: "selector",
-      isLoading,
-      isSelected: type === selectedModLoader.loaderType,
-      isChevronShown: selectedType !== type,
-      onSelect: () => {
-        setSelectedType(type);
-        if (selectedModLoader.loaderType !== type) {
-          onSelectModLoader({
-            loaderType: type,
-            version: "",
-            description: "",
-            stable: false,
-          });
-          setSelectedId("");
-        } else {
-          setSelectedId(selectedModLoader.version);
-        }
-        if (
-          type !== ModLoaderType.Forge ||
-          (selectedOptiFine && !selectedOptiFine.filename)
-        ) {
-          // When OptiFine is not compatible with the selected mod loader, or selected without a version, clear it
-          onSelectOptiFine?.(undefined);
-        }
-      },
-      onCancel: () => {
-        if (selectedType === type) {
-          setSelectedType(ModLoaderType.Unknown);
-          setSelectedId("");
-        }
-        onSelectModLoader(defaultModLoaderResourceInfo);
-      },
-    })
-  );
+  useEffect(() => {
+    if (mode === "optifine") {
+      setSelectedId(selectedOptiFine?.filename || "");
+      return;
+    }
 
-  if (typeof onSelectOptiFine === "function") {
-    selectableCardItems.push({
-      title: "OptiFine",
-      iconSrc: "/images/icons/OptiFine.png",
-      description: selectedOptiFine
-        ? selectedOptiFine.type + " " + selectedOptiFine.patch
-        : selectedModLoader.loaderType === ModLoaderType.Forge ||
-            selectedModLoader.loaderType === ModLoaderType.Unknown
-          ? t("LoaderSelector.noVersionSelected")
-          : t("LoaderSelector.notCompatibleWith", {
-              item: selectedModLoader.loaderType,
-            }),
-      displayMode: "selector",
-      isLoading,
-      isSelected: !!selectedOptiFine,
-      isDisabled: !(
-        selectedModLoader.loaderType === ModLoaderType.Forge ||
-        selectedModLoader.loaderType === ModLoaderType.Unknown
-      ),
-      isChevronShown: selectedType !== "OptiFine",
-      onSelect: () => {
-        setSelectedType("OptiFine");
-        if (!selectedOptiFine) {
-          onSelectOptiFine?.({
-            filename: "",
-            patch: "",
-            type: "",
-          });
-          setSelectedId("");
-        } else {
-          setSelectedId(selectedOptiFine.filename);
-        }
-
-        if (
-          selectedModLoader.loaderType !== ModLoaderType.Unknown &&
-          !selectedModLoader.version
-        ) {
-          // When some mod loader was selected without a version, clear it
-          onSelectModLoader(defaultModLoaderResourceInfo);
-        }
-      },
-      onCancel: () => {
-        if (selectedType === "OptiFine") {
-          setSelectedType(ModLoaderType.Unknown);
-          setSelectedId("");
-        }
-        onSelectOptiFine?.(undefined);
-      },
-    });
-  }
+    if (selectedOptiFine) {
+      setSelectedId(selectedOptiFine.filename);
+    } else {
+      setSelectedId(selectedModLoader.version);
+    }
+  }, [selectedModLoader, selectedOptiFine, mode]);
 
   useEffect(() => {
-    if (selectedType === "OptiFine") {
-      if (versionList.length === 0) {
-        handleFetchOptiFineVersionList();
+    if (mode === "optifine") {
+      setSelectedType("OptiFine");
+    } else if (mode === "modloader") {
+      if (selectedType === "OptiFine") {
+        setSelectedType(ModLoaderType.Unknown);
       }
+    }
+  }, [selectedType, mode]);
+
+  useEffect(() => {
+    if (mode === "optifine") {
+      handleFetchOptiFineVersionList();
+      return;
+    }
+
+    if (selectedType === "OptiFine") {
+      handleFetchOptiFineVersionList();
     } else if (selectedType !== ModLoaderType.Unknown) {
       handleFetchModLoaderVersionList(selectedType);
     } else {
@@ -299,18 +232,74 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
     }
   }, [
     selectedType,
-    versionList.length,
+    mode,
     handleFetchModLoaderVersionList,
     handleFetchOptiFineVersionList,
   ]);
 
-  useEffect(() => {
-    if (onlyOptifine && selectedType !== "OptiFine") {
-      setSelectedType("OptiFine");
-    }
-  }, [onlyOptifine, selectedType]);
+  let selectableCardItems: SelectableCardProps[] = [];
 
-  // Scroll selected item into view when version list changes or selected item changes
+  if (mode !== "optifine") {
+    selectableCardItems.push(
+      ...modLoaderTypes.map((type) => ({
+        title: type,
+        iconSrc: `/images/icons/${modLoaderTypesToIcon[type]}`,
+        description:
+          selectedModLoader.loaderType === type
+            ? selectedModLoader.version || t("LoaderSelector.noVersionSelected")
+            : t("LoaderSelector.noVersionSelected"),
+        displayMode: "selector" as const,
+        isLoading,
+        isSelected: type === selectedModLoader.loaderType,
+        isChevronShown: selectedType !== type,
+        onSelect: () => {
+          setSelectedType(type);
+          onSelectModLoader({
+            loaderType: type,
+            version: "",
+            description: "",
+            stable: false,
+          });
+          setSelectedId("");
+          onSelectOptiFine?.(undefined);
+        },
+        onCancel: () => {
+          setSelectedType(ModLoaderType.Unknown);
+          setSelectedId("");
+          onSelectModLoader(defaultModLoaderResourceInfo);
+        },
+      }))
+    );
+  }
+
+  if (mode !== "modloader" && onSelectOptiFine) {
+    selectableCardItems.push({
+      title: "OptiFine",
+      iconSrc: "/images/icons/OptiFine.png",
+      description: selectedOptiFine
+        ? selectedOptiFine.type + " " + selectedOptiFine.patch
+        : t("LoaderSelector.noVersionSelected"),
+      displayMode: "selector",
+      isLoading,
+      isSelected: !!selectedOptiFine,
+      isChevronShown: selectedType !== "OptiFine",
+      onSelect: () => {
+        setSelectedType("OptiFine");
+        onSelectOptiFine({
+          filename: "",
+          patch: "",
+          type: "",
+        });
+        setSelectedId("");
+      },
+      onCancel: () => {
+        setSelectedType(ModLoaderType.Unknown);
+        setSelectedId("");
+        onSelectOptiFine(undefined);
+      },
+    });
+  }
+
   useEffect(() => {
     const list = selectableCardListRef.current;
     if (!list) return;
@@ -322,25 +311,24 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
     const frame = requestAnimationFrame(() => {
       selectedCard.scrollIntoView({
         block: "nearest",
-        inline: "nearest",
       });
     });
 
     return () => cancelAnimationFrame(frame);
-  }, [selectedModLoader.loaderType, selectedOptiFine?.filename, selectedType]);
+  }, [selectedType, selectedOptiFine, selectedModLoader]);
 
   return (
     <HStack {...props} w="100%" h="100%" spacing={4} overflow="hidden">
-      <VStack
-        spacing={3.5}
-        h="100%"
-        overflowY="auto"
-        overflowX="hidden"
-        flexShrink={0}
-        ref={selectableCardListRef}
-      >
-        {!onlyOptifine &&
-          selectableCardItems.map((item, index) => (
+      {mode !== "optifine" && (
+        <VStack
+          spacing={3.5}
+          h="100%"
+          overflowY="auto"
+          overflowX="hidden"
+          flexShrink={0}
+          ref={selectableCardListRef}
+        >
+          {selectableCardItems.map((item, index) => (
             <SelectableCard
               key={index}
               {...item}
@@ -349,7 +337,8 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
               data-loader-selected={item.isSelected ? "true" : undefined}
             />
           ))}
-      </VStack>
+        </VStack>
+      )}
       <Section overflow="auto" flexGrow={1} w="100%" h="100%">
         {isLoading ? (
           <Center h="100%">

--- a/src/components/modals/change-loader-modal.tsx
+++ b/src/components/modals/change-loader-modal.tsx
@@ -36,12 +36,12 @@ import { parseModLoaderVersion } from "@/utils/instance";
 
 type Mode = "modloader" | "optifine";
 
-interface ChangeModLoaderModalProps extends Omit<ModalProps, "children"> {
+interface ChangeLoaderModalProps extends Omit<ModalProps, "children"> {
   defaultSelectedType?: ModLoaderType;
   mode?: Mode;
 }
 
-export const ChangeModLoaderModal: React.FC<ChangeModLoaderModalProps> = ({
+export const ChangeLoaderModal: React.FC<ChangeLoaderModalProps> = ({
   defaultSelectedType,
   mode = "modloader",
   ...modalProps
@@ -156,7 +156,15 @@ export const ChangeModLoaderModal: React.FC<ChangeModLoaderModalProps> = ({
       <ModalContent h="100%">
         <ModalHeader>
           {t(
-            `ChangeModLoaderModal.header.title.${currentModLoader.loaderType === "Unknown" ? "install" : "change"}`
+            `ChangeLoaderModal.header.${mode}.title.${
+              mode === "modloader"
+                ? currentModLoader.loaderType === "Unknown"
+                  ? "install"
+                  : "change"
+                : !summary?.optifine
+                  ? "install"
+                  : "change"
+            }`
           )}
         </ModalHeader>
         <ModalCloseButton />
@@ -194,7 +202,7 @@ export const ChangeModLoaderModal: React.FC<ChangeModLoaderModalProps> = ({
                   prefixElement={<Skeleton boxSize="36px" borderRadius="md" />}
                   title={
                     <Text fontSize="sm" fontWeight="medium" color="gray.500">
-                      {t("ChangeModLoaderModal.notSelectedLoader")}
+                      {t("ChangeLoaderModal.notSelectedLoader")}
                     </Text>
                   }
                 />
@@ -267,7 +275,7 @@ export const ChangeModLoaderModal: React.FC<ChangeModLoaderModalProps> = ({
                     }
                     title={
                       <Text fontSize="sm" fontWeight="medium" color="gray.500">
-                        {t("ChangeModLoaderModal.noOptifineInstalled")}
+                        {t("ChangeLoaderModal.noOptifineInstalled")}
                       </Text>
                     }
                   />
@@ -286,7 +294,7 @@ export const ChangeModLoaderModal: React.FC<ChangeModLoaderModalProps> = ({
                     }
                     title={
                       <Text fontSize="sm" fontWeight="medium" color="gray.500">
-                        {t("ChangeModLoaderModal.notSelectedOptifine")}
+                        {t("ChangeLoaderModal.notSelectedOptifine")}
                       </Text>
                     }
                   />
@@ -343,7 +351,7 @@ export const ChangeModLoaderModal: React.FC<ChangeModLoaderModalProps> = ({
                 onChange={(e) => setIsInstallFabricApi(e.target.checked)}
               >
                 <Text fontSize="sm">
-                  {t("ChangeModLoaderModal.footer.installFabricApi")}
+                  {t("ChangeLoaderModal.footer.installFabricApi")}
                 </Text>
               </Checkbox>
             )}
@@ -357,7 +365,7 @@ export const ChangeModLoaderModal: React.FC<ChangeModLoaderModalProps> = ({
                 onChange={(e) => setIsInstallQfApi(e.target.checked)}
               >
                 <Text fontSize="sm">
-                  {t("ChangeModLoaderModal.footer.installQFAPI")}
+                  {t("ChangeLoaderModal.footer.installQFAPI")}
                 </Text>
               </Checkbox>
             )}
@@ -374,7 +382,7 @@ export const ChangeModLoaderModal: React.FC<ChangeModLoaderModalProps> = ({
               isDisabled={isDisabled}
             >
               {isSameAsCurrent
-                ? t("ChangeModLoaderModal.footer.reinstall")
+                ? t("ChangeLoaderModal.footer.reinstall")
                 : t("General.confirm")}
             </Button>
           </HStack>

--- a/src/components/modals/change-loader-modal.tsx
+++ b/src/components/modals/change-loader-modal.tsx
@@ -231,19 +231,27 @@ export const ChangeLoaderModal: React.FC<ChangeLoaderModalProps> = ({
             </Flex>
           </Flex>
         )}
-        <ModalBody flexGrow="1" flexDir="column" h="100%" overflow="auto">
+        <ModalBody
+          flex="1"
+          display="flex"
+          flexDirection="column"
+          overflow="hidden"
+          minH={0}
+        >
           {mode === "modloader" && summary?.version && (
-            <LoaderSelector
-              selectedGameVersion={{
-                id: summary.version,
-                gameType: "release",
-                releaseTime: new Date().toISOString(),
-                url: "",
-              }}
-              selectedModLoader={selectedModLoader}
-              onSelectModLoader={setSelectedModLoader}
-              mode="modloader"
-            />
+            <Box flex="1" minH={0} display="flex">
+              <LoaderSelector
+                selectedGameVersion={{
+                  id: summary.version,
+                  gameType: "release",
+                  releaseTime: new Date().toISOString(),
+                  url: "",
+                }}
+                selectedModLoader={selectedModLoader}
+                onSelectModLoader={setSelectedModLoader}
+                mode="modloader"
+              />
+            </Box>
           )}
           {mode === "optifine" && summary?.version && summary?.optifine && (
             <Flex position="relative" align="center" justify="center" py={2}>

--- a/src/components/modals/change-loader-modal.tsx
+++ b/src/components/modals/change-loader-modal.tsx
@@ -256,39 +256,26 @@ export const ChangeLoaderModal: React.FC<ChangeLoaderModalProps> = ({
           {mode === "optifine" && summary?.version && summary?.optifine && (
             <Flex position="relative" align="center" justify="center" py={2}>
               <Flex flex="1" justify="flex-end" pr={8}>
-                {summary?.optifine ? (
-                  <OptionItem
-                    prefixElement={
-                      <Image
-                        src={`/images/icons/OptiFine.png`}
-                        alt="OptiFine"
-                        boxSize="36px"
-                        borderRadius="md"
-                      />
-                    }
-                    title={
-                      <Text fontSize="sm" fontWeight="medium">
-                        OptiFine
-                      </Text>
-                    }
-                    description={
-                      <Text fontSize="xs" color="gray.500">
-                        {summary.optifine.version}
-                      </Text>
-                    }
-                  />
-                ) : (
-                  <OptionItem
-                    prefixElement={
-                      <Skeleton boxSize="36px" borderRadius="md" />
-                    }
-                    title={
-                      <Text fontSize="sm" fontWeight="medium" color="gray.500">
-                        {t("ChangeLoaderModal.noOptifineInstalled")}
-                      </Text>
-                    }
-                  />
-                )}
+                <OptionItem
+                  prefixElement={
+                    <Image
+                      src={`/images/icons/OptiFine.png`}
+                      alt="OptiFine"
+                      boxSize="36px"
+                      borderRadius="md"
+                    />
+                  }
+                  title={
+                    <Text fontSize="sm" fontWeight="medium">
+                      OptiFine
+                    </Text>
+                  }
+                  description={
+                    <Text fontSize="xs" color="gray.500">
+                      {summary.optifine.version}
+                    </Text>
+                  }
+                />
               </Flex>
 
               <Box position="absolute" left="50%" transform="translateX(-50%)">

--- a/src/components/modals/change-loader-modal.tsx
+++ b/src/components/modals/change-loader-modal.tsx
@@ -242,6 +242,7 @@ export const ChangeLoaderModal: React.FC<ChangeLoaderModalProps> = ({
               }}
               selectedModLoader={selectedModLoader}
               onSelectModLoader={setSelectedModLoader}
+              mode="modloader"
             />
           )}
           {mode === "optifine" && summary?.version && summary?.optifine && (
@@ -335,7 +336,7 @@ export const ChangeLoaderModal: React.FC<ChangeLoaderModalProps> = ({
               onSelectModLoader={() => {}}
               selectedOptiFine={selectedOptifine || undefined}
               onSelectOptiFine={(opt) => setSelectedOptifine(opt)}
-              onlyOptifine
+              mode="optifine"
             />
           )}
         </ModalBody>

--- a/src/components/modals/change-loader-modal.tsx
+++ b/src/components/modals/change-loader-modal.tsx
@@ -249,7 +249,6 @@ export const ChangeLoaderModal: React.FC<ChangeLoaderModalProps> = ({
                 }}
                 selectedModLoader={selectedModLoader}
                 onSelectModLoader={setSelectedModLoader}
-                mode="modloader"
               />
             </Box>
           )}

--- a/src/components/modals/change-mod-loader-modal.tsx
+++ b/src/components/modals/change-mod-loader-modal.tsx
@@ -28,17 +28,22 @@ import { useToast } from "@/contexts/toast";
 import { ModLoaderType } from "@/enums/instance";
 import {
   ModLoaderResourceInfo,
+  OptiFineResourceInfo,
   defaultModLoaderResourceInfo,
 } from "@/models/resource";
 import { InstanceService } from "@/services/instance";
 import { parseModLoaderVersion } from "@/utils/instance";
 
+type Mode = "modloader" | "optifine";
+
 interface ChangeModLoaderModalProps extends Omit<ModalProps, "children"> {
   defaultSelectedType?: ModLoaderType;
+  mode?: Mode;
 }
 
 export const ChangeModLoaderModal: React.FC<ChangeModLoaderModalProps> = ({
   defaultSelectedType,
+  mode = "modloader",
   ...modalProps
 }) => {
   const { t } = useTranslation();
@@ -50,22 +55,35 @@ export const ChangeModLoaderModal: React.FC<ChangeModLoaderModalProps> = ({
 
   const [selectedModLoader, setSelectedModLoader] =
     useState<ModLoaderResourceInfo>(defaultModLoaderResourceInfo);
+  const [selectedOptifine, setSelectedOptifine] = useState<
+    OptiFineResourceInfo | undefined
+  >(undefined);
   const [isLoading, setIsLoading] = useState(false);
   const [isInstallFabricApi, setIsInstallFabricApi] = useState(true);
   const [isInstallQfApi, setIsInstallQfApi] = useState(true);
 
   useEffect(() => {
-    if (defaultSelectedType && defaultSelectedType !== ModLoaderType.Unknown) {
-      setSelectedModLoader({
-        ...defaultModLoaderResourceInfo,
-        loaderType: defaultSelectedType,
-      });
-    } else {
-      setSelectedModLoader(defaultModLoaderResourceInfo);
+    if (mode === "modloader") {
+      if (
+        defaultSelectedType &&
+        defaultSelectedType !== ModLoaderType.Unknown
+      ) {
+        setSelectedModLoader({
+          ...defaultModLoaderResourceInfo,
+          loaderType: defaultSelectedType,
+        });
+      } else {
+        setSelectedModLoader(defaultModLoaderResourceInfo);
+      }
     }
+
+    if (mode === "optifine") {
+      setSelectedOptifine(undefined);
+    }
+
     setIsInstallFabricApi(true);
     setIsInstallQfApi(true);
-  }, [modalProps.isOpen, summary?.version, defaultSelectedType]);
+  }, [modalProps.isOpen, summary?.version, defaultSelectedType, mode]);
 
   const currentModLoader: ModLoaderResourceInfo = useMemo(() => {
     if (!summary?.modLoader)
@@ -88,7 +106,8 @@ export const ChangeModLoaderModal: React.FC<ChangeModLoaderModalProps> = ({
     try {
       const res = await InstanceService.changeModLoader(
         summary.id,
-        selectedModLoader,
+        mode === "modloader" ? selectedModLoader : null,
+        mode === "optifine" ? selectedOptifine : null,
         isInstallFabricApi,
         isInstallQfApi
       );
@@ -113,16 +132,23 @@ export const ChangeModLoaderModal: React.FC<ChangeModLoaderModalProps> = ({
     selectedModLoader.loaderType === ModLoaderType.Unknown;
 
   const isSameAsCurrent =
-    selectedModLoader.loaderType === currentModLoader.loaderType &&
-    parseModLoaderVersion(selectedModLoader.version) ===
-      parseModLoaderVersion(currentModLoader.version);
+    mode === "modloader"
+      ? selectedModLoader.loaderType === currentModLoader.loaderType &&
+        parseModLoaderVersion(selectedModLoader.version) ===
+          parseModLoaderVersion(currentModLoader.version)
+      : summary?.optifine &&
+        selectedOptifine &&
+        summary.optifine.version ===
+          `${selectedOptifine.type}_${selectedOptifine.patch}`;
 
+  const isDisabled = mode === "modloader" ? isUnselected : !selectedOptifine;
   return (
     <Modal
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
       onCloseComplete={() => {
         setSelectedModLoader(defaultModLoaderResourceInfo);
+        setSelectedOptifine(undefined);
       }}
       {...modalProps}
     >
@@ -134,7 +160,8 @@ export const ChangeModLoaderModal: React.FC<ChangeModLoaderModalProps> = ({
           )}
         </ModalHeader>
         <ModalCloseButton />
-        {currentModLoader.loaderType !== "Unknown" && (
+
+        {mode === "modloader" && currentModLoader.loaderType !== "Unknown" && (
           <Flex position="relative" align="center" justify="center" py={2}>
             <Flex flex="1" justify="flex-end" pr={8}>
               <OptionItem
@@ -197,7 +224,7 @@ export const ChangeModLoaderModal: React.FC<ChangeModLoaderModalProps> = ({
           </Flex>
         )}
         <ModalBody flexGrow="1" flexDir="column" h="100%" overflow="auto">
-          {summary?.version && (
+          {mode === "modloader" && summary?.version && (
             <LoaderSelector
               selectedGameVersion={{
                 id: summary.version,
@@ -209,41 +236,142 @@ export const ChangeModLoaderModal: React.FC<ChangeModLoaderModalProps> = ({
               onSelectModLoader={setSelectedModLoader}
             />
           )}
+          {mode === "optifine" && summary?.version && summary?.optifine && (
+            <Flex position="relative" align="center" justify="center" py={2}>
+              <Flex flex="1" justify="flex-end" pr={8}>
+                {summary?.optifine ? (
+                  <OptionItem
+                    prefixElement={
+                      <Image
+                        src={`/images/icons/OptiFine.png`}
+                        alt="OptiFine"
+                        boxSize="36px"
+                        borderRadius="md"
+                      />
+                    }
+                    title={
+                      <Text fontSize="sm" fontWeight="medium">
+                        OptiFine
+                      </Text>
+                    }
+                    description={
+                      <Text fontSize="xs" color="gray.500">
+                        {summary.optifine.version}
+                      </Text>
+                    }
+                  />
+                ) : (
+                  <OptionItem
+                    prefixElement={
+                      <Skeleton boxSize="36px" borderRadius="md" />
+                    }
+                    title={
+                      <Text fontSize="sm" fontWeight="medium" color="gray.500">
+                        {t("ChangeModLoaderModal.noOptifineInstalled")}
+                      </Text>
+                    }
+                  />
+                )}
+              </Flex>
+
+              <Box position="absolute" left="50%" transform="translateX(-50%)">
+                <LuArrowRight size={18} />
+              </Box>
+
+              <Flex flex="1" justify="flex-start" pl={8}>
+                {!selectedOptifine || !selectedOptifine.filename ? (
+                  <OptionItem
+                    prefixElement={
+                      <Skeleton boxSize="36px" borderRadius="md" />
+                    }
+                    title={
+                      <Text fontSize="sm" fontWeight="medium" color="gray.500">
+                        {t("ChangeModLoaderModal.notSelectedOptifine")}
+                      </Text>
+                    }
+                  />
+                ) : (
+                  <OptionItem
+                    prefixElement={
+                      <Image
+                        src={`/images/icons/OptiFine.png`}
+                        alt="OptiFine"
+                        boxSize="36px"
+                        borderRadius="md"
+                      />
+                    }
+                    title={
+                      <Text fontSize="sm" fontWeight="medium">
+                        OptiFine
+                      </Text>
+                    }
+                    description={
+                      <Text fontSize="xs" color="gray.500">
+                        {selectedOptifine.type + "_" + selectedOptifine.patch}
+                      </Text>
+                    }
+                  />
+                )}
+              </Flex>
+            </Flex>
+          )}
+          {mode === "optifine" && summary?.version && (
+            <LoaderSelector
+              selectedGameVersion={{
+                id: summary.version,
+                gameType: "release",
+                releaseTime: new Date().toISOString(),
+                url: "",
+              }}
+              selectedModLoader={defaultModLoaderResourceInfo}
+              onSelectModLoader={() => {}}
+              selectedOptiFine={selectedOptifine || undefined}
+              onSelectOptiFine={(opt) => setSelectedOptifine(opt)}
+              onlyOptifine
+            />
+          )}
         </ModalBody>
         <ModalFooter>
-          {selectedModLoader.loaderType === ModLoaderType.Fabric && (
-            <Checkbox
-              colorScheme={primaryColor}
-              isChecked={selectedModLoader.version !== "" && isInstallFabricApi}
-              disabled={!selectedModLoader.version}
-              onChange={(e) => setIsInstallFabricApi(e.target.checked)}
-            >
-              <Text fontSize="sm">
-                {t("ChangeModLoaderModal.footer.installFabricApi")}
-              </Text>
-            </Checkbox>
-          )}
-          {selectedModLoader.loaderType === ModLoaderType.Quilt && (
-            <Checkbox
-              colorScheme={primaryColor}
-              isChecked={selectedModLoader.version !== "" && isInstallQfApi}
-              disabled={!selectedModLoader.version}
-              onChange={(e) => setIsInstallQfApi(e.target.checked)}
-            >
-              <Text fontSize="sm">
-                {t("ChangeModLoaderModal.footer.installQFAPI")}
-              </Text>
-            </Checkbox>
-          )}
+          {mode === "modloader" &&
+            selectedModLoader.loaderType === ModLoaderType.Fabric && (
+              <Checkbox
+                colorScheme={primaryColor}
+                isChecked={
+                  selectedModLoader.version !== "" && isInstallFabricApi
+                }
+                disabled={!selectedModLoader.version}
+                onChange={(e) => setIsInstallFabricApi(e.target.checked)}
+              >
+                <Text fontSize="sm">
+                  {t("ChangeModLoaderModal.footer.installFabricApi")}
+                </Text>
+              </Checkbox>
+            )}
+
+          {mode === "modloader" &&
+            selectedModLoader.loaderType === ModLoaderType.Quilt && (
+              <Checkbox
+                colorScheme={primaryColor}
+                isChecked={selectedModLoader.version !== "" && isInstallQfApi}
+                disabled={!selectedModLoader.version}
+                onChange={(e) => setIsInstallQfApi(e.target.checked)}
+              >
+                <Text fontSize="sm">
+                  {t("ChangeModLoaderModal.footer.installQFAPI")}
+                </Text>
+              </Checkbox>
+            )}
+
           <HStack spacing={3} ml="auto">
             <Button variant="ghost" onClick={modalProps.onClose}>
               {t("General.cancel")}
             </Button>
+
             <Button
               colorScheme={primaryColor}
               onClick={handleChangeModLoader}
               isLoading={isLoading}
-              isDisabled={isUnselected}
+              isDisabled={isDisabled}
             >
               {isSameAsCurrent
                 ? t("ChangeModLoaderModal.footer.reinstall")

--- a/src/contexts/task.tsx
+++ b/src/contexts/task.tsx
@@ -450,6 +450,9 @@ export const TaskContextProvider: React.FC<{ children: React.ReactNode }> = ({
               case "change-mod-loader":
                 getInstanceList(true);
                 break;
+              case "change-optifine":
+                getInstanceList(true);
+                break;
               case "game-client-w-java":
                 getInstanceList(true);
                 getJavaInfos(true);
@@ -493,9 +496,6 @@ export const TaskContextProvider: React.FC<{ children: React.ReactNode }> = ({
                     }
                   );
                 }
-                break;
-              case "change-optifine":
-                getInstanceList(true);
                 break;
               case "optifine-libraries":
                 if (params.param || params.param1) {

--- a/src/contexts/task.tsx
+++ b/src/contexts/task.tsx
@@ -494,6 +494,9 @@ export const TaskContextProvider: React.FC<{ children: React.ReactNode }> = ({
                   );
                 }
                 break;
+              case "change-optifine":
+                getInstanceList(true);
+                break;
               case "optifine-libraries":
                 if (params.param || params.param1) {
                   const instanceId = params.param || params.param1;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -633,6 +633,7 @@
       "game-client-w-java": "Game Client {{param1}} (with Java {{param2}})",
       "game-server": "Game Server {{param}}",
       "change-mod-loader": "Change Mod Loader {{param}}",
+      "change-optifine": "Change Shaderpack Loader {{param}}",
       "mod": "Mod",
       "world": "World",
       "resourcepack": "Resourcepack",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -352,6 +352,7 @@
       }
     },
     "notSelectedLoader": "No new loader selected",
+    "notSelectedOptifine": "No new Optifine selected",
     "footer": {
       "installFabricApi": "Install Fabric API Mod",
       "installQFAPI": "Install QFAPI / QSL Mod (if available)",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -344,11 +344,19 @@
       }
     }
   },
-  "ChangeModLoaderModal": {
+  "ChangeLoaderModal": {
     "header": {
-      "title": {
-        "change": "Change Mod Loader",
-        "install": "Install Mod Loader"
+      "modloader": {
+        "title": {
+          "change": "Change Mod Loader",
+          "install": "Install Mod Loader"
+        }
+      },
+      "optifine": {
+        "title": {
+          "change": "Change OptiFine",
+          "install": "Install OptiFine"
+        }
       }
     },
     "notSelectedLoader": "No new loader selected",

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -344,11 +344,19 @@
       }
     }
   },
-  "ChangeModLoaderModal": {
+  "ChangeLoaderModal": {
     "header": {
-      "title": {
-        "change": "修改模组加载器",
-        "install": "安装模组加载器"
+      "modloader": {
+        "title": {
+          "change": "修改模组加载器",
+          "install": "安装模组加载器"
+        }
+      },
+      "optifine": {
+        "title": {
+          "change": "修改光影加载器",
+          "install": "安装光影加载器"
+        }
       }
     },
     "notSelectedLoader": "未选择新的加载器",

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -633,6 +633,7 @@
       "game-client-w-java": "游戏客户端 {{param1}}（包含 Java {{param2}}）",
       "game-server": "游戏服务端 {{param}}",
       "change-mod-loader": "修改模组加载器 {{param}}",
+      "change-optifine": "修改光影加载器 {{param}}",
       "mod": "模组",
       "world": "存档",
       "resourcepack": "资源包",

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -352,6 +352,7 @@
       }
     },
     "notSelectedLoader": "未选择新的加载器",
+    "notSelectedOptifine": "未选择新的Optifine",
     "footer": {
       "installFabricApi": "同时安装 Fabric API 模组",
       "installQFAPI": "同时安装 QFAPI / QSL 模组（如果可用）",

--- a/src/pages/instances/details/[id]/mods.tsx
+++ b/src/pages/instances/details/[id]/mods.tsx
@@ -38,7 +38,7 @@ import {
   modLoaderTypes,
   modLoaderTypesToIcon,
 } from "@/components/loader-selector";
-import { ChangeModLoaderModal } from "@/components/modals/change-mod-loader-modal";
+import { ChangeLoaderModal } from "@/components/modals/change-loader-modal";
 import CheckModUpdateModal from "@/components/modals/check-mod-update-modal";
 import ModInfoModal from "@/components/modals/mod-info-modal";
 import { useLauncherConfig } from "@/contexts/config";
@@ -90,9 +90,9 @@ const InstanceModsPage = () => {
     useState<LocalModInfo | null>(null);
 
   const {
-    isOpen: isChangeModLoaderModalOpen,
-    onOpen: onChangeModLoaderModalOpen,
-    onClose: onChangeModLoaderModalClose,
+    isOpen: isChangeLoaderModalOpen,
+    onOpen: onChangeLoaderModalOpen,
+    onClose: onChangeLoaderModalClose,
   } = useDisclosure();
 
   const {
@@ -117,7 +117,7 @@ const InstanceModsPage = () => {
     if (response.status === "success") {
       if (response.data) {
         setTargetLoaderType(type);
-        onChangeModLoaderModalOpen();
+        onChangeLoaderModalOpen();
       } else {
         toast({
           title: t("Services.instance.changeModLoader.error.title"),
@@ -631,9 +631,9 @@ const InstanceModsPage = () => {
         localMods={localMods}
       />
 
-      <ChangeModLoaderModal
-        isOpen={isChangeModLoaderModalOpen}
-        onClose={onChangeModLoaderModalClose}
+      <ChangeLoaderModal
+        isOpen={isChangeLoaderModalOpen}
+        onClose={onChangeLoaderModalClose}
         defaultSelectedType={targetLoaderType}
       />
 

--- a/src/pages/instances/details/[id]/shaderpacks.tsx
+++ b/src/pages/instances/details/[id]/shaderpacks.tsx
@@ -11,7 +11,7 @@ import { Section } from "@/components/common/section";
 import SelectableCard, {
   SelectableCardProps,
 } from "@/components/common/selectable-card";
-import { ChangeModLoaderModal } from "@/components/modals/change-mod-loader-modal";
+import { ChangeLoaderModal } from "@/components/modals/change-loader-modal";
 import { useLauncherConfig } from "@/contexts/config";
 import { useInstanceSharedData } from "@/contexts/instance";
 import { useSharedModals } from "@/contexts/shared-modal";
@@ -37,9 +37,9 @@ const InstanceShaderPacksPage = () => {
   const [shaderPacks, setShaderPacks] = useState<ShaderPackInfo[]>([]);
 
   const {
-    isOpen: isChangeModLoaderModalOpen,
-    onOpen: onChangeModLoaderModalOpen,
-    onClose: onChangeModLoaderModalClose,
+    isOpen: isChangeLoaderModalOpen,
+    onOpen: onChangeLoaderModalOpen,
+    onClose: onChangeLoaderModalClose,
   } = useDisclosure();
 
   const getShaderPackListWrapper = useCallback(
@@ -131,7 +131,7 @@ const InstanceShaderPacksPage = () => {
       displayMode: "entry",
       isSelected: summary?.optifine?.status === "Installed",
       onSelect: () => {
-        onChangeModLoaderModalOpen();
+        onChangeLoaderModalOpen();
       },
       isDisabled: false,
       isChevronShown: true,
@@ -214,9 +214,9 @@ const InstanceShaderPacksPage = () => {
           <Empty withIcon={false} size="sm" />
         )}
       </Section>
-      <ChangeModLoaderModal
-        isOpen={isChangeModLoaderModalOpen}
-        onClose={onChangeModLoaderModalClose}
+      <ChangeLoaderModal
+        isOpen={isChangeLoaderModalOpen}
+        onClose={onChangeLoaderModalClose}
         mode="optifine"
       />
     </>

--- a/src/pages/instances/details/[id]/shaderpacks.tsx
+++ b/src/pages/instances/details/[id]/shaderpacks.tsx
@@ -1,4 +1,4 @@
-import { Center, HStack } from "@chakra-ui/react";
+import { Center, HStack, useDisclosure } from "@chakra-ui/react";
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -11,6 +11,7 @@ import { Section } from "@/components/common/section";
 import SelectableCard, {
   SelectableCardProps,
 } from "@/components/common/selectable-card";
+import { ChangeModLoaderModal } from "@/components/modals/change-mod-loader-modal";
 import { useLauncherConfig } from "@/contexts/config";
 import { useInstanceSharedData } from "@/contexts/instance";
 import { useSharedModals } from "@/contexts/shared-modal";
@@ -34,6 +35,12 @@ const InstanceShaderPacksPage = () => {
   const accordionStates = config.states.instanceShaderPacksPage.accordionStates;
 
   const [shaderPacks, setShaderPacks] = useState<ShaderPackInfo[]>([]);
+
+  const {
+    isOpen: isChangeModLoaderModalOpen,
+    onOpen: onChangeModLoaderModalOpen,
+    onClose: onChangeModLoaderModalClose,
+  } = useDisclosure();
 
   const getShaderPackListWrapper = useCallback(
     (sync?: boolean) => {
@@ -123,10 +130,11 @@ const InstanceShaderPacksPage = () => {
           : t("InstanceShaderPacksPage.shaderLoaderList.notInstalled"),
       displayMode: "entry",
       isSelected: summary?.optifine?.status === "Installed",
-      onSelect: () => {},
-      // TODO: add OptiFine installation support
-      isDisabled: true,
-      isChevronShown: false,
+      onSelect: () => {
+        onChangeModLoaderModalOpen();
+      },
+      isDisabled: false,
+      isChevronShown: true,
     },
   ];
 
@@ -174,7 +182,6 @@ const InstanceShaderPacksPage = () => {
                 icon={btn.icon}
                 onClick={btn.onClick}
                 size="xs"
-                fontSize="sm"
                 h={21}
               />
             ))}
@@ -207,6 +214,11 @@ const InstanceShaderPacksPage = () => {
           <Empty withIcon={false} size="sm" />
         )}
       </Section>
+      <ChangeModLoaderModal
+        isOpen={isChangeModLoaderModalOpen}
+        onClose={onChangeModLoaderModalClose}
+        mode="optifine"
+      />
     </>
   );
 };

--- a/src/services/instance.ts
+++ b/src/services/instance.ts
@@ -476,14 +476,14 @@ export class InstanceService {
   static async changeModLoader(
     instanceId: string,
     newModLoader?: ModLoaderResourceInfo | null,
-    optifine?: OptiFineResourceInfo | null,
+    newOptifine?: OptiFineResourceInfo | null,
     isInstallFabricApi?: boolean,
     isInstallQfApi?: boolean
   ): Promise<InvokeResponse<void>> {
     return await invoke("change_mod_loader", {
       instanceId,
       newModLoader: newModLoader ?? null,
-      optifine: optifine ?? null,
+      newOptifine: newOptifine ?? null,
       isInstallFabricApi,
       isInstallQfApi,
     });

--- a/src/services/instance.ts
+++ b/src/services/instance.ts
@@ -475,13 +475,15 @@ export class InstanceService {
   @responseHandler("instance")
   static async changeModLoader(
     instanceId: string,
-    newModLoader: ModLoaderResourceInfo,
+    newModLoader?: ModLoaderResourceInfo | null,
+    optifine?: OptiFineResourceInfo | null,
     isInstallFabricApi?: boolean,
     isInstallQfApi?: boolean
   ): Promise<InvokeResponse<void>> {
     return await invoke("change_mod_loader", {
       instanceId,
-      newModLoader,
+      newModLoader: newModLoader ?? null,
+      optifine: optifine ?? null,
       isInstallFabricApi,
       isInstallQfApi,
     });


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - e.g. close #xxxx, fix #xxxx

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Support changing an instance’s OptiFine configuration through the existing change-mod-loader flow and shaderpacks UI, alongside standard mod loader changes.

New Features:
- Allow selecting and changing the OptiFine version for an instance via the ChangeModLoader modal and shaderpacks page.
- Extend the loader selector component to operate in an OptiFine-only mode for choosing OptiFine builds.

Enhancements:
- Update the change_mod_loader backend command to accept optional mod loader and OptiFine parameters and schedule installation tasks only when needed.