### PR TITLE
feat(home-widget): presist store home widgets' state: width, if collapsed; support change their orders

### DIFF
--- a/src-tauri/src/extension/commands.rs
+++ b/src-tauri/src/extension/commands.rs
@@ -167,7 +167,7 @@ pub fn delete_extension(app: AppHandle, identifier: String) -> SJMCLResult<()> {
   )?;
 
   let home_widget_prefix = format!("{identifier}:home_widget");
-  let home_widget_state: Vec<(String, usize, bool)> = config_state
+  let home_widget_state: Vec<(String, u32, bool)> = config_state
     .extension
     .home_widget_state
     .iter()

--- a/src-tauri/src/extension/commands.rs
+++ b/src-tauri/src/extension/commands.rs
@@ -150,6 +150,7 @@ pub fn delete_extension(app: AppHandle, identifier: String) -> SJMCLResult<()> {
 
   fs::remove_dir_all(extension_dir)?;
 
+  // update related fields in config: enabled list and home widget state
   let config_binding = app.state::<Mutex<LauncherConfig>>();
   let mut config_state = config_binding.lock()?;
   let enabled: Vec<String> = config_state
@@ -163,6 +164,20 @@ pub fn delete_extension(app: AppHandle, identifier: String) -> SJMCLResult<()> {
     &app,
     "extension.enabled",
     &serde_json::to_string(&enabled).unwrap_or_default(),
+  )?;
+
+  let home_widget_prefix = format!("{identifier}:home_widget");
+  let home_widget_state: Vec<(String, usize, bool)> = config_state
+    .extension
+    .home_widget_state
+    .iter()
+    .filter(|(widget_identifier, _, _)| !widget_identifier.starts_with(&home_widget_prefix))
+    .cloned()
+    .collect();
+  config_state.partial_update(
+    &app,
+    "extension.home_widget_state",
+    &serde_json::to_string(&home_widget_state).unwrap_or_default(),
   )?;
   config_state.save()?;
 

--- a/src-tauri/src/launcher_config/models.rs
+++ b/src-tauri/src/launcher_config/models.rs
@@ -298,7 +298,7 @@ structstruck::strike! {
     pub extension: struct ExtensionConfig {
       pub enabled: Vec<String>,
       #[serde(default)]
-      pub home_widget_state: Vec<(String, usize, bool)>,  // widget_key, width, collapsed
+      pub home_widget_state: Vec<(String, u32, bool)>,  // widget_key, width, collapsed
     },
     pub global_game_config: GameConfig,
     pub local_game_directories: Vec<GameDirectory>,

--- a/src-tauri/src/launcher_config/models.rs
+++ b/src-tauri/src/launcher_config/models.rs
@@ -297,6 +297,8 @@ structstruck::strike! {
     },
     pub extension: struct ExtensionConfig {
       pub enabled: Vec<String>,
+      #[serde(default)]
+      pub home_widget_state: Vec<(String, usize, bool)>,  // widget_key, width, collapsed
     },
     pub global_game_config: GameConfig,
     pub local_game_directories: Vec<GameDirectory>,

--- a/src/components/common/common-icon-button.tsx
+++ b/src/components/common/common-icon-button.tsx
@@ -5,6 +5,7 @@ import {
   PlacementWithLogical,
   Tooltip,
 } from "@chakra-ui/react";
+import { forwardRef } from "react";
 import { useTranslation } from "react-i18next";
 import { IconType } from "react-icons";
 import {
@@ -37,73 +38,78 @@ interface CommonIconButtonProps extends Omit<
   tooltipPlacement?: PlacementWithLogical;
 }
 
-export const CommonIconButton: React.FC<CommonIconButtonProps> = ({
-  icon,
-  label,
-  withTooltip = true,
-  tooltipPlacement = "bottom",
-  ...props
-}) => {
-  const { t } = useTranslation();
-  const { config } = useLauncherConfig();
+export const CommonIconButton = forwardRef<
+  HTMLButtonElement,
+  CommonIconButtonProps
+>(
+  (
+    { icon, label, withTooltip = true, tooltipPlacement = "bottom", ...props },
+    ref
+  ) => {
+    const { t } = useTranslation();
+    const { config } = useLauncherConfig();
 
-  const supportIcons: Record<string, JSX.Element> = {
-    add: <LuPlus />,
-    copy: <LuCopy />,
-    copyOrMove: <LuFiles />,
-    delete: <LuTrash />,
-    download: <LuArrowDownToLine />,
-    edit: <LuPenLine />,
-    external: <LuExternalLink size="14" />, // keep the same as deprecated link-icon-button
-    info: <LuInfo />,
-    launch: <LuPlay />,
-    more: <LuEllipsis />,
-    open: <LuFolderOpen />,
-    openFolder: <LuFolderOpen />,
-    refresh: <LuRefreshCcw />,
-    revealFile: <LuFolderSearch />,
-    settings: <LuSettings />,
-    share: <LuShare />,
-  };
+    const supportIcons: Record<string, JSX.Element> = {
+      add: <LuPlus />,
+      copy: <LuCopy />,
+      copyOrMove: <LuFiles />,
+      delete: <LuTrash />,
+      download: <LuArrowDownToLine />,
+      edit: <LuPenLine />,
+      external: <LuExternalLink size="14" />, // keep the same as deprecated link-icon-button
+      info: <LuInfo />,
+      launch: <LuPlay />,
+      more: <LuEllipsis />,
+      open: <LuFolderOpen />,
+      openFolder: <LuFolderOpen />,
+      refresh: <LuRefreshCcw />,
+      revealFile: <LuFolderSearch />,
+      settings: <LuSettings />,
+      share: <LuShare />,
+    };
 
-  const specLabels: Record<string, string> = {
-    copy: t("General.copy.text"),
-    copyOrMove: t(`General.copyOrMove.${config.basicInfo.osType}`),
-    revealFile: t("General.revealFile", {
-      opener: t(`Enums.systemFileManager.${config.basicInfo.osType}`),
-    }),
-    share: t("General.share.text"),
-  };
+    const specLabels: Record<string, string> = {
+      copy: t("General.copy.text"),
+      copyOrMove: t(`General.copyOrMove.${config.basicInfo.osType}`),
+      revealFile: t("General.revealFile", {
+        opener: t(`Enums.systemFileManager.${config.basicInfo.osType}`),
+      }),
+      share: t("General.share.text"),
+    };
 
-  const selectedIcon =
-    typeof icon === "string" ? (
-      supportIcons[icon] || <LuCircleHelp />
-    ) : (
-      <Icon as={icon} />
-    );
+    const selectedIcon =
+      typeof icon === "string" ? (
+        supportIcons[icon] || <LuCircleHelp />
+      ) : (
+        <Icon as={icon} />
+      );
 
-  const finalLabel =
-    label ||
-    (typeof icon === "string"
-      ? specLabels[icon]
+    const finalLabel =
+      label ||
+      (typeof icon === "string"
         ? specLabels[icon]
-        : t(`General.${icon}`)
-      : "");
+          ? specLabels[icon]
+          : t(`General.${icon}`)
+        : "");
 
-  return (
-    <Tooltip
-      label={finalLabel}
-      isDisabled={!withTooltip}
-      key={finalLabel}
-      placement={tooltipPlacement}
-    >
-      <IconButton
-        icon={selectedIcon}
-        aria-label={finalLabel}
-        variant="ghost"
-        size="sm"
-        {...props}
-      />
-    </Tooltip>
-  );
-};
+    return (
+      <Tooltip
+        label={finalLabel}
+        isDisabled={!withTooltip}
+        key={finalLabel}
+        placement={tooltipPlacement}
+      >
+        <IconButton
+          ref={ref}
+          icon={selectedIcon}
+          aria-label={finalLabel}
+          variant="ghost"
+          size="sm"
+          {...props}
+        />
+      </Tooltip>
+    );
+  }
+);
+
+CommonIconButton.displayName = "CommonIconButton";

--- a/src/components/extension/home-widget-container.tsx
+++ b/src/components/extension/home-widget-container.tsx
@@ -3,7 +3,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import HomeWidget from "@/components/extension/home-widget";
 import { useLauncherConfig } from "@/contexts/config";
 import { useExtensionHost } from "@/contexts/extension/host";
-import { ExtensionHomeWidgetContribution } from "@/models/extension";
+import {
+  ExtensionHomeWidgetContribution,
+  type HomeWidgetStateTuple,
+} from "@/models/extension";
 import { areArraysEqual, clamp } from "@/utils/math";
 
 interface HomeWidgetContainerProps {
@@ -14,8 +17,6 @@ interface WidthBounds {
   lower: number;
   upper: number;
 }
-
-type HomeWidgetStateTuple = [string, number, boolean];
 
 const DEFAULT_WIDGET_WIDTH = 300;
 
@@ -71,6 +72,7 @@ const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
   const widgetOrderRef = useRef<string[]>([]);
   const widgetWidthMapRef = useRef<Record<string, number>>({});
   const widgetCollapsedMapRef = useRef<Record<string, boolean>>({});
+  const persistHomeWidgetStateRef = useRef<() => void>(() => undefined);
 
   useEffect(() => {
     widgetOrderRef.current = widgetOrder;
@@ -191,7 +193,9 @@ const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
             nextWidthMap[widget.identifier] ??
             widget.defaultWidth ??
             DEFAULT_WIDGET_WIDTH;
-          const width = clamp(preferredWidth, bounds.lower, bounds.upper);
+          const width = Math.round(
+            clamp(preferredWidth, bounds.lower, bounds.upper)
+          );
 
           return [
             widget.identifier,
@@ -217,6 +221,10 @@ const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
       widgetsByIdentifier,
     ]
   );
+
+  useEffect(() => {
+    persistHomeWidgetStateRef.current = persistHomeWidgetState;
+  }, [persistHomeWidgetState]);
 
   const widgetLayouts = useMemo(() => {
     return orderedWidgetIdentifiers
@@ -302,8 +310,8 @@ const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
 
   useEffect(() => {
     if (!isHydrated || orderedWidgetIdentifiers.length === 0) return;
-    persistHomeWidgetState();
-  }, [isHydrated, orderedWidgetIdentifiers, persistHomeWidgetState]);
+    persistHomeWidgetStateRef.current();
+  }, [isHydrated, orderedWidgetIdentifiers]);
 
   const containerWidth = useMemo(
     () => Math.max(0, ...widgetLayouts.map((layout) => layout.width)),

--- a/src/components/extension/home-widget-container.tsx
+++ b/src/components/extension/home-widget-container.tsx
@@ -1,9 +1,10 @@
 import { Box, VStack } from "@chakra-ui/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import HomeWidget from "@/components/extension/home-widget";
+import { useLauncherConfig } from "@/contexts/config";
 import { useExtensionHost } from "@/contexts/extension/host";
 import { ExtensionHomeWidgetContribution } from "@/models/extension";
-import { clamp } from "@/utils/math";
+import { areArraysEqual, clamp } from "@/utils/math";
 
 interface HomeWidgetContainerProps {
   maxWidth: number;
@@ -14,51 +15,133 @@ interface WidthBounds {
   upper: number;
 }
 
+type HomeWidgetStateTuple = [string, number, boolean];
+
 const DEFAULT_WIDGET_WIDTH = 300;
 
-const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
-  const { homeWidgets, stateStore } = useExtensionHost();
-  const widgets = homeWidgets;
+const areHomeWidgetStatesEqual = (
+  left: HomeWidgetStateTuple[],
+  right: HomeWidgetStateTuple[]
+) => {
+  return areArraysEqual(
+    left,
+    right,
+    (
+      [leftIdentifier, leftWidth, leftCollapsed],
+      [rightIdentifier, rightWidth, rightCollapsed]
+    ) =>
+      leftIdentifier === rightIdentifier &&
+      leftWidth === rightWidth &&
+      leftCollapsed === rightCollapsed
+  );
+};
 
+const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
+  const { config, update } = useLauncherConfig();
+  const { homeWidgets } = useExtensionHost();
+  const persistedState = config.extension.homeWidgetState;
+
+  const widgetsByIdentifier = useMemo(() => {
+    return new Map(homeWidgets.map((widget) => [widget.identifier, widget]));
+  }, [homeWidgets]);
+
+  const visibleWidgetIdentifiers = useMemo(
+    () => homeWidgets.map((widget) => widget.identifier),
+    [homeWidgets]
+  );
+
+  const persistedStateMap = useMemo(() => {
+    return new Map(
+      persistedState.map(([identifier, width, collapsed]) => [
+        identifier,
+        { width, collapsed },
+      ])
+    );
+  }, [persistedState]);
+
+  const [widgetOrder, setWidgetOrder] = useState<string[]>([]);
   const [widgetWidthMap, setWidgetWidthMap] = useState<Record<string, number>>(
     {}
   );
   const [widgetCollapsedMap, setWidgetCollapsedMap] = useState<
     Record<string, boolean>
   >({});
+  const [isHydrated, setIsHydrated] = useState(false);
 
-  // hydrate widget widths and collapsed state from extension host state so they survive page remounts.
+  const widgetOrderRef = useRef<string[]>([]);
+  const widgetWidthMapRef = useRef<Record<string, number>>({});
+  const widgetCollapsedMapRef = useRef<Record<string, boolean>>({});
+
   useEffect(() => {
-    if (widgets.length === 0) return;
+    widgetOrderRef.current = widgetOrder;
+  }, [widgetOrder]);
 
-    setWidgetWidthMap((prev) => {
-      const next = { ...prev };
-      for (const widget of widgets) {
-        const scope = `home-widget:${widget.identifier}`;
-        next[widget.identifier] = stateStore.getValue(
-          scope,
-          "width",
-          widget.defaultWidth ?? DEFAULT_WIDGET_WIDTH
-        );
+  useEffect(() => {
+    widgetWidthMapRef.current = widgetWidthMap;
+  }, [widgetWidthMap]);
+
+  useEffect(() => {
+    widgetCollapsedMapRef.current = widgetCollapsedMap;
+  }, [widgetCollapsedMap]);
+
+  useEffect(() => {
+    if (visibleWidgetIdentifiers.length === 0) {
+      setWidgetOrder([]);
+      setWidgetWidthMap({});
+      setWidgetCollapsedMap({});
+      setIsHydrated(false);
+      return;
+    }
+
+    const visibleWidgetSet = new Set(visibleWidgetIdentifiers);
+    const nextOrder: string[] = [];
+    const seenIdentifiers = new Set<string>();
+
+    for (const [identifier] of persistedState) {
+      if (
+        visibleWidgetSet.has(identifier) &&
+        !seenIdentifiers.has(identifier)
+      ) {
+        nextOrder.push(identifier);
+        seenIdentifiers.add(identifier);
       }
-      return next;
-    });
+    }
 
-    setWidgetCollapsedMap((prev) => {
-      const next = { ...prev };
-      for (const widget of widgets) {
-        const scope = `home-widget:${widget.identifier}`;
-        next[widget.identifier] = stateStore.getValue(
-          scope,
-          "collapsed",
-          false
-        );
+    for (const identifier of visibleWidgetIdentifiers) {
+      if (!seenIdentifiers.has(identifier)) {
+        nextOrder.push(identifier);
+        seenIdentifiers.add(identifier);
       }
-      return next;
-    });
-  }, [stateStore, widgets]);
+    }
 
-  // calculate each widget's width bound by its declaration and container's current max width.
+    const nextWidthMap = Object.fromEntries(
+      homeWidgets.map((widget) => [
+        widget.identifier,
+        persistedStateMap.get(widget.identifier)?.width ??
+          widget.defaultWidth ??
+          DEFAULT_WIDGET_WIDTH,
+      ])
+    );
+    const nextCollapsedMap = Object.fromEntries(
+      homeWidgets.map((widget) => [
+        widget.identifier,
+        persistedStateMap.get(widget.identifier)?.collapsed ?? false,
+      ])
+    );
+
+    setWidgetOrder((prev) =>
+      areArraysEqual(prev, nextOrder) ? prev : nextOrder
+    );
+    setWidgetWidthMap(nextWidthMap);
+    setWidgetCollapsedMap(nextCollapsedMap);
+    setIsHydrated(true);
+  }, [
+    homeWidgets,
+    persistedState,
+    persistedStateMap,
+    visibleWidgetIdentifiers,
+  ]);
+
   const getWidgetWidthBounds = useCallback(
     (widget: ExtensionHomeWidgetContribution): WidthBounds => {
       const lower = Math.max(0, widget.minWidth ?? 0);
@@ -71,9 +154,75 @@ const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
     [maxWidth]
   );
 
-  const widgetLayouts = useMemo(
-    () =>
-      widgets.map((widget) => {
+  const orderedWidgetIdentifiers = useMemo(() => {
+    const orderedIdentifiers = widgetOrder.filter((identifier) =>
+      widgetsByIdentifier.has(identifier)
+    );
+    const missingIdentifiers = visibleWidgetIdentifiers.filter(
+      (identifier) => !orderedIdentifiers.includes(identifier)
+    );
+
+    return [...orderedIdentifiers, ...missingIdentifiers];
+  }, [visibleWidgetIdentifiers, widgetOrder, widgetsByIdentifier]);
+
+  // Merge current UI state with hidden widgets so launcher config can fully restore the layout.
+  const persistHomeWidgetState = useCallback(
+    (
+      nextOrder = widgetOrderRef.current,
+      nextWidthMap = widgetWidthMapRef.current,
+      nextCollapsedMap = widgetCollapsedMapRef.current
+    ) => {
+      const normalizedOrder = [
+        ...nextOrder.filter((identifier) =>
+          widgetsByIdentifier.has(identifier)
+        ),
+        ...visibleWidgetIdentifiers.filter(
+          (identifier) => !nextOrder.includes(identifier)
+        ),
+      ];
+      const visibleWidgetSet = new Set(visibleWidgetIdentifiers);
+
+      const nextVisibleState = normalizedOrder
+        .map((identifier) => widgetsByIdentifier.get(identifier))
+        .filter((widget) => !!widget)
+        .map((widget) => {
+          const bounds = getWidgetWidthBounds(widget);
+          const preferredWidth =
+            nextWidthMap[widget.identifier] ??
+            widget.defaultWidth ??
+            DEFAULT_WIDGET_WIDTH;
+          const width = clamp(preferredWidth, bounds.lower, bounds.upper);
+
+          return [
+            widget.identifier,
+            width,
+            !!nextCollapsedMap[widget.identifier],
+          ] as HomeWidgetStateTuple;
+        });
+
+      const hiddenState = persistedState.filter(
+        ([identifier]) => !visibleWidgetSet.has(identifier)
+      );
+      const nextState = [...nextVisibleState, ...hiddenState];
+
+      if (!areHomeWidgetStatesEqual(persistedState, nextState)) {
+        update("extension.homeWidgetState", nextState);
+      }
+    },
+    [
+      getWidgetWidthBounds,
+      persistedState,
+      update,
+      visibleWidgetIdentifiers,
+      widgetsByIdentifier,
+    ]
+  );
+
+  const widgetLayouts = useMemo(() => {
+    return orderedWidgetIdentifiers
+      .map((identifier) => widgetsByIdentifier.get(identifier))
+      .filter((widget) => !!widget)
+      .map((widget) => {
         const bounds = getWidgetWidthBounds(widget);
         const preferredWidth =
           widgetWidthMap[widget.identifier] ??
@@ -81,56 +230,89 @@ const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
           DEFAULT_WIDGET_WIDTH;
         const width = clamp(preferredWidth, bounds.lower, bounds.upper);
 
-        return { widget, bounds, width };
-      }),
-    [getWidgetWidthBounds, widgetWidthMap, widgets]
-  );
+        return {
+          widget,
+          bounds,
+          width,
+        };
+      });
+  }, [
+    getWidgetWidthBounds,
+    orderedWidgetIdentifiers,
+    widgetWidthMap,
+    widgetsByIdentifier,
+  ]);
 
   const handleWidgetWidthChange = useCallback(
-    (identifier: string, width: number) => {
+    (widgetIdentifier: string, width: number) => {
       setWidgetWidthMap((prev) => {
-        if (prev[identifier] === width) return prev;
+        if (prev[widgetIdentifier] === width) return prev;
+
         return {
           ...prev,
-          [identifier]: width,
+          [widgetIdentifier]: width,
         };
       });
-
-      stateStore.setValue(
-        `home-widget:${identifier}`,
-        "width",
-        width,
-        DEFAULT_WIDGET_WIDTH
-      );
     },
-    [stateStore]
+    []
   );
 
+  // Commit the final width on mouse up so drag updates don't spam config writes.
+  const handleWidgetWidthCommit = useCallback(
+    (widgetIdentifier: string, width: number) => {
+      const nextWidthMap = {
+        ...widgetWidthMapRef.current,
+        [widgetIdentifier]: width,
+      };
+      setWidgetWidthMap(nextWidthMap);
+      persistHomeWidgetState(undefined, nextWidthMap);
+    },
+    [persistHomeWidgetState]
+  );
+
+  // Persist collapsed state immediately because this action is discrete and cheap to save.
   const handleWidgetCollapsedChange = useCallback(
-    (identifier: string, collapsed: boolean) => {
-      setWidgetCollapsedMap((prev) => {
-        if (prev[identifier] === collapsed) return prev;
-        return {
-          ...prev,
-          [identifier]: collapsed,
-        };
-      });
-      stateStore.setValue(
-        `home-widget:${identifier}`,
-        "collapsed",
-        collapsed,
-        false
-      );
+    (widgetIdentifier: string, collapsed: boolean) => {
+      const nextCollapsedMap = {
+        ...widgetCollapsedMapRef.current,
+        [widgetIdentifier]: collapsed,
+      };
+      setWidgetCollapsedMap(nextCollapsedMap);
+      persistHomeWidgetState(undefined, undefined, nextCollapsedMap);
     },
-    [stateStore]
+    [persistHomeWidgetState]
   );
+
+  const handleMoveWidgetUp = useCallback(
+    (widgetIdentifier: string) => {
+      const currentOrder = [...orderedWidgetIdentifiers];
+      const currentIndex = currentOrder.indexOf(widgetIdentifier);
+      if (currentIndex <= 0) return;
+
+      [currentOrder[currentIndex - 1], currentOrder[currentIndex]] = [
+        currentOrder[currentIndex],
+        currentOrder[currentIndex - 1],
+      ];
+
+      setWidgetOrder(currentOrder);
+      persistHomeWidgetState(currentOrder);
+    },
+    [orderedWidgetIdentifiers, persistHomeWidgetState]
+  );
+
+  useEffect(() => {
+    if (!isHydrated || orderedWidgetIdentifiers.length === 0) return;
+    persistHomeWidgetState();
+  }, [isHydrated, orderedWidgetIdentifiers, persistHomeWidgetState]);
 
   const containerWidth = useMemo(
     () => Math.max(0, ...widgetLayouts.map((layout) => layout.width)),
     [widgetLayouts]
   );
 
-  if (widgets.length === 0) return null;
+  const topWidgetIdentifier = orderedWidgetIdentifiers[0];
+
+  if (homeWidgets.length === 0) return null;
 
   return (
     <Box
@@ -160,10 +342,15 @@ const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
               onWidthChange={(nextWidth) =>
                 handleWidgetWidthChange(widget.identifier, nextWidth)
               }
+              onWidthCommit={(nextWidth) =>
+                handleWidgetWidthCommit(widget.identifier, nextWidth)
+              }
               isCollapsed={!!widgetCollapsedMap[widget.identifier]}
               onCollapsedChange={(collapsed) =>
                 handleWidgetCollapsedChange(widget.identifier, collapsed)
               }
+              showMoveUpButton={widget.identifier !== topWidgetIdentifier}
+              onMoveUp={() => handleMoveWidgetUp(widget.identifier)}
             />
           ))}
         </VStack>

--- a/src/components/extension/home-widget.tsx
+++ b/src/components/extension/home-widget.tsx
@@ -1,7 +1,21 @@
-import { Avatar, Box, HStack, Icon, IconButton, Text } from "@chakra-ui/react";
+import {
+  Avatar,
+  Box,
+  HStack,
+  Icon,
+  IconButton,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  Portal,
+  Text,
+} from "@chakra-ui/react";
 import { type MouseEvent as ReactMouseEvent, useEffect, useRef } from "react";
-import { LuChevronRight } from "react-icons/lu";
+import { useTranslation } from "react-i18next";
+import { LuChevronRight, LuTriangle } from "react-icons/lu";
 import AdvancedCard from "@/components/common/advanced-card";
+import { CommonIconButton } from "@/components/common/common-icon-button";
 import ExtensionContributionWrapper from "@/components/extension/contribution-wrapper";
 import { ExtensionHomeWidgetContribution } from "@/models/extension";
 import { clamp } from "@/utils/math";
@@ -16,17 +30,67 @@ interface HomeWidgetProps {
     upper: number;
   };
   onWidthChange: (width: number) => void;
+  onWidthCommit: (width: number) => void;
   isCollapsed: boolean;
   onCollapsedChange: (collapsed: boolean) => void;
+  showMoveUpButton: boolean;
+  onMoveUp: () => void;
 }
+
+interface ExtraOperationMenuProps {
+  isCollapsed: boolean;
+  onMoveUp: () => void;
+}
+
+const ExtraOperationMenu = ({
+  isCollapsed,
+  onMoveUp,
+}: ExtraOperationMenuProps) => {
+  const { t } = useTranslation();
+
+  const extraOpMenu = {
+    moveUp: {
+      icon: LuTriangle,
+      onClick: onMoveUp,
+    },
+  };
+
+  return (
+    <Menu>
+      <MenuButton
+        as={CommonIconButton}
+        icon="more"
+        withTooltip={false}
+        size="xs"
+        h={21}
+        ml={isCollapsed ? 0 : "auto"}
+      />
+      <Portal>
+        <MenuList>
+          {Object.entries(extraOpMenu).map(([key, item]) => (
+            <MenuItem key={key} fontSize="xs" onClick={item.onClick}>
+              <HStack>
+                <item.icon />
+                <Text>{t(`HomeWidget.extraOpMenu.${key}`)}</Text>
+              </HStack>
+            </MenuItem>
+          ))}
+        </MenuList>
+      </Portal>
+    </Menu>
+  );
+};
 
 const HomeWidget = ({
   widget,
   width,
   widthBounds,
   onWidthChange,
+  onWidthCommit,
   isCollapsed,
   onCollapsedChange,
+  showMoveUpButton,
+  onMoveUp,
 }: HomeWidgetProps) => {
   const resizeHandlersRef = useRef<(() => void) | null>(null);
   useEffect(() => {
@@ -41,20 +105,30 @@ const HomeWidget = ({
   // drag to resize
   const handleResizeStart = (event: ReactMouseEvent) => {
     event.preventDefault();
+    resizeHandlersRef.current?.();
+
     const startX = event.clientX;
     const startWidth = width;
+
+    const cleanup = () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+      resizeHandlersRef.current = null;
+    };
 
     const handleMouseMove = (moveEvent: MouseEvent) => {
       const next = startWidth + (moveEvent.clientX - startX);
       onWidthChange(clamp(next, widthBounds.lower, widthBounds.upper));
     };
-    const handleMouseUp = () => {
-      window.removeEventListener("mousemove", handleMouseMove);
-      window.removeEventListener("mouseup", handleMouseUp);
+    const handleMouseUp = (moveEvent: MouseEvent) => {
+      const next = startWidth + (moveEvent.clientX - startX);
+      onWidthCommit(clamp(next, widthBounds.lower, widthBounds.upper));
+      cleanup();
     };
 
     window.addEventListener("mousemove", handleMouseMove);
     window.addEventListener("mouseup", handleMouseUp);
+    resizeHandlersRef.current = cleanup;
   };
 
   return (
@@ -87,7 +161,6 @@ const HomeWidget = ({
             size="xs"
             h={21}
             variant="ghost"
-            colorScheme="gray"
             onClick={() => onCollapsedChange(!isCollapsed)}
           />
           <Avatar
@@ -100,6 +173,9 @@ const HomeWidget = ({
           <Text fontSize="xs-sm" fontWeight="semibold" noOfLines={1}>
             {widget.title}
           </Text>
+          {showMoveUpButton && (
+            <ExtraOperationMenu isCollapsed={isCollapsed} onMoveUp={onMoveUp} />
+          )}
         </HStack>
 
         <Box display={isCollapsed ? "none" : "block"} w="100%">

--- a/src/contexts/extension/host.tsx
+++ b/src/contexts/extension/host.tsx
@@ -999,9 +999,9 @@ export const ExtensionHostContextProvider: React.FC<{
               ...homeWidget,
               identifier:
                 homeWidgetDefinitions.length === 1
-                  ? extension.identifier
-                  : `${extension.identifier}:${homeWidget.key || index}`,
-              resetKey: `${extension.identifier}:${signature}:${homeWidget.key || index}`,
+                  ? `${extension.identifier}:home_widget`
+                  : `${extension.identifier}:home_widget:${homeWidget.key || index}`,
+              resetKey: `${extension.identifier}:${signature}:home_widget:${homeWidget.key || index}`,
               extension,
             })
           ),

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1314,6 +1314,11 @@
       }
     }
   },
+  "HomeWidget": {
+    "extraOpMenu": {
+      "moveUp": "Move This Widget Up"
+    }
+  },
   "ImportAccountInfoModal": {
     "header": {
       "title": "Import Players and Auth Servers"

--- a/src/locales/lzh.json
+++ b/src/locales/lzh.json
@@ -1314,6 +1314,11 @@
       }
     }
   },
+  "HomeWidget": {
+    "extraOpMenu": {
+      "moveUp": "上移此卡片"
+    }
+  },
   "ImportAccountInfoModal": {
     "header": {
       "title": "自他啟者匯入戶簿資訊"

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -1314,6 +1314,11 @@
       }
     }
   },
+  "HomeWidget": {
+    "extraOpMenu": {
+      "moveUp": "上移此卡片"
+    }
+  },
   "ImportAccountInfoModal": {
     "header": {
       "title": "从其他启动器导入账户信息"

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -140,6 +140,7 @@ export interface LauncherConfig {
   };
   extension: {
     enabled: string[];
+    homeWidgetState: [string, number, boolean][];
   };
   localGameDirectories: GameDirectory[];
   globalGameConfig: GameConfig;
@@ -316,6 +317,7 @@ export const defaultConfig: LauncherConfig = {
   },
   extension: {
     enabled: [],
+    homeWidgetState: [],
   },
   localGameDirectories: [{ name: "Current", dir: ".minecraft/" }],
   globalGameConfig: defaultGameConfig,

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -1,3 +1,5 @@
+import type { HomeWidgetStateTuple } from "@/models/extension";
+
 export interface GameConfig {
   gameJava: {
     auto: boolean;
@@ -140,7 +142,7 @@ export interface LauncherConfig {
   };
   extension: {
     enabled: string[];
-    homeWidgetState: [string, number, boolean][];
+    homeWidgetState: HomeWidgetStateTuple[];
   };
   localGameDirectories: GameDirectory[];
   globalGameConfig: GameConfig;

--- a/src/models/extension.ts
+++ b/src/models/extension.ts
@@ -115,3 +115,6 @@ export interface ExtensionSettingsPageContribution
 
 export interface ExtensionPageContribution
   extends ExtensionPageDefinition, ExtensionContributionBaseExtend {}
+
+// persisted extension data stored in launcher config.
+export type HomeWidgetStateTuple = [string, number, boolean];

--- a/src/pages/settings/extension/index.tsx
+++ b/src/pages/settings/extension/index.tsx
@@ -87,10 +87,6 @@ const ExtensionSettingsPage = () => {
   const handleDeleteExtension = async (identifier: string) => {
     const response = await ExtensionService.deleteExtension(identifier);
     if (response.status === "success") {
-      update(
-        "extension.enabled",
-        config.extension.enabled.filter((id) => id !== identifier)
-      );
       toast({
         title: response.message,
         status: "success",

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,2 +1,13 @@
 export const clamp = (value: number, min: number, max: number) =>
   Math.min(max, Math.max(min, value));
+
+export const areArraysEqual = <T>(
+  left: T[],
+  right: T[],
+  isEqual: (leftValue: T, rightValue: T) => boolean = Object.is
+) => {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => isEqual(value, right[index]))
+  );
+};


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - e.g. close #xxxx, fix #xxxx

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Persist home widget layout (width, collapsed state, and ordering) in launcher configuration and add UI controls for reordering widgets from the home screen.

New Features:
- Allow home widgets to be reordered via a move-up control in the widget header menu.
- Persist home widget layout (width, collapsed state, collapsed flag) across sessions using launcher configuration instead of the extension host state store.

Enhancements:
- Hydrate and normalize home widget order and visibility based on persisted state and currently available widgets.
- Use a shared array equality helper to avoid redundant config updates when widget state is unchanged.
- Defer width persistence until resize completes to reduce configuration write frequency.
- Convert the common icon button to support refs via React forwardRef for better composability with other components.
- Extend launcher configuration models (Rust and TypeScript) with a typed home widget state field to fully restore widget layout.