### PR TITLE
fix(frontend): reset oauth state when auth source change in the add player modal

### DIFF
--- a/src/components/modals/add-player-modal.tsx
+++ b/src/components/modals/add-player-modal.tsx
@@ -89,8 +89,10 @@ const AddPlayerModal: React.FC<AddPlayerModalProps> = ({
   const [showAdvancedOptions, setShowAdvancedOptions] =
     useState<boolean>(false);
   const [candidatePlayers, setCandidatePlayers] = useState<Player[]>([]);
+  const [isOAuthSubmitting, setIsOAuthSubmitting] = useState<boolean>(false);
 
   const initialRef = useRef<HTMLInputElement>(null);
+  const oauthRequestIdRef = useRef(0);
 
   const {
     isOpen: isSelectPlayerModalOpen,
@@ -142,13 +144,25 @@ const AddPlayerModal: React.FC<AddPlayerModalProps> = ({
     setPassword("");
     setShowAdvancedOptions(false);
     setUuid("");
+    setIsOAuthSubmitting(false);
 
     AccountService.cancelOAuth();
   }, [modalProps.isOpen]);
 
   useEffect(() => {
+    if (isOAuthSubmitting) return;
+
+    oauthRequestIdRef.current += 1;
     setOAuthCodeResponse(undefined);
-  }, [showOAuth, playerType, modalProps.isOpen]);
+    setIsLoading(false);
+    AccountService.cancelOAuth();
+  }, [
+    showOAuth,
+    playerType,
+    modalProps.isOpen,
+    authServer?.authUrl,
+    isOAuthSubmitting,
+  ]);
 
   useEffect(() => {
     setCandidatePlayers([]);
@@ -166,10 +180,14 @@ const AddPlayerModal: React.FC<AddPlayerModalProps> = ({
 
   const handleFetchOAuthCode = () => {
     if (playerType === PlayerType.Offline) return;
+    setIsOAuthSubmitting(false);
+    const requestId = ++oauthRequestIdRef.current;
     setOAuthCodeResponse(undefined);
     setIsLoading(true);
     AccountService.fetchOAuthCode(playerType, authServer?.authUrl).then(
       (response) => {
+        if (requestId !== oauthRequestIdRef.current) return;
+
         if (response.status === "success") {
           setOAuthCodeResponse(response.data);
         } else {
@@ -232,6 +250,7 @@ const AddPlayerModal: React.FC<AddPlayerModalProps> = ({
           );
       } else {
         if (!oauthCodeResponse) return;
+        setIsOAuthSubmitting(true);
         openUrl(oauthCodeResponse.verificationUri);
         loginServiceFunction = () =>
           AccountService.addPlayerOAuth(
@@ -243,13 +262,17 @@ const AddPlayerModal: React.FC<AddPlayerModalProps> = ({
 
       setIsLoading(true);
 
-      loginServiceFunction().then((response) => {
-        if (response.status === "success") {
-          afterLogin(response);
-        } else {
-          afterFailure(response);
-        }
-      });
+      loginServiceFunction()
+        .then((response) => {
+          if (response.status === "success") {
+            afterLogin(response);
+          } else {
+            afterFailure(response);
+          }
+        })
+        .finally(() => {
+          if (isOAuth) setIsOAuthSubmitting(false);
+        });
     }
   };
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

fix #1498 

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Reset and isolate OAuth flow state in the Add Player modal to prevent stale or conflicting OAuth operations when auth configuration changes.

Bug Fixes:
- Prevent stale or overlapping OAuth requests from affecting the Add Player modal when the auth source or configuration changes by cancelling in‑flight requests and resetting state appropriately.

Enhancements:
- Track OAuth submission state and ignore out-of-date OAuth responses using request IDs, ensuring only the latest OAuth flow affects the UI state.