### PR TITLE
fix(frontend): decode HTML entities in PosterCard title

### DIFF
--- a/src/components/poster-card.tsx
+++ b/src/components/poster-card.tsx
@@ -67,7 +67,7 @@ const PosterCard = ({ data }: PosterCardProps) => {
 
       <CardBody p={3}>
         <VStack spacing={1} alignItems="start" overflow="hidden">
-          <Text fontSize="xs-sm">{title}</Text>
+          <Text fontSize="xs-sm">{cleanHtmlText(title)}</Text>
           {keywords && keywords.trim() && (
             <Wrap spacing={1}>
               {keywords.split(",").map((keyword, index) => (

--- a/src/pages/discover/home.tsx
+++ b/src/pages/discover/home.tsx
@@ -153,7 +153,7 @@ const NewsCard: React.FC<{ post: NewsPostSummary | null }> = ({ post }) => {
       )}
       <Box position="relative" pt={3} bg="inherit">
         <Text fontSize="sm" noOfLines={2} visibility="hidden">
-          {post?.title}
+          {cleanHtmlText(post?.title || "")}
         </Text>
         <Box
           position="absolute"
@@ -164,7 +164,7 @@ const NewsCard: React.FC<{ post: NewsPostSummary | null }> = ({ post }) => {
           pt={1.5}
         >
           <Text fontSize="sm" noOfLines={2}>
-            {post?.title}
+            {cleanHtmlText(post?.title || "")}
           </Text>
           <Text
             fontSize="xs"


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.

### This PR is a ..


- [x] 🐞 Bug fix


### Related Issues
<img width="203" height="61" alt="屏幕截图 2026-04-15 173628" src="https://github.com/user-attachments/assets/742108c9-c096-44c6-abf6-d6955f0f16f6" />

>  fix #1502

## Summary by Sourcery

Bug Fixes:
- Fix poster card titles showing raw HTML entities by decoding them before rendering.