### PR TITLE
feat(extension): dismiss extension settings alert once and persist

### DIFF
--- a/src-tauri/src/launcher_config/models.rs
+++ b/src-tauri/src/launcher_config/models.rs
@@ -330,6 +330,9 @@ structstruck::strike! {
       pub instance_shader_packs_page: struct {
         #[default([true, true])]
         pub accordion_states: [bool; 2],
+      },
+      pub extension_settings_page: struct {
+        pub hide_alert: bool,
       }
     }
   }

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -172,6 +172,9 @@ export interface LauncherConfig {
     instanceShaderPacksPage: {
       accordionStates: boolean[];
     };
+    extensionSettingsPage: {
+      hideAlert: boolean;
+    };
   };
 }
 
@@ -346,6 +349,9 @@ export const defaultConfig: LauncherConfig = {
     },
     instanceShaderPacksPage: {
       accordionStates: [true, true],
+    },
+    extensionSettingsPage: {
+      hideAlert: false,
     },
   },
 };

--- a/src/pages/settings/extension/index.tsx
+++ b/src/pages/settings/extension/index.tsx
@@ -234,18 +234,17 @@ const ExtensionSettingsPage = () => {
         </HStack>
       }
     >
-      {!config.suppressedDialogs?.includes("extensionSettingsAlert") && (
+      {!config.states.extensionSettingsPage.hideAlert && (
         <Alert status="warning" fontSize="xs-sm" borderRadius="md" mb={3}>
           <AlertIcon />
           {t("ExtensionSettingsPage.alert")}
           <CloseButton
             alignSelf="flex-start"
-            ml="auto"
+            position="relative"
+            right={-2}
+            size="sm"
             onClick={() =>
-              update("suppressedDialogs", [
-                ...(config.suppressedDialogs ?? []),
-                "extensionSettingsAlert",
-              ])
+              update("states.extensionSettingsPage.hideAlert", true)
             }
           />
         </Alert>

--- a/src/pages/settings/extension/index.tsx
+++ b/src/pages/settings/extension/index.tsx
@@ -4,6 +4,7 @@ import {
   Avatar,
   AvatarBadge,
   Badge,
+  CloseButton,
   HStack,
   Text,
 } from "@chakra-ui/react";
@@ -233,10 +234,22 @@ const ExtensionSettingsPage = () => {
         </HStack>
       }
     >
-      <Alert status="warning" fontSize="xs-sm" borderRadius="md" mb={3}>
-        <AlertIcon />
-        {t("ExtensionSettingsPage.alert")}
-      </Alert>
+      {!config.suppressedDialogs?.includes("extensionSettingsAlert") && (
+        <Alert status="warning" fontSize="xs-sm" borderRadius="md" mb={3}>
+          <AlertIcon />
+          {t("ExtensionSettingsPage.alert")}
+          <CloseButton
+            alignSelf="flex-start"
+            ml="auto"
+            onClick={() =>
+              update("suppressedDialogs", [
+                ...(config.suppressedDialogs ?? []),
+                "extensionSettingsAlert",
+              ])
+            }
+          />
+        </Alert>
+      )}
       {extensions.length > 0 ? (
         <OptionItemGroup items={extensionItems} />
       ) : (


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - e.g. close #xxxx, fix #xxxx

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Add a persistent, dismissible warning alert to the extension settings page backed by launcher configuration state.

New Features:
- Allow users to dismiss the extension settings warning alert on the settings page.
- Persist the dismissed state of the extension settings alert in the launcher configuration so it does not reappear once closed.

Enhancements:
- Extend launcher configuration models (frontend and Tauri backend) to store per-page state for the extension settings alert visibility.