### PR TITLE
feat(home-widget): add collapse functionality to home widgets

### DIFF
--- a/src/components/extension/home-widget-container.tsx
+++ b/src/components/extension/home-widget-container.tsx
@@ -23,8 +23,11 @@ const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
   const [widgetWidthMap, setWidgetWidthMap] = useState<Record<string, number>>(
     {}
   );
+  const [widgetCollapsedMap, setWidgetCollapsedMap] = useState<
+    Record<string, boolean>
+  >({});
 
-  // hydrate widget widths from extension host state so they survive page remounts.
+  // hydrate widget widths and collapsed state from extension host state so they survive page remounts.
   useEffect(() => {
     if (widgets.length === 0) return;
 
@@ -36,6 +39,19 @@ const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
           scope,
           "width",
           widget.defaultWidth ?? DEFAULT_WIDGET_WIDTH
+        );
+      }
+      return next;
+    });
+
+    setWidgetCollapsedMap((prev) => {
+      const next = { ...prev };
+      for (const widget of widgets) {
+        const scope = `home-widget:${widget.identifier}`;
+        next[widget.identifier] = stateStore.getValue(
+          scope,
+          "collapsed",
+          false
         );
       }
       return next;
@@ -90,6 +106,25 @@ const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
     [stateStore]
   );
 
+  const handleWidgetCollapsedChange = useCallback(
+    (identifier: string, collapsed: boolean) => {
+      setWidgetCollapsedMap((prev) => {
+        if (prev[identifier] === collapsed) return prev;
+        return {
+          ...prev,
+          [identifier]: collapsed,
+        };
+      });
+      stateStore.setValue(
+        `home-widget:${identifier}`,
+        "collapsed",
+        collapsed,
+        false
+      );
+    },
+    [stateStore]
+  );
+
   const containerWidth = useMemo(
     () => Math.max(0, ...widgetLayouts.map((layout) => layout.width)),
     [widgetLayouts]
@@ -124,6 +159,10 @@ const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
               widthBounds={bounds}
               onWidthChange={(nextWidth) =>
                 handleWidgetWidthChange(widget.identifier, nextWidth)
+              }
+              isCollapsed={!!widgetCollapsedMap[widget.identifier]}
+              onCollapsedChange={(collapsed) =>
+                handleWidgetCollapsedChange(widget.identifier, collapsed)
               }
             />
           ))}

