### PR TITLE
Feat/persist extension state and alert

### DIFF
--- a/src/components/common/option-item.tsx
+++ b/src/components/common/option-item.tsx
@@ -3,7 +3,6 @@ import {
   BoxProps,
   Button,
   Card,
-  Collapse,
   Divider,
   Flex,
   HStack,
@@ -216,19 +215,17 @@ export const OptionItem: React.FC<OptionItemProps> = ({
         {isChildrenIndependent && wrappedChildren}
       </Flex>
 
-      {collapsibleContent && (
-        <Collapse in={!isCollapsed} animateOpacity>
-          <Box
-            p={3}
-            mt={2}
-            bg={collapsibleBg}
-            borderRadius="md"
-            borderWidth="1px"
-            borderColor={collapsibleBorderColor}
-          >
-            {collapsibleContent}
-          </Box>
-        </Collapse>
+      {collapsibleContent && !isCollapsed && (
+        <Box
+          p={3}
+          mt={2}
+          bg={collapsibleBg}
+          borderRadius="md"
+          borderWidth="1px"
+          borderColor={collapsibleBorderColor}
+        >
+          {collapsibleContent}
+        </Box>
       )}
     </Box>
   );

--- a/src/components/common/option-item.tsx
+++ b/src/components/common/option-item.tsx
@@ -3,6 +3,7 @@ import {
   BoxProps,
   Button,
   Card,
+  Collapse,
   Divider,
   Flex,
   HStack,
@@ -15,6 +16,7 @@ import {
 } from "@chakra-ui/react";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { LuChevronDown } from "react-icons/lu";
 import { Section, SectionProps } from "@/components/common/section";
 import { useLauncherConfig } from "@/contexts/config";
 import cardStyles from "@/styles/card.module.css";
@@ -32,6 +34,9 @@ export interface OptionItemProps extends Omit<BoxProps, "title"> {
   isChildrenIndependent?: boolean;
   maxTitleLines?: number;
   maxDescriptionLines?: number;
+  collapsibleContent?: React.ReactNode;
+  isCollapsed?: boolean;
+  onToggleCollapse?: () => void;
 }
 
 export interface OptionItemGroupProps extends SectionProps {
@@ -55,11 +60,19 @@ export const OptionItem: React.FC<OptionItemProps> = ({
   isChildrenIndependent = false,
   maxTitleLines = undefined,
   maxDescriptionLines = undefined,
+  collapsibleContent,
+  isCollapsed = false,
+  onToggleCollapse,
   ...boxProps
 }) => {
   const [isHovered, setIsHovered] = useState(false);
 
   const palettes = useColorModeValue([100, 200, 300], [900, 800, 700]);
+  const collapsibleBg = useColorModeValue("gray.50", "whiteAlpha.50");
+  const collapsibleBorderColor = useColorModeValue(
+    "gray.100",
+    "whiteAlpha.100"
+  );
 
   const titleLineClampProps: TextProps = {
     noOfLines: maxTitleLines,
@@ -110,73 +123,114 @@ export const OptionItem: React.FC<OptionItemProps> = ({
       children
     ));
 
-  return (
-    <Flex justify="space-between" alignItems="center">
-      <Flex
-        flex={1}
-        justify="space-between"
-        alignItems="center"
-        overflow="hidden"
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-        borderRadius="md"
-        _hover={{
-          bg: isFullClickZone ? `gray.${palettes[0]}` : "inherit",
-          transition: "background-color 0.2s ease-in-out",
-        }}
-        _active={{
-          bg: isFullClickZone ? `gray.${palettes[1]}` : "inherit",
-          transition: "background-color 0.1s ease-in-out",
-        }}
-        cursor={isFullClickZone ? "pointer" : "default"}
-        p={0.5}
-        {...boxProps}
-      >
-        <HStack spacing={2.5} overflow="hidden">
-          {prefixElement && (
-            <Skeleton isLoaded={!isLoading} flex="0 0 auto">
-              {prefixElement}
-            </Skeleton>
-          )}
-          <VStack
-            spacing={0}
-            mr={2}
-            alignItems="stretch"
-            overflow="hidden"
-            flex={"1 1 auto"}
-          >
-            {titleLineWrap ? (
-              <Wrap spacingX={2} spacingY={0.5}>
-                {_title}
-                {titleExtra && _titleExtra}
-              </Wrap>
-            ) : (
-              <HStack spacing={2} flexWrap="nowrap">
-                {_title}
-                {titleExtra && _titleExtra}
-              </HStack>
-            )}
+  const isClickable = isFullClickZone || !!collapsibleContent;
 
-            {description &&
-              (typeof description === "string" ? (
-                <Skeleton isLoaded={!isLoading}>
-                  <Text
-                    fontSize="xs"
-                    className="secondary-text"
-                    {...(maxDescriptionLines ? descriptionLineClampProps : {})}
-                  >
-                    {description}
-                  </Text>
-                </Skeleton>
+  return (
+    <Box w="100%">
+      <Flex justify="space-between" alignItems="center">
+        <Flex
+          flex={1}
+          justify="space-between"
+          alignItems="center"
+          overflow="hidden"
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+          borderRadius="md"
+          _hover={{
+            bg: isClickable ? `gray.${palettes[0]}` : "inherit",
+            transition: "background-color 0.2s ease-in-out",
+          }}
+          _active={{
+            bg: isClickable ? `gray.${palettes[1]}` : "inherit",
+            transition: "background-color 0.1s ease-in-out",
+          }}
+          cursor={isClickable ? "pointer" : "default"}
+          p={0.5}
+          onClick={(e) => {
+            if (collapsibleContent && onToggleCollapse) {
+              onToggleCollapse();
+            }
+            if (boxProps.onClick) {
+              boxProps.onClick(e);
+            }
+          }}
+          {...boxProps}
+        >
+          <HStack spacing={2.5} overflow="hidden">
+            {prefixElement && (
+              <Skeleton isLoaded={!isLoading} flex="0 0 auto">
+                {prefixElement}
+              </Skeleton>
+            )}
+            <VStack
+              spacing={0}
+              mr={2}
+              alignItems="stretch"
+              overflow="hidden"
+              flex={"1 1 auto"}
+            >
+              {titleLineWrap ? (
+                <Wrap spacingX={2} spacingY={0.5}>
+                  {_title}
+                  {titleExtra && _titleExtra}
+                </Wrap>
               ) : (
-                description
-              ))}
-          </VStack>
-        </HStack>
-        {!isChildrenIndependent && wrappedChildren}
+                <HStack spacing={2} flexWrap="nowrap">
+                  {_title}
+                  {titleExtra && _titleExtra}
+                </HStack>
+              )}
+
+              {description &&
+                (typeof description === "string" ? (
+                  <Skeleton isLoaded={!isLoading}>
+                    <Text
+                      fontSize="xs"
+                      className="secondary-text"
+                      {...(maxDescriptionLines
+                        ? descriptionLineClampProps
+                        : {})}
+                    >
+                      {description}
+                    </Text>
+                  </Skeleton>
+                ) : (
+                  description
+                ))}
+            </VStack>
+          </HStack>
+
+          <HStack spacing={2}>
+            {!isChildrenIndependent && wrappedChildren}
+
+            {collapsibleContent && (
+              <Box
+                as={LuChevronDown}
+                transition="transform 0.2s"
+                transform={isCollapsed ? "rotate(0deg)" : "rotate(-180deg)"}
+                color="gray.500"
+              />
+            )}
+          </HStack>
+        </Flex>
+        {isChildrenIndependent && wrappedChildren}
       </Flex>
-      {isChildrenIndependent && wrappedChildren}
-    </Flex>
+
+      {collapsibleContent && (
+        <Collapse in={!isCollapsed} animateOpacity>
+          <Box
+            p={3}
+            mt={2}
+            bg={collapsibleBg}
+            borderRadius="md"
+            borderWidth="1px"
+            borderColor={collapsibleBorderColor}
+          >
+            {collapsibleContent}
+          </Box>
+        </Collapse>
+      )}
+    </Box>
   );
 };
 

--- a/src/components/extension/home-widget-container.tsx
+++ b/src/components/extension/home-widget-container.tsx
@@ -23,6 +23,7 @@ const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
   const [widgetWidthMap, setWidgetWidthMap] = useState<Record<string, number>>(
     {}
   );
+  const [collapsedMap, setCollapsedMap] = useState<Record<string, boolean>>({});
 
   // hydrate widget widths from extension host state so they survive page remounts.
   useEffect(() => {
@@ -36,6 +37,24 @@ const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
           scope,
           "width",
           widget.defaultWidth ?? DEFAULT_WIDGET_WIDTH
+        );
+      }
+      return next;
+    });
+  }, [stateStore, widgets]);
+
+  // hydrate widget collapsed states from extension host state so they survive page remounts.
+  useEffect(() => {
+    if (widgets.length === 0) return;
+
+    setCollapsedMap((prev) => {
+      const next = { ...prev };
+      for (const widget of widgets) {
+        const scope = `home-widget:${widget.identifier}`;
+        next[widget.identifier] = stateStore.getValue(
+          scope,
+          "collapsed",
+          false
         );
       }
       return next;
@@ -90,6 +109,22 @@ const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
     [stateStore]
   );
 
+  const handleWidgetCollapseToggle = useCallback(
+    (identifier: string) => {
+      setCollapsedMap((prev) => {
+        const next = !prev[identifier];
+        stateStore.setValue(
+          `home-widget:${identifier}`,
+          "collapsed",
+          next,
+          false
+        );
+        return { ...prev, [identifier]: next };
+      });
+    },
+    [stateStore]
+  );
+
   const containerWidth = useMemo(
     () => Math.max(0, ...widgetLayouts.map((layout) => layout.width)),
     [widgetLayouts]
@@ -124,6 +159,10 @@ const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
               widthBounds={bounds}
               onWidthChange={(nextWidth) =>
                 handleWidgetWidthChange(widget.identifier, nextWidth)
+              }
+              isCollapsed={collapsedMap[widget.identifier] ?? false}
+              onToggleCollapse={() =>
+                handleWidgetCollapseToggle(widget.identifier)
               }
             />
           ))}

--- a/src/components/extension/home-widget.tsx
+++ b/src/components/extension/home-widget.tsx
@@ -1,12 +1,4 @@
-import {
-  Avatar,
-  Box,
-  Collapse,
-  HStack,
-  Icon,
-  IconButton,
-  Text,
-} from "@chakra-ui/react";
+import { Avatar, Box, HStack, Icon, IconButton, Text } from "@chakra-ui/react";
 import { type MouseEvent as ReactMouseEvent } from "react";
 import { LuChevronRight } from "react-icons/lu";
 import AdvancedCard from "@/components/common/advanced-card";
@@ -103,11 +95,11 @@ const HomeWidget = ({
           </Text>
         </HStack>
 
-        <Collapse in={!isCollapsed} animateOpacity>
+        {!isCollapsed && (
           <ExtensionContributionWrapper resetKey={widget.resetKey}>
             <WidgetComponent />
           </ExtensionContributionWrapper>
-        </Collapse>
+        )}
       </AdvancedCard>
 
       {/* resize area */}

--- a/src/components/extension/home-widget.tsx
+++ b/src/components/extension/home-widget.tsx
@@ -7,7 +7,7 @@ import {
   IconButton,
   Text,
 } from "@chakra-ui/react";
-import { type MouseEvent as ReactMouseEvent, useState } from "react";
+import { type MouseEvent as ReactMouseEvent } from "react";
 import { LuChevronRight } from "react-icons/lu";
 import AdvancedCard from "@/components/common/advanced-card";
 import ExtensionContributionWrapper from "@/components/extension/contribution-wrapper";
@@ -24,6 +24,8 @@ interface HomeWidgetProps {
     upper: number;
   };
   onWidthChange: (width: number) => void;
+  isCollapsed: boolean;
+  onToggleCollapse: () => void;
 }
 
 const HomeWidget = ({
@@ -31,8 +33,9 @@ const HomeWidget = ({
   width,
   widthBounds,
   onWidthChange,
+  isCollapsed,
+  onToggleCollapse,
 }: HomeWidgetProps) => {
-  const [isCollapsed, setIsCollapsed] = useState(false);
   const WidgetComponent = widget.Component;
   const iconSrc = widget.icon || base64ImgSrc(widget.extension.iconSrc);
 
@@ -86,7 +89,7 @@ const HomeWidget = ({
             h={21}
             variant="ghost"
             colorScheme="gray"
-            onClick={() => setIsCollapsed((prev) => !prev)}
+            onClick={onToggleCollapse}
           />
           <Avatar
             src={iconSrc}

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -138,6 +138,7 @@ export interface LauncherConfig {
   };
   extension: {
     enabled: string[];
+    collapsed?: string[];
   };
   localGameDirectories: GameDirectory[];
   globalGameConfig: GameConfig;

--- a/src/pages/settings/extension/index.tsx
+++ b/src/pages/settings/extension/index.tsx
@@ -4,8 +4,10 @@ import {
   Avatar,
   AvatarBadge,
   Badge,
+  CloseButton,
   HStack,
   Text,
+  VStack,
 } from "@chakra-ui/react";
 import { appDataDir, join } from "@tauri-apps/api/path";
 import { open } from "@tauri-apps/plugin-dialog";
@@ -41,6 +43,19 @@ const ExtensionSettingsPage = () => {
     getExtensionSettingsPage,
   } = useExtensionHost();
   const extensions = extensionList || [];
+
+  const collapsedList = config.extension.collapsed || [];
+  const collapsedSet = new Set(collapsedList);
+
+  const handleToggleCollapse = (identifier: string) => {
+    const newCollapsedSet = new Set(collapsedSet);
+    if (newCollapsedSet.has(identifier)) {
+      newCollapsedSet.delete(identifier);
+    } else {
+      newCollapsedSet.add(identifier);
+    }
+    update("extension.collapsed", Array.from(newCollapsedSet));
+  };
 
   const handleOpenExtensionsFolder = async () => {
     const base = await appDataDir();
@@ -157,56 +172,73 @@ const ExtensionSettingsPage = () => {
   };
 
   const extensionItems: OptionItemGroupProps["items"] = extensions.map(
-    (extension: ExtensionInfo) => (
-      <OptionItem
-        key={extension.identifier}
-        title={extension.name}
-        titleExtra={
-          <Text fontSize="xs" className="secondary-text">
-            {[extension.identifier, extension.version]
-              .filter(Boolean)
-              .join(" · ")}
-          </Text>
-        }
-        description={extension.description}
-        childrenOnHover
-        titleLineWrap={false}
-        maxTitleLines={1}
-        maxDescriptionLines={2}
-        prefixElement={
-          <Avatar
-            boxSize="28px"
-            borderRadius="4px"
-            src={base64ImgSrc(extension.iconSrc)}
-            name={extension.name}
-            style={{
-              filter: enabledSet.has(extension.identifier)
-                ? "none"
-                : "grayscale(90%)",
-              opacity: enabledSet.has(extension.identifier) ? 1 : 0.5,
-            }}
-          >
-            <AvatarBadge
-              bg={enabledSet.has(extension.identifier) ? "green" : "black"}
-              boxSize="0.75em"
-              borderWidth={2}
-            />
-          </Avatar>
-        }
-      >
-        <HStack spacing={0}>
-          {extensionItemMenuOperations(extension).map((item, index) => (
-            <CommonIconButton
-              key={index}
-              icon={item.icon}
-              label={item.label}
-              colorScheme={item.danger ? "red" : "gray"}
-              onClick={item.onClick}
-            />
-          ))}
-        </HStack>
-      </OptionItem>
-    )
+    (extension: ExtensionInfo) => {
+      const isCollapsed = collapsedSet.has(extension.identifier);
+
+      return (
+        <OptionItem
+          key={extension.identifier}
+          title={extension.name}
+          titleExtra={
+            <Text fontSize="xs" className="secondary-text">
+              {[extension.identifier, extension.version]
+                .filter(Boolean)
+                .join(" · ")}
+            </Text>
+          }
+          description={extension.description}
+          childrenOnHover
+          titleLineWrap={false}
+          maxTitleLines={1}
+          maxDescriptionLines={2}
+          prefixElement={
+            <Avatar
+              boxSize="28px"
+              borderRadius="4px"
+              src={base64ImgSrc(extension.iconSrc)}
+              name={extension.name}
+              style={{
+                filter: enabledSet.has(extension.identifier)
+                  ? "none"
+                  : "grayscale(90%)",
+                opacity: enabledSet.has(extension.identifier) ? 1 : 0.5,
+              }}
+            >
+              <AvatarBadge
+                bg={enabledSet.has(extension.identifier) ? "green" : "black"}
+                boxSize="0.75em"
+                borderWidth={2}
+              />
+            </Avatar>
+          }
+          isCollapsed={isCollapsed}
+          onToggleCollapse={() => handleToggleCollapse(extension.identifier)}
+          collapsibleContent={
+            <VStack align="stretch" spacing={2} fontSize="xs" py={1}>
+              <Text color="gray.500">
+                {t("ExtensionSettingsPage.id")}: {extension.identifier}
+              </Text>
+              <Text>
+                {t("ExtensionSettingsPage.author")}:{" "}
+                {extension.author || "Unknown"}
+              </Text>
+            </VStack>
+          }
+        >
+          <HStack spacing={0}>
+            {extensionItemMenuOperations(extension).map((item, index) => (
+              <CommonIconButton
+                key={index}
+                icon={item.icon}
+                label={item.label}
+                colorScheme={item.danger ? "red" : "gray"}
+                onClick={item.onClick}
+              />
+            ))}
+          </HStack>
+        </OptionItem>
+      );
+    }
   );
 
   return (
@@ -233,10 +265,22 @@ const ExtensionSettingsPage = () => {
         </HStack>
       }
     >
-      <Alert status="warning" fontSize="xs-sm" borderRadius="md" mb={3}>
-        <AlertIcon />
-        {t("ExtensionSettingsPage.alert")}
-      </Alert>
+      {!config.suppressedDialogs?.includes("extensionSettingsAlert") && (
+        <Alert status="warning" fontSize="xs-sm" borderRadius="md" mb={3}>
+          <AlertIcon />
+          {t("ExtensionSettingsPage.alert")}
+          <CloseButton
+            alignSelf="flex-start"
+            ml="auto"
+            onClick={() =>
+              update("suppressedDialogs", [
+                ...(config.suppressedDialogs ?? []),
+                "extensionSettingsAlert",
+              ])
+            }
+          />
+        </Alert>
+      )}
       {extensions.length > 0 ? (
         <OptionItemGroup items={extensionItems} />
       ) : (


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.


### This PR is a ..


- [x] ⚡️ Performance improvement

## Summary by Sourcery

Persist extension UI state for collapsible elements and add a dismissible warning alert in extension settings.

New Features:
- Allow option items to display collapsible content with a toggleable chevron and expanded details area.
- Persist per-extension collapsed state in settings so users see the same collapsed list across sessions.
- Persist home widget collapsed state per widget so widget visibility preferences survive remounts.
- Allow users to dismiss the extension settings warning alert and remember that preference in config.

Enhancements:
- Refine extension settings option items to show additional metadata like extension ID and author in an expandable section.
- Extend launcher configuration to store collapsed extension identifiers alongside enabled ones.