### PR TITLE
Add macOS Style Close Button and Title

### DIFF
--- a/src/components/common/macos-close-button.tsx
+++ b/src/components/common/macos-close-button.tsx
@@ -1,16 +1,16 @@
 import { Box, ModalCloseButton } from "@chakra-ui/react";
 import { useLauncherConfig } from "@/contexts/config";
+import { isMacPlatform } from "@/utils/platform";
 
-interface WindowsCloseButtonProps {
+interface MacosCloseButtonProps {
   onClick: () => void;
 }
 
-export const WindowsCloseButton: React.FC<WindowsCloseButtonProps> = ({
+export const MacosCloseButton: React.FC<MacosCloseButtonProps> = ({
   onClick,
 }) => {
   const { config } = useLauncherConfig();
-  const isMac =
-    config.basicInfo.osType === "macos" || config.basicInfo.osType === "darwin";
+  const isMac = isMacPlatform(config.basicInfo.osType);
 
   if (!isMac) {
     return <ModalCloseButton onClick={onClick} />;
@@ -19,6 +19,7 @@ export const WindowsCloseButton: React.FC<WindowsCloseButtonProps> = ({
   return (
     <Box
       as="button"
+      type="button"
       position="absolute"
       top="11px"
       left="12px"
@@ -31,15 +32,20 @@ export const WindowsCloseButton: React.FC<WindowsCloseButtonProps> = ({
       justifyContent="center"
       cursor="pointer"
       transition="all 0.1s"
+      aria-label="Close"
       _hover={{
-        "& .windows-close-icon": {
+        "& .macos-close-icon": {
           opacity: 1,
         },
+      }}
+      _focus={{
+        outline: "2px solid #007AFF",
+        outlineOffset: "2px",
       }}
       onClick={onClick}
     >
       <Box
-        className="windows-close-icon"
+        className="macos-close-icon"
         w="6px"
         h="6px"
         display="flex"

--- a/src/components/common/macos-modal-header.tsx
+++ b/src/components/common/macos-modal-header.tsx
@@ -1,0 +1,13 @@
+import {
+  ModalHeader as ChakraModalHeader,
+  ModalHeaderProps as ChakraModalHeaderProps,
+} from "@chakra-ui/react";
+import { useLauncherConfig } from "@/contexts/config";
+
+export const MacosModalHeader: React.FC<ChakraModalHeaderProps> = (props) => {
+  const { config } = useLauncherConfig();
+  const isMac =
+    config.basicInfo.osType === "macos" || config.basicInfo.osType === "darwin";
+
+  return <ChakraModalHeader textAlign={isMac ? "center" : "left"} {...props} />;
+};

--- a/src/components/common/macos-modal-header.tsx
+++ b/src/components/common/macos-modal-header.tsx
@@ -3,11 +3,11 @@ import {
   ModalHeaderProps as ChakraModalHeaderProps,
 } from "@chakra-ui/react";
 import { useLauncherConfig } from "@/contexts/config";
+import { isMacPlatform } from "@/utils/platform";
 
 export const MacosModalHeader: React.FC<ChakraModalHeaderProps> = (props) => {
   const { config } = useLauncherConfig();
-  const isMac =
-    config.basicInfo.osType === "macos" || config.basicInfo.osType === "darwin";
+  const isMac = isMacPlatform(config.basicInfo.osType);
 
   return <ChakraModalHeader textAlign={isMac ? "center" : "left"} {...props} />;
 };

--- a/src/components/common/windows-close-button.tsx
+++ b/src/components/common/windows-close-button.tsx
@@ -1,0 +1,59 @@
+import { Box } from "@chakra-ui/react";
+
+interface WindowsCloseButtonProps {
+  onClick: () => void;
+}
+
+export const WindowsCloseButton: React.FC<WindowsCloseButtonProps> = ({
+  onClick,
+}) => {
+  return (
+    <Box
+      as="button"
+      position="absolute"
+      top="11px"
+      left="12px"
+      w="12px"
+      h="12px"
+      borderRadius="full"
+      bg="#ff5f57"
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      cursor="pointer"
+      transition="all 0.1s"
+      _hover={{
+        "& .windows-close-icon": {
+          opacity: 1,
+        },
+      }}
+      onClick={onClick}
+    >
+      <Box
+        className="windows-close-icon"
+        w="6px"
+        h="6px"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        opacity={0}
+        transition="opacity 0.1s"
+      >
+        <svg
+          width="6"
+          height="6"
+          viewBox="0 0 6 6"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M1 1L5 5M5 1L1 5"
+            stroke="black"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+        </svg>
+      </Box>
+    </Box>
+  );
+};

--- a/src/components/common/windows-close-button.tsx
+++ b/src/components/common/windows-close-button.tsx
@@ -1,4 +1,5 @@
 import { Box } from "@chakra-ui/react";
+import { useLauncherConfig } from "@/contexts/config";
 
 interface WindowsCloseButtonProps {
   onClick: () => void;
@@ -7,6 +8,12 @@ interface WindowsCloseButtonProps {
 export const WindowsCloseButton: React.FC<WindowsCloseButtonProps> = ({
   onClick,
 }) => {
+  const { config } = useLauncherConfig();
+  const isMac =
+    config.basicInfo.osType === "macos" || config.basicInfo.osType === "darwin";
+
+  if (!isMac) return null;
+
   return (
     <Box
       as="button"

--- a/src/components/common/windows-close-button.tsx
+++ b/src/components/common/windows-close-button.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@chakra-ui/react";
+import { Box, ModalCloseButton } from "@chakra-ui/react";
 import { useLauncherConfig } from "@/contexts/config";
 
 interface WindowsCloseButtonProps {
@@ -12,7 +12,9 @@ export const WindowsCloseButton: React.FC<WindowsCloseButtonProps> = ({
   const isMac =
     config.basicInfo.osType === "macos" || config.basicInfo.osType === "darwin";
 
-  if (!isMac) return null;
+  if (!isMac) {
+    return <ModalCloseButton onClick={onClick} />;
+  }
 
   return (
     <Box

--- a/src/components/modals/add-auth-server-modal.tsx
+++ b/src/components/modals/add-auth-server-modal.tsx
@@ -20,8 +20,8 @@ import {
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
 import { useToast } from "@/contexts/toast";
@@ -132,7 +132,7 @@ const AddAuthServerModal: React.FC<AddAuthServerModalProps> = ({
         <MacosModalHeader>
           {t("AddAuthServerModal.header.title")}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={onClose} />
+        <MacosCloseButton onClick={onClose} />
         <ModalBody>
           {!config.basicInfo.allowFullLoginFeature && (
             <Alert status="error" borderRadius="md" mb="3">

--- a/src/components/modals/add-auth-server-modal.tsx
+++ b/src/components/modals/add-auth-server-modal.tsx
@@ -11,7 +11,6 @@ import {
   Input,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -22,6 +21,7 @@ import {
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
 import { useToast } from "@/contexts/toast";
@@ -130,7 +130,7 @@ const AddAuthServerModal: React.FC<AddAuthServerModalProps> = ({
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("AddAuthServerModal.header.title")}</ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={onClose} />
         <ModalBody>
           {!config.basicInfo.allowFullLoginFeature && (
             <Alert status="error" borderRadius="md" mb="3">

--- a/src/components/modals/add-auth-server-modal.tsx
+++ b/src/components/modals/add-auth-server-modal.tsx
@@ -13,7 +13,6 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   Text,
@@ -21,6 +20,7 @@ import {
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
@@ -129,7 +129,9 @@ const AddAuthServerModal: React.FC<AddAuthServerModalProps> = ({
     >
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>{t("AddAuthServerModal.header.title")}</ModalHeader>
+        <MacosModalHeader>
+          {t("AddAuthServerModal.header.title")}
+        </MacosModalHeader>
         <WindowsCloseButton onClick={onClose} />
         <ModalBody>
           {!config.basicInfo.allowFullLoginFeature && (

--- a/src/components/modals/add-game-server-modal.tsx
+++ b/src/components/modals/add-game-server-modal.tsx
@@ -14,8 +14,8 @@ import {
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
 import { InstanceService } from "@/services/instance";
@@ -98,7 +98,7 @@ const AddGameServerModal: React.FC<AddGameServerModalProps> = ({
         <MacosModalHeader>
           {t("AddGameServerModal.header.title")}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={onClose} />
+        <MacosCloseButton onClick={onClose} />
         <ModalBody>
           <VStack spacing={4} align="stretch">
             <FormControl isInvalid={isServerAddrInvalid} isRequired>

--- a/src/components/modals/add-game-server-modal.tsx
+++ b/src/components/modals/add-game-server-modal.tsx
@@ -6,7 +6,6 @@ import {
   Input,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -16,6 +15,7 @@ import {
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
 import { InstanceService } from "@/services/instance";
@@ -96,7 +96,7 @@ const AddGameServerModal: React.FC<AddGameServerModalProps> = ({
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("AddGameServerModal.header.title")}</ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={onClose} />
         <ModalBody>
           <VStack spacing={4} align="stretch">
             <FormControl isInvalid={isServerAddrInvalid} isRequired>

--- a/src/components/modals/add-game-server-modal.tsx
+++ b/src/components/modals/add-game-server-modal.tsx
@@ -8,13 +8,13 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   VStack,
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
@@ -95,7 +95,9 @@ const AddGameServerModal: React.FC<AddGameServerModalProps> = ({
     >
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>{t("AddGameServerModal.header.title")}</ModalHeader>
+        <MacosModalHeader>
+          {t("AddGameServerModal.header.title")}
+        </MacosModalHeader>
         <WindowsCloseButton onClick={onClose} />
         <ModalBody>
           <VStack spacing={4} align="stretch">

--- a/src/components/modals/add-player-modal.tsx
+++ b/src/components/modals/add-player-modal.tsx
@@ -39,10 +39,10 @@ import {
   LuServer,
   LuSquareUserRound,
 } from "react-icons/lu";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { Section } from "@/components/common/section";
 import SegmentedControl from "@/components/common/segmented";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import SelectPlayerModal from "@/components/modals/select-player-modal";
 import OAuthLoginPanel from "@/components/oauth-login-panel";
 import { useLauncherConfig } from "@/contexts/config";
@@ -291,7 +291,7 @@ const AddPlayerModal: React.FC<AddPlayerModalProps> = ({
       <ModalOverlay />
       <ModalContent>
         <MacosModalHeader>{t("AddPlayerModal.modal.header")}</MacosModalHeader>
-        <WindowsCloseButton onClick={modalProps.onClose} />
+        <MacosCloseButton onClick={modalProps.onClose} />
 
         <ModalBody>
           <VStack spacing={3.5}>

--- a/src/components/modals/add-player-modal.tsx
+++ b/src/components/modals/add-player-modal.tsx
@@ -18,7 +18,6 @@ import {
   MenuList,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -43,6 +42,7 @@ import {
 } from "react-icons/lu";
 import { Section } from "@/components/common/section";
 import SegmentedControl from "@/components/common/segmented";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import SelectPlayerModal from "@/components/modals/select-player-modal";
 import OAuthLoginPanel from "@/components/oauth-login-panel";
 import { useLauncherConfig } from "@/contexts/config";
@@ -291,7 +291,7 @@ const AddPlayerModal: React.FC<AddPlayerModalProps> = ({
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("AddPlayerModal.modal.header")}</ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={modalProps.onClose} />
 
         <ModalBody>
           <VStack spacing={3.5}>

--- a/src/components/modals/add-player-modal.tsx
+++ b/src/components/modals/add-player-modal.tsx
@@ -20,7 +20,6 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   Text,
@@ -40,6 +39,7 @@ import {
   LuServer,
   LuSquareUserRound,
 } from "react-icons/lu";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { Section } from "@/components/common/section";
 import SegmentedControl from "@/components/common/segmented";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
@@ -290,7 +290,7 @@ const AddPlayerModal: React.FC<AddPlayerModalProps> = ({
     >
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>{t("AddPlayerModal.modal.header")}</ModalHeader>
+        <MacosModalHeader>{t("AddPlayerModal.modal.header")}</MacosModalHeader>
         <WindowsCloseButton onClick={modalProps.onClose} />
 
         <ModalBody>

--- a/src/components/modals/add-post-source-modal.tsx
+++ b/src/components/modals/add-post-source-modal.tsx
@@ -5,7 +5,6 @@ import {
   Input,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -14,6 +13,7 @@ import {
 } from "@chakra-ui/react";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 
 const AddDiscoverSourceModal: React.FC<Omit<ModalProps, "children">> = ({
@@ -43,7 +43,7 @@ const AddDiscoverSourceModal: React.FC<Omit<ModalProps, "children">> = ({
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("AddDiscoverSourceModal.modal.header")}</ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={handleCloseModal} />
         <ModalBody>
           <FormControl isRequired>
             <FormLabel>

--- a/src/components/modals/add-post-source-modal.tsx
+++ b/src/components/modals/add-post-source-modal.tsx
@@ -12,8 +12,8 @@ import {
 } from "@chakra-ui/react";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 
 const AddDiscoverSourceModal: React.FC<Omit<ModalProps, "children">> = ({
@@ -45,7 +45,7 @@ const AddDiscoverSourceModal: React.FC<Omit<ModalProps, "children">> = ({
         <MacosModalHeader>
           {t("AddDiscoverSourceModal.modal.header")}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={handleCloseModal} />
+        <MacosCloseButton onClick={handleCloseModal} />
         <ModalBody>
           <FormControl isRequired>
             <FormLabel>

--- a/src/components/modals/add-post-source-modal.tsx
+++ b/src/components/modals/add-post-source-modal.tsx
@@ -7,12 +7,12 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
 } from "@chakra-ui/react";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 
@@ -42,7 +42,9 @@ const AddDiscoverSourceModal: React.FC<Omit<ModalProps, "children">> = ({
     <Modal {...props} onClose={handleCloseModal}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>{t("AddDiscoverSourceModal.modal.header")}</ModalHeader>
+        <MacosModalHeader>
+          {t("AddDiscoverSourceModal.modal.header")}
+        </MacosModalHeader>
         <WindowsCloseButton onClick={handleCloseModal} />
         <ModalBody>
           <FormControl isRequired>

--- a/src/components/modals/alert-resource-dependency-modal.tsx
+++ b/src/components/modals/alert-resource-dependency-modal.tsx
@@ -6,7 +6,6 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   Tag,
@@ -17,6 +16,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuDownload, LuGlobe, LuUpload } from "react-icons/lu";
 import { BeatLoader } from "react-spinners";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { OptionItem } from "@/components/common/option-item";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
@@ -207,9 +207,9 @@ const AlertResourceDependencyModal: React.FC<
     >
       <ModalOverlay />
       <ModalContent h="100%">
-        <ModalHeader>
+        <MacosModalHeader>
           {t("AlertResourceDependencyModal.header.title")}
-        </ModalHeader>
+        </MacosModalHeader>
         <WindowsCloseButton onClick={modalProps.onClose} />
 
         <ModalBody

--- a/src/components/modals/alert-resource-dependency-modal.tsx
+++ b/src/components/modals/alert-resource-dependency-modal.tsx
@@ -4,7 +4,6 @@ import {
   HStack,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -19,6 +18,7 @@ import { useTranslation } from "react-i18next";
 import { LuDownload, LuGlobe, LuUpload } from "react-icons/lu";
 import { BeatLoader } from "react-spinners";
 import { OptionItem } from "@/components/common/option-item";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useSharedModals } from "@/contexts/shared-modal";
 import { ModLoaderType } from "@/enums/instance";
@@ -210,7 +210,7 @@ const AlertResourceDependencyModal: React.FC<
         <ModalHeader>
           {t("AlertResourceDependencyModal.header.title")}
         </ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={modalProps.onClose} />
 
         <ModalBody
           flex="1"

--- a/src/components/modals/alert-resource-dependency-modal.tsx
+++ b/src/components/modals/alert-resource-dependency-modal.tsx
@@ -16,9 +16,9 @@ import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuDownload, LuGlobe, LuUpload } from "react-icons/lu";
 import { BeatLoader } from "react-spinners";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { OptionItem } from "@/components/common/option-item";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useSharedModals } from "@/contexts/shared-modal";
 import { ModLoaderType } from "@/enums/instance";
@@ -210,7 +210,7 @@ const AlertResourceDependencyModal: React.FC<
         <MacosModalHeader>
           {t("AlertResourceDependencyModal.header.title")}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={modalProps.onClose} />
+        <MacosCloseButton onClick={modalProps.onClose} />
 
         <ModalBody
           flex="1"

--- a/src/components/modals/change-mod-loader-modal.tsx
+++ b/src/components/modals/change-mod-loader-modal.tsx
@@ -18,9 +18,9 @@ import { useRouter } from "next/router";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuArrowRight } from "react-icons/lu";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { OptionItem } from "@/components/common/option-item";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { LoaderSelector } from "@/components/loader-selector";
 import { useLauncherConfig } from "@/contexts/config";
 import { useInstanceSharedData } from "@/contexts/instance";
@@ -133,7 +133,7 @@ export const ChangeModLoaderModal: React.FC<ChangeModLoaderModalProps> = ({
             `ChangeModLoaderModal.header.title.${currentModLoader.loaderType === "Unknown" ? "install" : "change"}`
           )}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={modalProps.onClose} />
+        <MacosCloseButton onClick={modalProps.onClose} />
         {currentModLoader.loaderType !== "Unknown" && (
           <Flex position="relative" align="center" justify="center" py={2}>
             <Flex flex="1" justify="flex-end" pr={8}>

--- a/src/components/modals/change-mod-loader-modal.tsx
+++ b/src/components/modals/change-mod-loader-modal.tsx
@@ -7,7 +7,6 @@ import {
   Image,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -21,6 +20,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuArrowRight } from "react-icons/lu";
 import { OptionItem } from "@/components/common/option-item";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { LoaderSelector } from "@/components/loader-selector";
 import { useLauncherConfig } from "@/contexts/config";
 import { useInstanceSharedData } from "@/contexts/instance";
@@ -133,7 +133,7 @@ export const ChangeModLoaderModal: React.FC<ChangeModLoaderModalProps> = ({
             `ChangeModLoaderModal.header.title.${currentModLoader.loaderType === "Unknown" ? "install" : "change"}`
           )}
         </ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={modalProps.onClose} />
         {currentModLoader.loaderType !== "Unknown" && (
           <Flex position="relative" align="center" justify="center" py={2}>
             <Flex flex="1" justify="flex-end" pr={8}>

--- a/src/components/modals/change-mod-loader-modal.tsx
+++ b/src/components/modals/change-mod-loader-modal.tsx
@@ -9,7 +9,6 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   Skeleton,
@@ -19,6 +18,7 @@ import { useRouter } from "next/router";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuArrowRight } from "react-icons/lu";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { OptionItem } from "@/components/common/option-item";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { LoaderSelector } from "@/components/loader-selector";
@@ -128,11 +128,11 @@ export const ChangeModLoaderModal: React.FC<ChangeModLoaderModalProps> = ({
     >
       <ModalOverlay />
       <ModalContent h="100%">
-        <ModalHeader>
+        <MacosModalHeader>
           {t(
             `ChangeModLoaderModal.header.title.${currentModLoader.loaderType === "Unknown" ? "install" : "change"}`
           )}
-        </ModalHeader>
+        </MacosModalHeader>
         <WindowsCloseButton onClick={modalProps.onClose} />
         {currentModLoader.loaderType !== "Unknown" && (
           <Flex position="relative" align="center" justify="center" py={2}>

--- a/src/components/modals/check-mod-update-modal.tsx
+++ b/src/components/modals/check-mod-update-modal.tsx
@@ -7,7 +7,6 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   Progress,
@@ -17,6 +16,7 @@ import {
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { ModLoaderType } from "@/enums/instance";
@@ -310,11 +310,11 @@ const CheckModUpdateModal: React.FC<CheckModUpdateModalProps> = ({
     >
       <ModalOverlay />
       <ModalContent h="100%">
-        <ModalHeader>
+        <MacosModalHeader>
           <HStack w="100%" justify="flex-start" align="center">
             <Text>{t("CheckModUpdateModal.header.title")}</Text>
           </HStack>
-        </ModalHeader>
+        </MacosModalHeader>
         <WindowsCloseButton onClick={modalProps.onClose} />
 
         <ModalBody

--- a/src/components/modals/check-mod-update-modal.tsx
+++ b/src/components/modals/check-mod-update-modal.tsx
@@ -16,8 +16,8 @@ import {
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { ModLoaderType } from "@/enums/instance";
 import { OtherResourceSource } from "@/enums/resource";
@@ -315,7 +315,7 @@ const CheckModUpdateModal: React.FC<CheckModUpdateModalProps> = ({
             <Text>{t("CheckModUpdateModal.header.title")}</Text>
           </HStack>
         </MacosModalHeader>
-        <WindowsCloseButton onClick={modalProps.onClose} />
+        <MacosCloseButton onClick={modalProps.onClose} />
 
         <ModalBody
           flex="1"

--- a/src/components/modals/check-mod-update-modal.tsx
+++ b/src/components/modals/check-mod-update-modal.tsx
@@ -5,7 +5,6 @@ import {
   HStack,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -18,6 +17,7 @@ import {
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { ModLoaderType } from "@/enums/instance";
 import { OtherResourceSource } from "@/enums/resource";
@@ -315,7 +315,7 @@ const CheckModUpdateModal: React.FC<CheckModUpdateModalProps> = ({
             <Text>{t("CheckModUpdateModal.header.title")}</Text>
           </HStack>
         </ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={modalProps.onClose} />
 
         <ModalBody
           flex="1"

--- a/src/components/modals/copy-or-move-modal.tsx
+++ b/src/components/modals/copy-or-move-modal.tsx
@@ -9,7 +9,6 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   Radio,
@@ -22,6 +21,7 @@ import { useRouter } from "next/router";
 import React, { useCallback, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { LuCopy, LuScissors } from "react-icons/lu";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { OptionItemGroup } from "@/components/common/option-item";
 import SegmentedControl from "@/components/common/segmented";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
@@ -281,7 +281,7 @@ const CopyOrMoveModal: React.FC<CopyOrMoveModalProps> = ({
     >
       <ModalOverlay />
       <ModalContent h="100%">
-        <ModalHeader>{t("CopyOrMoveModal.modal.header")}</ModalHeader>
+        <MacosModalHeader>{t("CopyOrMoveModal.modal.header")}</MacosModalHeader>
         <WindowsCloseButton onClick={modalProps.onClose} />
 
         <Flex flexGrow="1" flexDir="column" h="100%" overflow="auto">

--- a/src/components/modals/copy-or-move-modal.tsx
+++ b/src/components/modals/copy-or-move-modal.tsx
@@ -7,7 +7,6 @@ import {
   Image,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -25,6 +24,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { LuCopy, LuScissors } from "react-icons/lu";
 import { OptionItemGroup } from "@/components/common/option-item";
 import SegmentedControl from "@/components/common/segmented";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
 import { useToast } from "@/contexts/toast";
@@ -282,7 +282,7 @@ const CopyOrMoveModal: React.FC<CopyOrMoveModalProps> = ({
       <ModalOverlay />
       <ModalContent h="100%">
         <ModalHeader>{t("CopyOrMoveModal.modal.header")}</ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={modalProps.onClose} />
 
         <Flex flexGrow="1" flexDir="column" h="100%" overflow="auto">
           <ModalBody>

--- a/src/components/modals/copy-or-move-modal.tsx
+++ b/src/components/modals/copy-or-move-modal.tsx
@@ -21,10 +21,10 @@ import { useRouter } from "next/router";
 import React, { useCallback, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { LuCopy, LuScissors } from "react-icons/lu";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { OptionItemGroup } from "@/components/common/option-item";
 import SegmentedControl from "@/components/common/segmented";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
 import { useToast } from "@/contexts/toast";
@@ -282,7 +282,7 @@ const CopyOrMoveModal: React.FC<CopyOrMoveModalProps> = ({
       <ModalOverlay />
       <ModalContent h="100%">
         <MacosModalHeader>{t("CopyOrMoveModal.modal.header")}</MacosModalHeader>
-        <WindowsCloseButton onClick={modalProps.onClose} />
+        <MacosCloseButton onClick={modalProps.onClose} />
 
         <Flex flexGrow="1" flexDir="column" h="100%" overflow="auto">
           <ModalBody>

--- a/src/components/modals/create-instance-modal.tsx
+++ b/src/components/modals/create-instance-modal.tsx
@@ -7,7 +7,6 @@ import {
   HStack,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -28,6 +27,7 @@ import {
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { GameVersionSelector } from "@/components/game-version-selector";
 import { InstanceBasicSettings } from "@/components/instance-basic-settings";
 import { LoaderSelector } from "@/components/loader-selector";
@@ -374,7 +374,7 @@ export const CreateInstanceModal: React.FC<Omit<ModalProps, "children">> = ({
       <ModalOverlay />
       <ModalContent h="100%">
         <ModalHeader>{t("CreateInstanceModal.header.title")}</ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={modalProps.onClose} />
         <Center>
           <Stepper
             colorScheme={primaryColor}

--- a/src/components/modals/create-instance-modal.tsx
+++ b/src/components/modals/create-instance-modal.tsx
@@ -26,8 +26,8 @@ import {
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { GameVersionSelector } from "@/components/game-version-selector";
 import { InstanceBasicSettings } from "@/components/instance-basic-settings";
 import { LoaderSelector } from "@/components/loader-selector";
@@ -376,7 +376,7 @@ export const CreateInstanceModal: React.FC<Omit<ModalProps, "children">> = ({
         <MacosModalHeader>
           {t("CreateInstanceModal.header.title")}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={modalProps.onClose} />
+        <MacosCloseButton onClick={modalProps.onClose} />
         <Center>
           <Stepper
             colorScheme={primaryColor}

--- a/src/components/modals/create-instance-modal.tsx
+++ b/src/components/modals/create-instance-modal.tsx
@@ -9,7 +9,6 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   Step,
@@ -27,6 +26,7 @@ import {
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { GameVersionSelector } from "@/components/game-version-selector";
 import { InstanceBasicSettings } from "@/components/instance-basic-settings";
@@ -373,7 +373,9 @@ export const CreateInstanceModal: React.FC<Omit<ModalProps, "children">> = ({
     >
       <ModalOverlay />
       <ModalContent h="100%">
-        <ModalHeader>{t("CreateInstanceModal.header.title")}</ModalHeader>
+        <MacosModalHeader>
+          {t("CreateInstanceModal.header.title")}
+        </MacosModalHeader>
         <WindowsCloseButton onClick={modalProps.onClose} />
         <Center>
           <Stepper

--- a/src/components/modals/download-game-server-modal.tsx
+++ b/src/components/modals/download-game-server-modal.tsx
@@ -12,8 +12,8 @@ import { save } from "@tauri-apps/plugin-dialog";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { GameVersionSelector } from "@/components/game-version-selector";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
@@ -73,7 +73,7 @@ export const DownloadGameServerModal: React.FC<
         <MacosModalHeader>
           {t("AddAndImportInstancePage.moreOptions.server.title")}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={modalProps.onClose} />
+        <MacosCloseButton onClick={modalProps.onClose} />
         <Flex flexGrow="1" flexDir="column">
           <ModalBody>
             <GameVersionSelector

--- a/src/components/modals/download-game-server-modal.tsx
+++ b/src/components/modals/download-game-server-modal.tsx
@@ -3,7 +3,6 @@ import {
   Flex,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -14,6 +13,7 @@ import { save } from "@tauri-apps/plugin-dialog";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { GameVersionSelector } from "@/components/game-version-selector";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
@@ -73,7 +73,7 @@ export const DownloadGameServerModal: React.FC<
         <ModalHeader>
           {t("AddAndImportInstancePage.moreOptions.server.title")}
         </ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={modalProps.onClose} />
         <Flex flexGrow="1" flexDir="column">
           <ModalBody>
             <GameVersionSelector

--- a/src/components/modals/download-game-server-modal.tsx
+++ b/src/components/modals/download-game-server-modal.tsx
@@ -5,7 +5,6 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
 } from "@chakra-ui/react";
@@ -13,6 +12,7 @@ import { save } from "@tauri-apps/plugin-dialog";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { GameVersionSelector } from "@/components/game-version-selector";
 import { useLauncherConfig } from "@/contexts/config";
@@ -70,9 +70,9 @@ export const DownloadGameServerModal: React.FC<
     >
       <ModalOverlay />
       <ModalContent h="100%">
-        <ModalHeader>
+        <MacosModalHeader>
           {t("AddAndImportInstancePage.moreOptions.server.title")}
-        </ModalHeader>
+        </MacosModalHeader>
         <WindowsCloseButton onClick={modalProps.onClose} />
         <Flex flexGrow="1" flexDir="column">
           <ModalBody>

--- a/src/components/modals/download-java-modal.tsx
+++ b/src/components/modals/download-java-modal.tsx
@@ -3,7 +3,6 @@ import {
   Grid,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -18,6 +17,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuExternalLink } from "react-icons/lu";
 import { MenuSelector } from "@/components/common/menu-selector";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
 import { ConfigService } from "@/services/config";
@@ -160,7 +160,7 @@ export const DownloadJavaModal: React.FC<Omit<ModalProps, "children">> = ({
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("DownloadJavaModal.header.title")}</ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={props.onClose} />
         <ModalBody>
           <VStack align="stretch">
             <Grid templateColumns="1fr 1fr 1fr" gap={4} w="100%">

--- a/src/components/modals/download-java-modal.tsx
+++ b/src/components/modals/download-java-modal.tsx
@@ -15,9 +15,9 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuExternalLink } from "react-icons/lu";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { MenuSelector } from "@/components/common/menu-selector";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
 import { ConfigService } from "@/services/config";
@@ -162,7 +162,7 @@ export const DownloadJavaModal: React.FC<Omit<ModalProps, "children">> = ({
         <MacosModalHeader>
           {t("DownloadJavaModal.header.title")}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={props.onClose} />
+        <MacosCloseButton onClick={props.onClose} />
         <ModalBody>
           <VStack align="stretch">
             <Grid templateColumns="1fr 1fr 1fr" gap={4} w="100%">

--- a/src/components/modals/download-java-modal.tsx
+++ b/src/components/modals/download-java-modal.tsx
@@ -5,7 +5,6 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   Text,
@@ -16,6 +15,7 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuExternalLink } from "react-icons/lu";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { MenuSelector } from "@/components/common/menu-selector";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
@@ -159,7 +159,9 @@ export const DownloadJavaModal: React.FC<Omit<ModalProps, "children">> = ({
     <Modal size={{ base: "sm", lg: "md" }} {...props}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>{t("DownloadJavaModal.header.title")}</ModalHeader>
+        <MacosModalHeader>
+          {t("DownloadJavaModal.header.title")}
+        </MacosModalHeader>
         <WindowsCloseButton onClick={props.onClose} />
         <ModalBody>
           <VStack align="stretch">

--- a/src/components/modals/download-modpack-modal.tsx
+++ b/src/components/modals/download-modpack-modal.tsx
@@ -9,8 +9,8 @@ import {
   Text,
 } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import ResourceDownloader from "@/components/resource-downloader";
 import { OtherResourceSource, OtherResourceType } from "@/enums/resource";
 
@@ -39,7 +39,7 @@ export const DownloadModpackModal: React.FC<DownloadModpackModalProps> = ({
             <Text>{t("DownloadModpackModal.header.title")}</Text>
           </HStack>
         </MacosModalHeader>
-        <WindowsCloseButton onClick={modalProps.onClose} />
+        <MacosCloseButton onClick={modalProps.onClose} />
         <Flex flexGrow="1" flexDir="column">
           <ModalBody>
             <ResourceDownloader

--- a/src/components/modals/download-modpack-modal.tsx
+++ b/src/components/modals/download-modpack-modal.tsx
@@ -4,12 +4,12 @@ import {
   Modal,
   ModalBody,
   ModalContent,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   Text,
 } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import ResourceDownloader from "@/components/resource-downloader";
 import { OtherResourceSource, OtherResourceType } from "@/enums/resource";
@@ -34,11 +34,11 @@ export const DownloadModpackModal: React.FC<DownloadModpackModalProps> = ({
     >
       <ModalOverlay />
       <ModalContent h="100%">
-        <ModalHeader>
+        <MacosModalHeader>
           <HStack w="100%" justify="flex-start" align="center">
             <Text>{t("DownloadModpackModal.header.title")}</Text>
           </HStack>
-        </ModalHeader>
+        </MacosModalHeader>
         <WindowsCloseButton onClick={modalProps.onClose} />
         <Flex flexGrow="1" flexDir="column">
           <ModalBody>

--- a/src/components/modals/download-modpack-modal.tsx
+++ b/src/components/modals/download-modpack-modal.tsx
@@ -3,7 +3,6 @@ import {
   HStack,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalHeader,
   ModalOverlay,
@@ -11,6 +10,7 @@ import {
   Text,
 } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import ResourceDownloader from "@/components/resource-downloader";
 import { OtherResourceSource, OtherResourceType } from "@/enums/resource";
 
@@ -39,7 +39,7 @@ export const DownloadModpackModal: React.FC<DownloadModpackModalProps> = ({
             <Text>{t("DownloadModpackModal.header.title")}</Text>
           </HStack>
         </ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={modalProps.onClose} />
         <Flex flexGrow="1" flexDir="column">
           <ModalBody>
             <ResourceDownloader

--- a/src/components/modals/download-resource-modal.tsx
+++ b/src/components/modals/download-resource-modal.tsx
@@ -5,7 +5,6 @@ import {
   Modal,
   ModalBody,
   ModalContent,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   Text,
@@ -22,6 +21,7 @@ import {
   LuPuzzle,
   LuSquareLibrary,
 } from "react-icons/lu";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import NavMenu from "@/components/common/nav-menu";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import ResourceDownloader from "@/components/resource-downloader";
@@ -78,7 +78,7 @@ const DownloadResourceModal: React.FC<DownloadResourceModalProps> = ({
     >
       <ModalOverlay />
       <ModalContent h="100%" pb={4}>
-        <ModalHeader>
+        <MacosModalHeader>
           <HStack w="100%" justify="flex-start" align="center">
             <Text>{t("DownloadResourceModal.header.title")}</Text>
             <NavMenu
@@ -118,7 +118,7 @@ const DownloadResourceModal: React.FC<DownloadResourceModalProps> = ({
               }))}
             />
           </HStack>
-        </ModalHeader>
+        </MacosModalHeader>
         <WindowsCloseButton onClick={modalProps.onClose} />
         <Flex flexGrow="1" flexDir="column">
           <ModalBody>

--- a/src/components/modals/download-resource-modal.tsx
+++ b/src/components/modals/download-resource-modal.tsx
@@ -4,7 +4,6 @@ import {
   Icon,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalHeader,
   ModalOverlay,
@@ -24,6 +23,7 @@ import {
   LuSquareLibrary,
 } from "react-icons/lu";
 import NavMenu from "@/components/common/nav-menu";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import ResourceDownloader from "@/components/resource-downloader";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
@@ -119,7 +119,7 @@ const DownloadResourceModal: React.FC<DownloadResourceModalProps> = ({
             />
           </HStack>
         </ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={modalProps.onClose} />
         <Flex flexGrow="1" flexDir="column">
           <ModalBody>
             <ResourceDownloader

--- a/src/components/modals/download-resource-modal.tsx
+++ b/src/components/modals/download-resource-modal.tsx
@@ -21,9 +21,9 @@ import {
   LuPuzzle,
   LuSquareLibrary,
 } from "react-icons/lu";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import NavMenu from "@/components/common/nav-menu";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import ResourceDownloader from "@/components/resource-downloader";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
@@ -119,7 +119,7 @@ const DownloadResourceModal: React.FC<DownloadResourceModalProps> = ({
             />
           </HStack>
         </MacosModalHeader>
-        <WindowsCloseButton onClick={modalProps.onClose} />
+        <MacosCloseButton onClick={modalProps.onClose} />
         <Flex flexGrow="1" flexDir="column">
           <ModalBody>
             <ResourceDownloader

--- a/src/components/modals/download-specific-resource-modal.tsx
+++ b/src/components/modals/download-specific-resource-modal.tsx
@@ -10,7 +10,6 @@ import {
   Modal,
   ModalBody,
   ModalContent,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   Tag,
@@ -33,6 +32,7 @@ import {
 import { BeatLoader } from "react-spinners";
 import CountTag from "@/components/common/count-tag";
 import Empty from "@/components/common/empty";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { MenuSelector } from "@/components/common/menu-selector";
 import NavMenu from "@/components/common/nav-menu";
 import { OptionItem, OptionItemGroup } from "@/components/common/option-item";
@@ -504,7 +504,7 @@ const DownloadSpecificResourceModal: React.FC<
     >
       <ModalOverlay />
       <ModalContent h="100%" pb={4}>
-        <ModalHeader>
+        <MacosModalHeader>
           {t("DownloadSpecificResourceModal.title", {
             name:
               showZhTrans && resource.translatedName
@@ -512,7 +512,7 @@ const DownloadSpecificResourceModal: React.FC<
                 : resource.name,
             source: resource.source,
           })}
-        </ModalHeader>
+        </MacosModalHeader>
         <WindowsCloseButton onClick={modalProps.onClose} />
         <ModalBody>
           <Card

--- a/src/components/modals/download-specific-resource-modal.tsx
+++ b/src/components/modals/download-specific-resource-modal.tsx
@@ -32,12 +32,12 @@ import {
 import { BeatLoader } from "react-spinners";
 import CountTag from "@/components/common/count-tag";
 import Empty from "@/components/common/empty";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { MenuSelector } from "@/components/common/menu-selector";
 import NavMenu from "@/components/common/nav-menu";
 import { OptionItem, OptionItemGroup } from "@/components/common/option-item";
 import { Section } from "@/components/common/section";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import MCVersionNumberHelper from "@/components/mc-version-number-helper";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
@@ -513,7 +513,7 @@ const DownloadSpecificResourceModal: React.FC<
             source: resource.source,
           })}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={modalProps.onClose} />
+        <MacosCloseButton onClick={modalProps.onClose} />
         <ModalBody>
           <Card
             className={cardStyles["card-front"]}

--- a/src/components/modals/download-specific-resource-modal.tsx
+++ b/src/components/modals/download-specific-resource-modal.tsx
@@ -9,7 +9,6 @@ import {
   Link,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalHeader,
   ModalOverlay,
@@ -38,6 +37,7 @@ import { MenuSelector } from "@/components/common/menu-selector";
 import NavMenu from "@/components/common/nav-menu";
 import { OptionItem, OptionItemGroup } from "@/components/common/option-item";
 import { Section } from "@/components/common/section";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import MCVersionNumberHelper from "@/components/mc-version-number-helper";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
@@ -513,7 +513,7 @@ const DownloadSpecificResourceModal: React.FC<
             source: resource.source,
           })}
         </ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={modalProps.onClose} />
         <ModalBody>
           <Card
             className={cardStyles["card-front"]}

--- a/src/components/modals/edit-game-directory-modal.tsx
+++ b/src/components/modals/edit-game-directory-modal.tsx
@@ -26,8 +26,8 @@ import {
 import { open } from "@tauri-apps/plugin-dialog";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
 import { useRoutingHistory } from "@/contexts/routing-history";
@@ -294,7 +294,7 @@ const EditGameDirectoryModal: React.FC<EditGameDirectoryModalProps> = ({
         <MacosModalHeader>
           {t(`EditGameDirectoryModal.header.title.${add ? "add" : "edit"}`)}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={modalProps.onClose} />
+        <MacosCloseButton onClick={modalProps.onClose} />
 
         <ModalBody>
           <Stack direction="column" spacing={3.5}>

--- a/src/components/modals/edit-game-directory-modal.tsx
+++ b/src/components/modals/edit-game-directory-modal.tsx
@@ -18,7 +18,6 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   Stack,
@@ -27,6 +26,7 @@ import {
 import { open } from "@tauri-apps/plugin-dialog";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
@@ -291,9 +291,9 @@ const EditGameDirectoryModal: React.FC<EditGameDirectoryModalProps> = ({
     >
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>
+        <MacosModalHeader>
           {t(`EditGameDirectoryModal.header.title.${add ? "add" : "edit"}`)}
-        </ModalHeader>
+        </MacosModalHeader>
         <WindowsCloseButton onClick={modalProps.onClose} />
 
         <ModalBody>

--- a/src/components/modals/edit-game-directory-modal.tsx
+++ b/src/components/modals/edit-game-directory-modal.tsx
@@ -16,7 +16,6 @@ import {
   InputRightElement,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -28,6 +27,7 @@ import {
 import { open } from "@tauri-apps/plugin-dialog";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
 import { useRoutingHistory } from "@/contexts/routing-history";
@@ -294,7 +294,7 @@ const EditGameDirectoryModal: React.FC<EditGameDirectoryModalProps> = ({
         <ModalHeader>
           {t(`EditGameDirectoryModal.header.title.${add ? "add" : "edit"}`)}
         </ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={modalProps.onClose} />
 
         <ModalBody>
           <Stack direction="column" spacing={3.5}>

--- a/src/components/modals/export-modpack-modal.tsx
+++ b/src/components/modals/export-modpack-modal.tsx
@@ -25,6 +25,7 @@ import { SiModrinth } from "react-icons/si";
 import { BeatLoader } from "react-spinners";
 import Editable from "@/components/common/editable";
 import Empty from "@/components/common/empty";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import {
   OptionItemGroup,
@@ -32,7 +33,6 @@ import {
 } from "@/components/common/option-item";
 import SegmentedControl from "@/components/common/segmented";
 import TreeView, { TreeNode } from "@/components/common/tree-view";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
 import { ExportModpackFormat } from "@/enums/instance";
@@ -570,7 +570,7 @@ const ExportModpackModal: React.FC<ExportModpackModalProps> = ({
         <MacosModalHeader>
           {t("ExportModpackModal.header.title", { param: instanceName })}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={modalProps.onClose} />
+        <MacosCloseButton onClick={modalProps.onClose} />
         <ModalBody>
           <VStack spacing={4} align="stretch">
             {optionGroups.map((group, index) => (

--- a/src/components/modals/export-modpack-modal.tsx
+++ b/src/components/modals/export-modpack-modal.tsx
@@ -7,7 +7,6 @@ import {
   Icon,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -33,6 +32,7 @@ import {
 } from "@/components/common/option-item";
 import SegmentedControl from "@/components/common/segmented";
 import TreeView, { TreeNode } from "@/components/common/tree-view";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
 import { ExportModpackFormat } from "@/enums/instance";
@@ -570,7 +570,7 @@ const ExportModpackModal: React.FC<ExportModpackModalProps> = ({
         <ModalHeader>
           {t("ExportModpackModal.header.title", { param: instanceName })}
         </ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={modalProps.onClose} />
         <ModalBody>
           <VStack spacing={4} align="stretch">
             {optionGroups.map((group, index) => (

--- a/src/components/modals/export-modpack-modal.tsx
+++ b/src/components/modals/export-modpack-modal.tsx
@@ -9,7 +9,6 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   NumberInput,
@@ -26,6 +25,7 @@ import { SiModrinth } from "react-icons/si";
 import { BeatLoader } from "react-spinners";
 import Editable from "@/components/common/editable";
 import Empty from "@/components/common/empty";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import {
   OptionItemGroup,
   OptionItemGroupProps,
@@ -567,9 +567,9 @@ const ExportModpackModal: React.FC<ExportModpackModalProps> = ({
     >
       <ModalOverlay />
       <ModalContent maxH="calc(100vh - 7.5rem)">
-        <ModalHeader>
+        <MacosModalHeader>
           {t("ExportModpackModal.header.title", { param: instanceName })}
-        </ModalHeader>
+        </MacosModalHeader>
         <WindowsCloseButton onClick={modalProps.onClose} />
         <ModalBody>
           <VStack spacing={4} align="stretch">

--- a/src/components/modals/import-account-info-modal.tsx
+++ b/src/components/modals/import-account-info-modal.tsx
@@ -7,7 +7,6 @@ import {
   HStack,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -25,6 +24,7 @@ import Empty from "@/components/common/empty";
 import { OptionItemGroup } from "@/components/common/option-item";
 import { Section } from "@/components/common/section";
 import SelectableCard from "@/components/common/selectable-card";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import PlayerAvatar from "@/components/player-avatar";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
@@ -248,7 +248,7 @@ const ImportAccountInfoModal: React.FC<ImportAccountInfoModalProps> = ({
       <ModalOverlay />
       <ModalContent h="100%">
         <ModalHeader>{t("ImportAccountInfoModal.header.title")}</ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={props.onClose} />
         <ModalBody overflow="hidden">
           <Grid templateColumns={"3fr 5fr"} gap={4} h="100%">
             <VStack minW="3xs" spacing={3.5} overflowY="auto" align="stretch">

--- a/src/components/modals/import-account-info-modal.tsx
+++ b/src/components/modals/import-account-info-modal.tsx
@@ -9,7 +9,6 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   Text,
@@ -21,6 +20,7 @@ import { useTranslation } from "react-i18next";
 import { LuCircleX, LuTriangleAlert } from "react-icons/lu";
 import { BeatLoader } from "react-spinners";
 import Empty from "@/components/common/empty";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { OptionItemGroup } from "@/components/common/option-item";
 import { Section } from "@/components/common/section";
 import SelectableCard from "@/components/common/selectable-card";
@@ -247,7 +247,9 @@ const ImportAccountInfoModal: React.FC<ImportAccountInfoModalProps> = ({
     >
       <ModalOverlay />
       <ModalContent h="100%">
-        <ModalHeader>{t("ImportAccountInfoModal.header.title")}</ModalHeader>
+        <MacosModalHeader>
+          {t("ImportAccountInfoModal.header.title")}
+        </MacosModalHeader>
         <WindowsCloseButton onClick={props.onClose} />
         <ModalBody overflow="hidden">
           <Grid templateColumns={"3fr 5fr"} gap={4} h="100%">

--- a/src/components/modals/import-account-info-modal.tsx
+++ b/src/components/modals/import-account-info-modal.tsx
@@ -20,11 +20,11 @@ import { useTranslation } from "react-i18next";
 import { LuCircleX, LuTriangleAlert } from "react-icons/lu";
 import { BeatLoader } from "react-spinners";
 import Empty from "@/components/common/empty";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { OptionItemGroup } from "@/components/common/option-item";
 import { Section } from "@/components/common/section";
 import SelectableCard from "@/components/common/selectable-card";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import PlayerAvatar from "@/components/player-avatar";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
@@ -250,7 +250,7 @@ const ImportAccountInfoModal: React.FC<ImportAccountInfoModalProps> = ({
         <MacosModalHeader>
           {t("ImportAccountInfoModal.header.title")}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={props.onClose} />
+        <MacosCloseButton onClick={props.onClose} />
         <ModalBody overflow="hidden">
           <Grid templateColumns={"3fr 5fr"} gap={4} h="100%">
             <VStack minW="3xs" spacing={3.5} overflowY="auto" align="stretch">

--- a/src/components/modals/import-modpack-modal.tsx
+++ b/src/components/modals/import-modpack-modal.tsx
@@ -13,12 +13,12 @@ import { t } from "i18next";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { BeatLoader } from "react-spinners";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import {
   OptionItemGroup,
   OptionItemGroupProps,
 } from "@/components/common/option-item";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { InstanceBasicSettings } from "@/components/instance-basic-settings";
 import {
   gameTypesToIcon,
@@ -202,7 +202,7 @@ const ImportModpackModal: React.FC<ImportModpackModalProps> = ({
         <MacosModalHeader>
           {t("ImportModpackModal.header.title")}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={onClose} />
+        <MacosCloseButton onClick={onClose} />
         <ModalBody h="100%">
           {isPageLoading ? (
             <Center h="100%">

--- a/src/components/modals/import-modpack-modal.tsx
+++ b/src/components/modals/import-modpack-modal.tsx
@@ -5,7 +5,6 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   VStack,
@@ -14,6 +13,7 @@ import { t } from "i18next";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { BeatLoader } from "react-spinners";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import {
   OptionItemGroup,
   OptionItemGroupProps,
@@ -199,7 +199,9 @@ const ImportModpackModal: React.FC<ImportModpackModalProps> = ({
     >
       <ModalOverlay />
       <ModalContent h="100%">
-        <ModalHeader>{t("ImportModpackModal.header.title")}</ModalHeader>
+        <MacosModalHeader>
+          {t("ImportModpackModal.header.title")}
+        </MacosModalHeader>
         <WindowsCloseButton onClick={onClose} />
         <ModalBody h="100%">
           {isPageLoading ? (

--- a/src/components/modals/import-modpack-modal.tsx
+++ b/src/components/modals/import-modpack-modal.tsx
@@ -3,7 +3,6 @@ import {
   Center,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -19,6 +18,7 @@ import {
   OptionItemGroup,
   OptionItemGroupProps,
 } from "@/components/common/option-item";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { InstanceBasicSettings } from "@/components/instance-basic-settings";
 import {
   gameTypesToIcon,
@@ -200,7 +200,7 @@ const ImportModpackModal: React.FC<ImportModpackModalProps> = ({
       <ModalOverlay />
       <ModalContent h="100%">
         <ModalHeader>{t("ImportModpackModal.header.title")}</ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={onClose} />
         <ModalBody h="100%">
           {isPageLoading ? (
             <Center h="100%">

--- a/src/components/modals/launch-process-modal.tsx
+++ b/src/components/modals/launch-process-modal.tsx
@@ -5,7 +5,6 @@ import {
   Icon,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -28,6 +27,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuX } from "react-icons/lu";
 import { BeatLoader } from "react-spinners";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import SelectInstanceModal from "@/components/modals/select-instance-modal";
 import SelectPlayerModal from "@/components/modals/select-player-modal";
 import { useLauncherConfig } from "@/contexts/config";
@@ -353,7 +353,7 @@ const LaunchProcessModal: React.FC<LaunchProcessModalProps> = ({
             name: effectiveInstance?.name,
           })}
         </ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={props.onClose} />
         <ModalBody minH="12rem">
           <Stepper
             index={activeStep}

--- a/src/components/modals/launch-process-modal.tsx
+++ b/src/components/modals/launch-process-modal.tsx
@@ -26,8 +26,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuX } from "react-icons/lu";
 import { BeatLoader } from "react-spinners";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import SelectInstanceModal from "@/components/modals/select-instance-modal";
 import SelectPlayerModal from "@/components/modals/select-player-modal";
 import { useLauncherConfig } from "@/contexts/config";
@@ -353,7 +353,7 @@ const LaunchProcessModal: React.FC<LaunchProcessModalProps> = ({
             name: effectiveInstance?.name,
           })}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={props.onClose} />
+        <MacosCloseButton onClick={props.onClose} />
         <ModalBody minH="12rem">
           <Stepper
             index={activeStep}

--- a/src/components/modals/launch-process-modal.tsx
+++ b/src/components/modals/launch-process-modal.tsx
@@ -7,7 +7,6 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   Step,
@@ -27,6 +26,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuX } from "react-icons/lu";
 import { BeatLoader } from "react-spinners";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import SelectInstanceModal from "@/components/modals/select-instance-modal";
 import SelectPlayerModal from "@/components/modals/select-player-modal";
@@ -348,11 +348,11 @@ const LaunchProcessModal: React.FC<LaunchProcessModalProps> = ({
     >
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>
+        <MacosModalHeader>
           {t("LaunchProcessModal.header.title", {
             name: effectiveInstance?.name,
           })}
-        </ModalHeader>
+        </MacosModalHeader>
         <WindowsCloseButton onClick={props.onClose} />
         <ModalBody minH="12rem">
           <Stepper

--- a/src/components/modals/manage-skin-modal.tsx
+++ b/src/components/modals/manage-skin-modal.tsx
@@ -9,7 +9,6 @@ import {
   Input,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -27,6 +26,7 @@ import { useTranslation } from "react-i18next";
 import { LuFolderOpen } from "react-icons/lu";
 import { AutoSizer } from "react-virtualized";
 import SegmentedControl from "@/components/common/segmented";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import SkinPreview from "@/components/skin-preview";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
@@ -219,7 +219,7 @@ const ManageSkinModal: React.FC<ManageSkinModalProps> = ({
       <ModalOverlay />
       <ModalContent width="100%">
         <ModalHeader>{t("ManageSkinModal.skinManage")}</ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={onClose} />
         <ModalBody width="100%">
           <Grid templateColumns="3fr 2fr" gap={4} h="320px" width="100%">
             <Box width="100%" height="100%">

--- a/src/components/modals/manage-skin-modal.tsx
+++ b/src/components/modals/manage-skin-modal.tsx
@@ -24,9 +24,9 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuFolderOpen } from "react-icons/lu";
 import { AutoSizer } from "react-virtualized";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import SegmentedControl from "@/components/common/segmented";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import SkinPreview from "@/components/skin-preview";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
@@ -219,7 +219,7 @@ const ManageSkinModal: React.FC<ManageSkinModalProps> = ({
       <ModalOverlay />
       <ModalContent width="100%">
         <MacosModalHeader>{t("ManageSkinModal.skinManage")}</MacosModalHeader>
-        <WindowsCloseButton onClick={onClose} />
+        <MacosCloseButton onClick={onClose} />
         <ModalBody width="100%">
           <Grid templateColumns="3fr 2fr" gap={4} h="320px" width="100%">
             <Box width="100%" height="100%">

--- a/src/components/modals/manage-skin-modal.tsx
+++ b/src/components/modals/manage-skin-modal.tsx
@@ -11,7 +11,6 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   Radio,
@@ -25,6 +24,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuFolderOpen } from "react-icons/lu";
 import { AutoSizer } from "react-virtualized";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import SegmentedControl from "@/components/common/segmented";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import SkinPreview from "@/components/skin-preview";
@@ -218,7 +218,7 @@ const ManageSkinModal: React.FC<ManageSkinModalProps> = ({
     >
       <ModalOverlay />
       <ModalContent width="100%">
-        <ModalHeader>{t("ManageSkinModal.skinManage")}</ModalHeader>
+        <MacosModalHeader>{t("ManageSkinModal.skinManage")}</MacosModalHeader>
         <WindowsCloseButton onClick={onClose} />
         <ModalBody width="100%">
           <Grid templateColumns="3fr 2fr" gap={4} h="320px" width="100%">

--- a/src/components/modals/manual-add-java-path-modal.tsx
+++ b/src/components/modals/manual-add-java-path-modal.tsx
@@ -16,8 +16,8 @@ import {
 import { open } from "@tauri-apps/plugin-dialog";
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
 
@@ -87,7 +87,7 @@ const ManualAddJavaPathModal: React.FC<ManualAddJavaPathModalProps> = ({
         <MacosModalHeader>
           {t("ManualAddJavaPathModal.modal.header")}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={props.onClose} />
+        <MacosCloseButton onClick={handleClose} />
         <ModalBody>
           <FormControl isRequired>
             <FormLabel>{t("ManualAddJavaPathModal.label.javaPath")}</FormLabel>

--- a/src/components/modals/manual-add-java-path-modal.tsx
+++ b/src/components/modals/manual-add-java-path-modal.tsx
@@ -10,13 +10,13 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
 } from "@chakra-ui/react";
 import { open } from "@tauri-apps/plugin-dialog";
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
@@ -84,7 +84,9 @@ const ManualAddJavaPathModal: React.FC<ManualAddJavaPathModalProps> = ({
     <Modal {...props} onClose={handleClose}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>{t("ManualAddJavaPathModal.modal.header")}</ModalHeader>
+        <MacosModalHeader>
+          {t("ManualAddJavaPathModal.modal.header")}
+        </MacosModalHeader>
         <WindowsCloseButton onClick={props.onClose} />
         <ModalBody>
           <FormControl isRequired>

--- a/src/components/modals/manual-add-java-path-modal.tsx
+++ b/src/components/modals/manual-add-java-path-modal.tsx
@@ -8,7 +8,6 @@ import {
   InputRightElement,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -18,6 +17,7 @@ import {
 import { open } from "@tauri-apps/plugin-dialog";
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
 
@@ -85,7 +85,7 @@ const ManualAddJavaPathModal: React.FC<ManualAddJavaPathModalProps> = ({
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("ManualAddJavaPathModal.modal.header")}</ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={props.onClose} />
         <ModalBody>
           <FormControl isRequired>
             <FormLabel>{t("ManualAddJavaPathModal.label.javaPath")}</FormLabel>

--- a/src/components/modals/mod-info-modal.tsx
+++ b/src/components/modals/mod-info-modal.tsx
@@ -4,7 +4,6 @@ import {
   HStack,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalOverlay,
@@ -17,6 +16,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuExternalLink } from "react-icons/lu";
 import { OptionItem } from "@/components/common/option-item";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { ModLoaderType } from "@/enums/instance";
 import { OtherResourceSource } from "@/enums/resource";
@@ -107,7 +107,7 @@ const ModInfoModal: React.FC<ModInfoModalProps> = ({
     <Modal size={{ base: "md", lg: "lg", xl: "xl" }} {...modalProps}>
       <ModalOverlay />
       <ModalContent>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={modalProps.onClose} />
         <ModalBody mt={2}>
           <OptionItem
             title={

--- a/src/components/modals/mod-info-modal.tsx
+++ b/src/components/modals/mod-info-modal.tsx
@@ -15,8 +15,8 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuExternalLink } from "react-icons/lu";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { OptionItem } from "@/components/common/option-item";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { ModLoaderType } from "@/enums/instance";
 import { OtherResourceSource } from "@/enums/resource";
@@ -107,7 +107,7 @@ const ModInfoModal: React.FC<ModInfoModalProps> = ({
     <Modal size={{ base: "md", lg: "lg", xl: "xl" }} {...modalProps}>
       <ModalOverlay />
       <ModalContent>
-        <WindowsCloseButton onClick={modalProps.onClose} />
+        <MacosCloseButton onClick={modalProps.onClose} />
         <ModalBody mt={2}>
           <OptionItem
             title={

--- a/src/components/modals/notify-new-version-modal.tsx
+++ b/src/components/modals/notify-new-version-modal.tsx
@@ -4,7 +4,6 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
 } from "@chakra-ui/react";
@@ -12,6 +11,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { useRouter } from "next/router";
 import { useTranslation } from "react-i18next";
 import { LuExternalLink } from "react-icons/lu";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import MarkdownContainer from "@/components/common/markdown-container";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
@@ -72,7 +72,7 @@ const NotifyNewVersionModal: React.FC<NotifyNewVersionModalProps> = ({
     <Modal scrollBehavior="inside" size="xl" {...props}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>{`${t("NotifyNewVersionModal.title")} - ${newVersion.version}`}</ModalHeader>
+        <MacosModalHeader>{`${t("NotifyNewVersionModal.title")} - ${newVersion.version}`}</MacosModalHeader>
         <WindowsCloseButton onClick={props.onClose} />
         <ModalBody>
           <MarkdownContainer>

--- a/src/components/modals/notify-new-version-modal.tsx
+++ b/src/components/modals/notify-new-version-modal.tsx
@@ -2,7 +2,6 @@ import {
   Button,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -14,6 +13,7 @@ import { useRouter } from "next/router";
 import { useTranslation } from "react-i18next";
 import { LuExternalLink } from "react-icons/lu";
 import MarkdownContainer from "@/components/common/markdown-container";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
 import { VersionMetaInfo } from "@/models/config";
@@ -73,7 +73,7 @@ const NotifyNewVersionModal: React.FC<NotifyNewVersionModalProps> = ({
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{`${t("NotifyNewVersionModal.title")} - ${newVersion.version}`}</ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={props.onClose} />
         <ModalBody>
           <MarkdownContainer>
             {processReleaseNotes(newVersion.releaseNotes || "")}

--- a/src/components/modals/notify-new-version-modal.tsx
+++ b/src/components/modals/notify-new-version-modal.tsx
@@ -11,9 +11,9 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { useRouter } from "next/router";
 import { useTranslation } from "react-i18next";
 import { LuExternalLink } from "react-icons/lu";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import MarkdownContainer from "@/components/common/markdown-container";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
 import { VersionMetaInfo } from "@/models/config";
@@ -73,7 +73,7 @@ const NotifyNewVersionModal: React.FC<NotifyNewVersionModalProps> = ({
       <ModalOverlay />
       <ModalContent>
         <MacosModalHeader>{`${t("NotifyNewVersionModal.title")} - ${newVersion.version}`}</MacosModalHeader>
-        <WindowsCloseButton onClick={props.onClose} />
+        <MacosCloseButton onClick={props.onClose} />
         <ModalBody>
           <MarkdownContainer>
             {processReleaseNotes(newVersion.releaseNotes || "")}

--- a/src/components/modals/preview-screenshot-modal.tsx
+++ b/src/components/modals/preview-screenshot-modal.tsx
@@ -16,7 +16,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { LuCalendarDays, LuImagePlay } from "react-icons/lu";
 import { CommonIconButton } from "@/components/common/common-icon-button";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
 import { ScreenshotInfo } from "@/models/instance/misc";
@@ -94,7 +94,7 @@ const PreviewScreenshotModal: React.FC<PreviewScreenshotModalProps> = ({
           borderRadius="md"
           objectFit="cover"
         />
-        <WindowsCloseButton onClick={props.onClose} />
+        <MacosCloseButton onClick={props.onClose} />
         <ModalBody>
           <Flex justify="space-between" align="center">
             <Text fontSize="sm" fontWeight="bold">

--- a/src/components/modals/preview-screenshot-modal.tsx
+++ b/src/components/modals/preview-screenshot-modal.tsx
@@ -5,7 +5,6 @@ import {
   Image,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalOverlay,
   ModalProps,
@@ -17,6 +16,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { LuCalendarDays, LuImagePlay } from "react-icons/lu";
 import { CommonIconButton } from "@/components/common/common-icon-button";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
 import { ScreenshotInfo } from "@/models/instance/misc";
@@ -94,7 +94,7 @@ const PreviewScreenshotModal: React.FC<PreviewScreenshotModalProps> = ({
           borderRadius="md"
           objectFit="cover"
         />
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={props.onClose} />
         <ModalBody>
           <Flex justify="space-between" align="center">
             <Text fontSize="sm" fontWeight="bold">

--- a/src/components/modals/relogin-player-modal.tsx
+++ b/src/components/modals/relogin-player-modal.tsx
@@ -5,7 +5,6 @@ import {
   Input,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -17,6 +16,7 @@ import {
 import { openUrl } from "@tauri-apps/plugin-opener";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import OAuthLoginPanel from "@/components/oauth-login-panel";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
@@ -128,7 +128,7 @@ const ReLoginPlayerModal: React.FC<ReLoginPlayerModalProps> = ({
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("ReLoginPlayerModal.modal.title")}</ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={props.onClose} />
         <ModalBody>
           <VStack spacing={3.5} align="flex-start">
             {isOAuth ? (

--- a/src/components/modals/relogin-player-modal.tsx
+++ b/src/components/modals/relogin-player-modal.tsx
@@ -15,8 +15,8 @@ import {
 import { openUrl } from "@tauri-apps/plugin-opener";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import OAuthLoginPanel from "@/components/oauth-login-panel";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
@@ -130,7 +130,7 @@ const ReLoginPlayerModal: React.FC<ReLoginPlayerModalProps> = ({
         <MacosModalHeader>
           {t("ReLoginPlayerModal.modal.title")}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={props.onClose} />
+        <MacosCloseButton onClick={handleCloseModal} />
         <ModalBody>
           <VStack spacing={3.5} align="flex-start">
             {isOAuth ? (

--- a/src/components/modals/relogin-player-modal.tsx
+++ b/src/components/modals/relogin-player-modal.tsx
@@ -7,7 +7,6 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   Text,
@@ -16,6 +15,7 @@ import {
 import { openUrl } from "@tauri-apps/plugin-opener";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import OAuthLoginPanel from "@/components/oauth-login-panel";
 import { useLauncherConfig } from "@/contexts/config";
@@ -127,7 +127,9 @@ const ReLoginPlayerModal: React.FC<ReLoginPlayerModalProps> = ({
     <Modal {...props} onClose={handleCloseModal}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>{t("ReLoginPlayerModal.modal.title")}</ModalHeader>
+        <MacosModalHeader>
+          {t("ReLoginPlayerModal.modal.title")}
+        </MacosModalHeader>
         <WindowsCloseButton onClick={props.onClose} />
         <ModalBody>
           <VStack spacing={3.5} align="flex-start">

--- a/src/components/modals/select-instance-modal.tsx
+++ b/src/components/modals/select-instance-modal.tsx
@@ -1,7 +1,6 @@
 import {
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -9,6 +8,7 @@ import {
   ModalProps,
 } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import InstancesView from "@/components/instances-view";
 import { InstanceSummary } from "@/models/instance/misc";
 
@@ -35,7 +35,7 @@ const SelectInstanceModal: React.FC<SelectInstanceModalProps> = ({
         <ModalHeader>
           {modalTitle || t("SelectInstanceModal.header.title")}
         </ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={modalProps.onClose} />
         <ModalBody display="flex" flexDir="column" flex="1">
           <InstancesView
             instances={candidateInstances}

--- a/src/components/modals/select-instance-modal.tsx
+++ b/src/components/modals/select-instance-modal.tsx
@@ -3,11 +3,11 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
 } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import InstancesView from "@/components/instances-view";
 import { InstanceSummary } from "@/models/instance/misc";
@@ -32,9 +32,9 @@ const SelectInstanceModal: React.FC<SelectInstanceModalProps> = ({
     <Modal scrollBehavior="inside" {...modalProps}>
       <ModalOverlay />
       <ModalContent maxH="calc(100vh - 7.5rem)">
-        <ModalHeader>
+        <MacosModalHeader>
           {modalTitle || t("SelectInstanceModal.header.title")}
-        </ModalHeader>
+        </MacosModalHeader>
         <WindowsCloseButton onClick={modalProps.onClose} />
         <ModalBody display="flex" flexDir="column" flex="1">
           <InstancesView

--- a/src/components/modals/select-instance-modal.tsx
+++ b/src/components/modals/select-instance-modal.tsx
@@ -7,8 +7,8 @@ import {
   ModalProps,
 } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import InstancesView from "@/components/instances-view";
 import { InstanceSummary } from "@/models/instance/misc";
 
@@ -35,7 +35,7 @@ const SelectInstanceModal: React.FC<SelectInstanceModalProps> = ({
         <MacosModalHeader>
           {modalTitle || t("SelectInstanceModal.header.title")}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={modalProps.onClose} />
+        <MacosCloseButton onClick={modalProps.onClose} />
         <ModalBody display="flex" flexDir="column" flex="1">
           <InstancesView
             instances={candidateInstances}

--- a/src/components/modals/select-player-modal.tsx
+++ b/src/components/modals/select-player-modal.tsx
@@ -1,7 +1,6 @@
 import {
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -9,6 +8,7 @@ import {
   ModalProps,
 } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import PlayersView from "@/components/players-view";
 import { Player } from "@/models/account";
 
@@ -35,7 +35,7 @@ const SelectPlayerModal: React.FC<SelectPlayerModalProps> = ({
         <ModalHeader>
           {modalTitle || t("SelectPlayerModal.header.title")}
         </ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={modalProps.onClose} />
         <ModalBody display="flex" flexDir="column" flex="1" minH={0}>
           <PlayersView
             players={candidatePlayers}

--- a/src/components/modals/select-player-modal.tsx
+++ b/src/components/modals/select-player-modal.tsx
@@ -7,8 +7,8 @@ import {
   ModalProps,
 } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import PlayersView from "@/components/players-view";
 import { Player } from "@/models/account";
 
@@ -35,7 +35,7 @@ const SelectPlayerModal: React.FC<SelectPlayerModalProps> = ({
         <MacosModalHeader>
           {modalTitle || t("SelectPlayerModal.header.title")}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={modalProps.onClose} />
+        <MacosCloseButton onClick={modalProps.onClose} />
         <ModalBody display="flex" flexDir="column" flex="1" minH={0}>
           <PlayersView
             players={candidatePlayers}

--- a/src/components/modals/select-player-modal.tsx
+++ b/src/components/modals/select-player-modal.tsx
@@ -3,11 +3,11 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
 } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import PlayersView from "@/components/players-view";
 import { Player } from "@/models/account";
@@ -32,9 +32,9 @@ const SelectPlayerModal: React.FC<SelectPlayerModalProps> = ({
     <Modal scrollBehavior="inside" {...modalProps}>
       <ModalOverlay />
       <ModalContent maxH="calc(100vh - 7.5rem)">
-        <ModalHeader>
+        <MacosModalHeader>
           {modalTitle || t("SelectPlayerModal.header.title")}
-        </ModalHeader>
+        </MacosModalHeader>
         <WindowsCloseButton onClick={modalProps.onClose} />
         <ModalBody display="flex" flexDir="column" flex="1" minH={0}>
           <PlayersView

--- a/src/components/modals/spotlight-search-modal.tsx
+++ b/src/components/modals/spotlight-search-modal.tsx
@@ -11,7 +11,6 @@ import {
   Modal,
   ModalBody,
   ModalContent,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   Spinner,
@@ -26,6 +25,7 @@ import { LuSearch } from "react-icons/lu";
 import stringSimilarity from "string-similarity";
 import CountTag from "@/components/common/count-tag";
 import Empty from "@/components/common/empty";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { OptionItem, OptionItemGroup } from "@/components/common/option-item";
 import PlayerAvatar from "@/components/player-avatar";
 import { useLauncherConfig } from "@/contexts/config";
@@ -473,7 +473,7 @@ const SpotlightSearchModal: React.FC<Omit<ModalProps, "children">> = ({
     <Modal scrollBehavior="inside" {...props}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>
+        <MacosModalHeader>
           <InputGroup size="md">
             <InputLeftElement pointerEvents="none" h="100%" w="auto">
               {isSearching ? <Spinner size="sm" /> : <LuSearch />}
@@ -499,7 +499,7 @@ const SpotlightSearchModal: React.FC<Omit<ModalProps, "children">> = ({
               }}
             />
           </InputGroup>
-        </ModalHeader>
+        </MacosModalHeader>
         <Divider />
         <ModalBody minH="8rem" overflowY="auto">
           {!queryText && (

--- a/src/components/modals/star-us-modal.tsx
+++ b/src/components/modals/star-us-modal.tsx
@@ -4,13 +4,13 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   Text,
 } from "@chakra-ui/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useTranslation } from "react-i18next";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 
 const StarUsModal: React.FC<Omit<ModalProps, "children">> = ({ ...props }) => {
@@ -28,7 +28,9 @@ const StarUsModal: React.FC<Omit<ModalProps, "children">> = ({ ...props }) => {
         <video autoPlay loop muted width="100%" height="auto">
           <source src="/videos/star-3-2.mp4" type="video/mp4" />
         </video>
-        <ModalHeader>🌟&nbsp;&nbsp;{t("StarUsModal.header.title")}</ModalHeader>
+        <MacosModalHeader>
+          🌟&nbsp;&nbsp;{t("StarUsModal.header.title")}
+        </MacosModalHeader>
         <WindowsCloseButton onClick={props.onClose} />
         <ModalBody mt={-1}>
           <Text color="gray.500">{t("StarUsModal.body")}</Text>

--- a/src/components/modals/star-us-modal.tsx
+++ b/src/components/modals/star-us-modal.tsx
@@ -10,8 +10,8 @@ import {
 } from "@chakra-ui/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useTranslation } from "react-i18next";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 
 const StarUsModal: React.FC<Omit<ModalProps, "children">> = ({ ...props }) => {
   const { t } = useTranslation();
@@ -31,7 +31,7 @@ const StarUsModal: React.FC<Omit<ModalProps, "children">> = ({ ...props }) => {
         <MacosModalHeader>
           🌟&nbsp;&nbsp;{t("StarUsModal.header.title")}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={props.onClose} />
+        <MacosCloseButton onClick={props.onClose} />
         <ModalBody mt={-1}>
           <Text color="gray.500">{t("StarUsModal.body")}</Text>
         </ModalBody>

--- a/src/components/modals/star-us-modal.tsx
+++ b/src/components/modals/star-us-modal.tsx
@@ -2,7 +2,6 @@ import {
   Button,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -12,6 +11,7 @@ import {
 } from "@chakra-ui/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useTranslation } from "react-i18next";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 
 const StarUsModal: React.FC<Omit<ModalProps, "children">> = ({ ...props }) => {
   const { t } = useTranslation();
@@ -29,7 +29,7 @@ const StarUsModal: React.FC<Omit<ModalProps, "children">> = ({ ...props }) => {
           <source src="/videos/star-3-2.mp4" type="video/mp4" />
         </video>
         <ModalHeader>🌟&nbsp;&nbsp;{t("StarUsModal.header.title")}</ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={props.onClose} />
         <ModalBody mt={-1}>
           <Text color="gray.500">{t("StarUsModal.body")}</Text>
         </ModalBody>

--- a/src/components/modals/sync-config-modals.tsx
+++ b/src/components/modals/sync-config-modals.tsx
@@ -10,7 +10,6 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   PinInput,
@@ -19,6 +18,7 @@ import {
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
@@ -91,7 +91,9 @@ export const SyncConfigExportModal: React.FC<SyncConfigModalProps> = ({
     >
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>{t("SyncConfigExportModal.header.title")}</ModalHeader>
+        <MacosModalHeader>
+          {t("SyncConfigExportModal.header.title")}
+        </MacosModalHeader>
         <WindowsCloseButton onClick={handleCloseModal} />
         <ModalBody>
           <FormControl>
@@ -169,7 +171,9 @@ export const SyncConfigImportModal: React.FC<SyncConfigModalProps> = ({
     >
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>{t("SyncConfigImportModal.header.title")}</ModalHeader>
+        <MacosModalHeader>
+          {t("SyncConfigImportModal.header.title")}
+        </MacosModalHeader>
         <WindowsCloseButton onClick={handleCloseModal} />
         <ModalBody>
           <FormControl>

--- a/src/components/modals/sync-config-modals.tsx
+++ b/src/components/modals/sync-config-modals.tsx
@@ -18,8 +18,8 @@ import {
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
 import { ConfigService } from "@/services/config";
@@ -94,7 +94,7 @@ export const SyncConfigExportModal: React.FC<SyncConfigModalProps> = ({
         <MacosModalHeader>
           {t("SyncConfigExportModal.header.title")}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={handleCloseModal} />
+        <MacosCloseButton onClick={handleCloseModal} />
         <ModalBody>
           <FormControl>
             <FormLabel>{t("SyncConfigExportModal.label.token")}</FormLabel>
@@ -174,7 +174,7 @@ export const SyncConfigImportModal: React.FC<SyncConfigModalProps> = ({
         <MacosModalHeader>
           {t("SyncConfigImportModal.header.title")}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={handleCloseModal} />
+        <MacosCloseButton onClick={handleCloseModal} />
         <ModalBody>
           <FormControl>
             <FormLabel>{t("SyncConfigImportModal.label.token")}</FormLabel>

--- a/src/components/modals/sync-config-modals.tsx
+++ b/src/components/modals/sync-config-modals.tsx
@@ -8,7 +8,6 @@ import {
   Heading,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -20,6 +19,7 @@ import {
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
 import { ConfigService } from "@/services/config";
@@ -92,7 +92,7 @@ export const SyncConfigExportModal: React.FC<SyncConfigModalProps> = ({
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("SyncConfigExportModal.header.title")}</ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={handleCloseModal} />
         <ModalBody>
           <FormControl>
             <FormLabel>{t("SyncConfigExportModal.label.token")}</FormLabel>
@@ -170,7 +170,7 @@ export const SyncConfigImportModal: React.FC<SyncConfigModalProps> = ({
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("SyncConfigImportModal.header.title")}</ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={handleCloseModal} />
         <ModalBody>
           <FormControl>
             <FormLabel>{t("SyncConfigImportModal.label.token")}</FormLabel>

--- a/src/components/modals/view-schematic-modal.tsx
+++ b/src/components/modals/view-schematic-modal.tsx
@@ -2,13 +2,13 @@ import {
   Flex,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalHeader,
   ModalOverlay,
   ModalProps,
 } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 
 interface ViewSchematicModalProps extends Omit<ModalProps, "children"> {
   fileUrl?: string;
@@ -27,7 +27,7 @@ const ViewSchematicModal: React.FC<ViewSchematicModalProps> = ({
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("ViewSchematicModal.header.title")}</ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={onClose} />
         <ModalBody pb={4}>
           <Flex justify="center" align="center" width="100%" height="100%">
             {/* TODO */}

--- a/src/components/modals/view-schematic-modal.tsx
+++ b/src/components/modals/view-schematic-modal.tsx
@@ -3,11 +3,11 @@ import {
   Modal,
   ModalBody,
   ModalContent,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
 } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 
 interface ViewSchematicModalProps extends Omit<ModalProps, "children"> {
@@ -26,7 +26,9 @@ const ViewSchematicModal: React.FC<ViewSchematicModalProps> = ({
     <Modal isOpen={isOpen} onClose={onClose} size="md" {...modalProps}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>{t("ViewSchematicModal.header.title")}</ModalHeader>
+        <MacosModalHeader>
+          {t("ViewSchematicModal.header.title")}
+        </MacosModalHeader>
         <WindowsCloseButton onClick={onClose} />
         <ModalBody pb={4}>
           <Flex justify="center" align="center" width="100%" height="100%">

--- a/src/components/modals/view-schematic-modal.tsx
+++ b/src/components/modals/view-schematic-modal.tsx
@@ -7,8 +7,8 @@ import {
   ModalProps,
 } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 
 interface ViewSchematicModalProps extends Omit<ModalProps, "children"> {
   fileUrl?: string;
@@ -29,7 +29,7 @@ const ViewSchematicModal: React.FC<ViewSchematicModalProps> = ({
         <MacosModalHeader>
           {t("ViewSchematicModal.header.title")}
         </MacosModalHeader>
-        <WindowsCloseButton onClick={onClose} />
+        <MacosCloseButton onClick={onClose} />
         <ModalBody pb={4}>
           <Flex justify="center" align="center" width="100%" height="100%">
             {/* TODO */}

--- a/src/components/modals/view-skin-modal.tsx
+++ b/src/components/modals/view-skin-modal.tsx
@@ -8,8 +8,8 @@ import {
 } from "@chakra-ui/react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import SkinPreview from "@/components/skin-preview";
 import { Texture } from "@/models/account";
 import { base64ImgSrc } from "@/utils/string";
@@ -34,7 +34,7 @@ const ViewSkinModal: React.FC<ViewSkinModalProps> = ({
       <ModalOverlay />
       <ModalContent>
         <MacosModalHeader>{t("ViewSkinModal.skinView")}</MacosModalHeader>
-        <WindowsCloseButton onClick={onClose} />
+        <MacosCloseButton onClick={onClose} />
         <ModalBody pb={6}>
           <Flex justify="center" align="center" width="100%" height="100%">
             <SkinPreview

--- a/src/components/modals/view-skin-modal.tsx
+++ b/src/components/modals/view-skin-modal.tsx
@@ -2,7 +2,6 @@ import {
   Flex,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalHeader,
   ModalOverlay,
@@ -10,6 +9,7 @@ import {
 } from "@chakra-ui/react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import SkinPreview from "@/components/skin-preview";
 import { Texture } from "@/models/account";
 import { base64ImgSrc } from "@/utils/string";
@@ -34,7 +34,7 @@ const ViewSkinModal: React.FC<ViewSkinModalProps> = ({
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("ViewSkinModal.skinView")}</ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={onClose} />
         <ModalBody pb={6}>
           <Flex justify="center" align="center" width="100%" height="100%">
             <SkinPreview

--- a/src/components/modals/view-skin-modal.tsx
+++ b/src/components/modals/view-skin-modal.tsx
@@ -3,12 +3,12 @@ import {
   Modal,
   ModalBody,
   ModalContent,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
 } from "@chakra-ui/react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import SkinPreview from "@/components/skin-preview";
 import { Texture } from "@/models/account";
@@ -33,7 +33,7 @@ const ViewSkinModal: React.FC<ViewSkinModalProps> = ({
     <Modal isOpen={isOpen} onClose={onClose} size="md" {...modalProps}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>{t("ViewSkinModal.skinView")}</ModalHeader>
+        <MacosModalHeader>{t("ViewSkinModal.skinView")}</MacosModalHeader>
         <WindowsCloseButton onClick={onClose} />
         <ModalBody pb={6}>
           <Flex justify="center" align="center" width="100%" height="100%">

--- a/src/components/modals/welcome-and-terms-modal.tsx
+++ b/src/components/modals/welcome-and-terms-modal.tsx
@@ -9,7 +9,6 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   Text,
@@ -18,6 +17,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { exit } from "@tauri-apps/plugin-process";
 import { Trans, useTranslation } from "react-i18next";
 import { LuLanguages } from "react-icons/lu";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import LanguageMenu from "@/components/language-menu";
 import { useGuidedTour } from "@/components/special/guided-tour-provider";
 import { useLauncherConfig } from "@/contexts/config";
@@ -58,9 +58,9 @@ const WelcomeAndTermsModal: React.FC<Omit<ModalProps, "children">> = ({
       <ModalOverlay />
       <ModalContent borderRadius="md" overflow="hidden">
         <Image alt="banner" src="/images/banner.png" />
-        <ModalHeader>
+        <MacosModalHeader>
           🎉&nbsp;&nbsp;{t("WelcomeAndTermsModal.header.title")}
-        </ModalHeader>
+        </MacosModalHeader>
         <ModalBody mt={-1}>
           <Text color="gray.500">
             <Trans

--- a/src/components/modals/world-level-data-modal.tsx
+++ b/src/components/modals/world-level-data-modal.tsx
@@ -6,7 +6,6 @@ import {
   ModalBody,
   ModalContent,
   ModalFooter,
-  ModalHeader,
   ModalOverlay,
   ModalProps,
   Text,
@@ -15,6 +14,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { BeatLoader } from "react-spinners";
 import Empty from "@/components/common/empty";
+import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import TreeView, {
   StructTreeNodeData,
   buildStructTreeNodes,
@@ -87,12 +87,12 @@ const WorldLevelDataModal: React.FC<WorldLevelDataModalProps> = ({
     >
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>
+        <MacosModalHeader>
           <HStack>
             <Text>{t("WorldLevelDataModal.header.title", { worldName })}</Text>
             <Badge colorScheme="purple">Beta</Badge>
           </HStack>
-        </ModalHeader>
+        </MacosModalHeader>
         <WindowsCloseButton onClick={onClose} />
 
         <ModalBody className="allow-select">

--- a/src/components/modals/world-level-data-modal.tsx
+++ b/src/components/modals/world-level-data-modal.tsx
@@ -4,7 +4,6 @@ import {
   HStack,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -20,6 +19,7 @@ import TreeView, {
   StructTreeNodeData,
   buildStructTreeNodes,
 } from "@/components/common/tree-view";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useToast } from "@/contexts/toast";
 import { LevelData } from "@/models/instance/world";
 import { InstanceService } from "@/services/instance";
@@ -93,7 +93,7 @@ const WorldLevelDataModal: React.FC<WorldLevelDataModalProps> = ({
             <Badge colorScheme="purple">Beta</Badge>
           </HStack>
         </ModalHeader>
-        <ModalCloseButton />
+        <WindowsCloseButton onClick={onClose} />
 
         <ModalBody className="allow-select">
           {levelData && (

--- a/src/components/modals/world-level-data-modal.tsx
+++ b/src/components/modals/world-level-data-modal.tsx
@@ -14,12 +14,12 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { BeatLoader } from "react-spinners";
 import Empty from "@/components/common/empty";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { MacosModalHeader } from "@/components/common/macos-modal-header";
 import TreeView, {
   StructTreeNodeData,
   buildStructTreeNodes,
 } from "@/components/common/tree-view";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useToast } from "@/contexts/toast";
 import { LevelData } from "@/models/instance/world";
 import { InstanceService } from "@/services/instance";
@@ -93,7 +93,7 @@ const WorldLevelDataModal: React.FC<WorldLevelDataModalProps> = ({
             <Badge colorScheme="purple">Beta</Badge>
           </HStack>
         </MacosModalHeader>
-        <WindowsCloseButton onClick={onClose} />
+        <MacosCloseButton onClick={onClose} />
 
         <ModalBody className="allow-select">
           {levelData && (

--- a/src/components/special/guided-tour-provider.tsx
+++ b/src/components/special/guided-tour-provider.tsx
@@ -6,7 +6,6 @@ import {
   Kbd,
   Modal,
   ModalBody,
-  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
@@ -31,6 +30,7 @@ import React, {
   useState,
 } from "react";
 import { Trans, useTranslation } from "react-i18next";
+import { WindowsCloseButton } from "@/components/common/windows-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 
 export type Placement = "top" | "right" | "bottom" | "left";
@@ -385,7 +385,7 @@ export const GuidedTourProvider: React.FC<TourProviderProps> = ({
               transitionTimingFunction: "cubic-bezier(.2,.8,.2,1)",
             }}
           >
-            <ModalCloseButton />
+            <WindowsCloseButton onClick={close} />
 
             <ModalHeader>{current?.title ?? `Step ${index + 1}`}</ModalHeader>
 

--- a/src/components/special/guided-tour-provider.tsx
+++ b/src/components/special/guided-tour-provider.tsx
@@ -30,7 +30,7 @@ import React, {
   useState,
 } from "react";
 import { Trans, useTranslation } from "react-i18next";
-import { WindowsCloseButton } from "@/components/common/windows-close-button";
+import { MacosCloseButton } from "@/components/common/macos-close-button";
 import { useLauncherConfig } from "@/contexts/config";
 
 export type Placement = "top" | "right" | "bottom" | "left";
@@ -385,7 +385,7 @@ export const GuidedTourProvider: React.FC<TourProviderProps> = ({
               transitionTimingFunction: "cubic-bezier(.2,.8,.2,1)",
             }}
           >
-            <WindowsCloseButton onClick={close} />
+            <MacosCloseButton onClick={close} />
 
             <ModalHeader>{current?.title ?? `Step ${index + 1}`}</ModalHeader>
 

--- a/src/styles/chakra-theme.ts
+++ b/src/styles/chakra-theme.ts
@@ -119,7 +119,6 @@ const chakraExtendTheme = extendTheme({
             paddingBottom: 2,
             userSelect: "none",
             cursor: "default",
-            textAlign: "center",
           },
           footer: {
             fontSize: "sm",

--- a/src/styles/chakra-theme.ts
+++ b/src/styles/chakra-theme.ts
@@ -113,13 +113,12 @@ const chakraExtendTheme = extendTheme({
         dialog: {
           header: {
             fontSize: "md",
-            paddingLeft: 6,
+            paddingLeft: 4,
             paddingRight: 8, // reserve space for close button (issue#1312)
             paddingTop: 3,
             paddingBottom: 2,
             userSelect: "none",
             cursor: "default",
-            textAlign: "center",
           },
           footer: {
             fontSize: "sm",

--- a/src/styles/chakra-theme.ts
+++ b/src/styles/chakra-theme.ts
@@ -119,6 +119,7 @@ const chakraExtendTheme = extendTheme({
             paddingBottom: 2,
             userSelect: "none",
             cursor: "default",
+            textAlign: "center",
           },
           footer: {
             fontSize: "sm",

--- a/src/styles/chakra-theme.ts
+++ b/src/styles/chakra-theme.ts
@@ -113,12 +113,13 @@ const chakraExtendTheme = extendTheme({
         dialog: {
           header: {
             fontSize: "md",
-            paddingLeft: 4,
+            paddingLeft: 6,
             paddingRight: 8, // reserve space for close button (issue#1312)
             paddingTop: 3,
             paddingBottom: 2,
             userSelect: "none",
             cursor: "default",
+            textAlign: "center",
           },
           footer: {
             fontSize: "sm",

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,0 +1,3 @@
+export const isMacPlatform = (osType: string): boolean => {
+  return osType === "macos" || osType === "darwin";
+};


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)



### Description

> Added macOS-style close button (the red circle on the left side) on the modals.
> Changed the modal title centered.
> These changes only work for macOS.

## Summary by Sourcery

Adopt macOS-specific modal styling by introducing shared components for a macOS-style close button and adaptive modal headers, and update existing modals to use these components while keeping existing behavior on non-macOS platforms.

New Features:
- Add a macOS-style circular close button component for modals that is used on macOS and falls back to the default close button on other platforms.

Enhancements:
- Introduce a shared modal header component that centers titles on macOS while preserving left-aligned titles on other platforms, and apply it across existing modals for consistent styling.
- Add a small platform utility to detect macOS from the configured OS type for use in platform-specific UI behavior.