--- a/src/components/extension/home-widget.tsx
+++ b/src/components/extension/home-widget.tsx
@@ -1,18 +1,5 @@
-import {
-  Avatar,
-  Box,
-  Collapse,
-  HStack,
-  Icon,
-  IconButton,
-  Text,
-} from "@chakra-ui/react";
-import {
-  type MouseEvent as ReactMouseEvent,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { Avatar, Box, HStack, Icon, IconButton, Text } from "@chakra-ui/react";
+import { type MouseEvent as ReactMouseEvent, useState } from "react";
 import { LuChevronRight } from "react-icons/lu";
 import AdvancedCard from "@/components/common/advanced-card";
 import ExtensionContributionWrapper from "@/components/extension/contribution-wrapper";
@@ -38,15 +25,8 @@ const HomeWidget = ({
   onWidthChange,
 }: HomeWidgetProps) => {
   const [isCollapsed, setIsCollapsed] = useState(false);
-  const resizeHandlersRef = useRef<(() => void) | null>(null);
   const WidgetComponent = widget.Component;
   const iconSrc = widget.icon || base64ImgSrc(widget.extension.iconSrc);
-
-  useEffect(() => {
-    return () => {
-      resizeHandlersRef.current?.();
-    };
-  }, []);
 
   // drag to resize
   const handleResizeStart = (event: ReactMouseEvent) => {
@@ -59,13 +39,10 @@ const HomeWidget = ({
       onWidthChange(clamp(next, widthBounds.lower, widthBounds.upper));
     };
     const handleMouseUp = () => {
-      resizeHandlersRef.current?.();
-      resizeHandlersRef.current = null;
-    };
-    resizeHandlersRef.current = () => {
       window.removeEventListener("mousemove", handleMouseMove);
       window.removeEventListener("mouseup", handleMouseUp);
     };
+
     window.addEventListener("mousemove", handleMouseMove);
     window.addEventListener("mouseup", handleMouseUp);
   };
@@ -73,7 +50,7 @@ const HomeWidget = ({
   return (
     <Box
       position="relative"
-      w={`${width}px`}
+      w={isCollapsed ? "max-content" : `${width}px`}
       minW={0}
       maxW="100%"
       alignSelf="start"
@@ -115,23 +92,25 @@ const HomeWidget = ({
           </Text>
         </HStack>
 
-        <Collapse in={!isCollapsed} animateOpacity>
+        <Box display={isCollapsed ? "none" : "block"} w="100%">
           <ExtensionContributionWrapper resetKey={widget.resetKey}>
             <WidgetComponent />
           </ExtensionContributionWrapper>
-        </Collapse>
+        </Box>
       </AdvancedCard>
 
       {/* resize area */}
-      <Box
-        position="absolute"
-        top={0}
-        right={0}
-        bottom={0}
-        w="10px"
-        cursor="ew-resize"
-        onMouseDown={handleResizeStart}
-      />
+      {!isCollapsed && (
+        <Box
+          position="absolute"
+          top={0}
+          right={0}
+          bottom={0}
+          w="10px"
+          cursor="ew-resize"
+          onMouseDown={handleResizeStart}
+        />
+      )}
     </Box>
   );
 };

--- a/src/components/extension/home-widget.tsx
+++ b/src/components/extension/home-widget.tsx
@@ -1,5 +1,5 @@
 import { Avatar, Box, HStack, Icon, IconButton, Text } from "@chakra-ui/react";
-import { type MouseEvent as ReactMouseEvent, useState } from "react";
+import { type MouseEvent as ReactMouseEvent, useEffect, useRef } from "react";
 import { LuChevronRight } from "react-icons/lu";
 import AdvancedCard from "@/components/common/advanced-card";
 import ExtensionContributionWrapper from "@/components/extension/contribution-wrapper";
@@ -9,13 +9,14 @@ import { base64ImgSrc } from "@/utils/string";
 
 interface HomeWidgetProps {
   widget: ExtensionHomeWidgetContribution;
-  // widget width state and bound are managed and calculated by the container.
   width: number;
   widthBounds: {
     lower: number;
     upper: number;
   };
   onWidthChange: (width: number) => void;
+  isCollapsed: boolean;
+  onCollapsedChange: (collapsed: boolean) => void;
 }
 
 const HomeWidget = ({
@@ -23,8 +24,16 @@ const HomeWidget = ({
   width,
   widthBounds,
   onWidthChange,
+  isCollapsed,
+  onCollapsedChange,
 }: HomeWidgetProps) => {
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  const resizeHandlersRef = useRef<(() => void) | null>(null);
+  useEffect(() => {
+    const cleanup = resizeHandlersRef.current;
+    return () => {
+      cleanup?.();
+    };
+  }, []);
   const WidgetComponent = widget.Component;
   const iconSrc = widget.icon || base64ImgSrc(widget.extension.iconSrc);
 
@@ -78,7 +87,7 @@ const HomeWidget = ({
             h={21}
             variant="ghost"
             colorScheme="gray"
-            onClick={() => setIsCollapsed((prev) => !prev)}
+            onClick={() => onCollapsedChange(!isCollapsed)}
           />
           <Avatar
             src={iconSrc}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - e.g. close #xxxx, fix #xxxx

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Add centralized collapse state management for extension home widgets and persist it via the extension host state store.

New Features:
- Allow home widgets to be collapsed and expanded with their collapsed state persisted per widget across page remounts.

Enhancements:
- Delegate collapse state from individual home widgets to the container for centralized management and persistence.
- Update widget layout and resize behavior so collapsed widgets shrink to their header and disable resize interactions while collapsed.