### PR TITLE
feat(frontend): dismiss extension settings alert once and persist

### DIFF
--- a/src/pages/settings/extension/index.tsx
+++ b/src/pages/settings/extension/index.tsx
@@ -4,6 +4,7 @@ import {
   Avatar,
   AvatarBadge,
   Badge,
+  CloseButton,
   HStack,
   Text,
 } from "@chakra-ui/react";
@@ -233,10 +234,22 @@ const ExtensionSettingsPage = () => {
         </HStack>
       }
     >
-      <Alert status="warning" fontSize="xs-sm" borderRadius="md" mb={3}>
-        <AlertIcon />
-        {t("ExtensionSettingsPage.alert")}
-      </Alert>
+      {!config.suppressedDialogs?.includes("extensionSettingsAlert") && (
+        <Alert status="warning" fontSize="xs-sm" borderRadius="md" mb={3}>
+          <AlertIcon />
+          {t("ExtensionSettingsPage.alert")}
+          <CloseButton
+            alignSelf="flex-start"
+            ml="auto"
+            onClick={() =>
+              update("suppressedDialogs", [
+                ...(config.suppressedDialogs ?? []),
+                "extensionSettingsAlert",
+              ])
+            }
+          />
+        </Alert>
+      )}
       {extensions.length > 0 ? (
         <OptionItemGroup items={extensionItems} />
       ) : (


### PR DESCRIPTION
- [x] Changes have been tested locally and work as expected.

### This PR is a ..


- [x] ⚡️ Performance improvement

## Summary by Sourcery

New Features:
- Allow users to dismiss the extension settings warning alert and persist that choice using the existing configuration storage.