### PR TITLE
perf(instance): extend mod translation cache expiry from 24h to 30d

### DIFF
--- a/src-tauri/src/instance/constants.rs
+++ b/src-tauri/src/instance/constants.rs
@@ -2,5 +2,5 @@ pub const INSTANCE_CFG_FILE_NAME: &str = "sjmclcfg.json";
 
 pub const COMPRESSED_ICON_SIZE: (u32, u32) = (64, 64);
 
-pub const TRANSLATION_CACHE_EXPIRY_HOURS: u64 = 24;
+pub const TRANSLATION_CACHE_EXPIRY_HOURS: u64 = 24 * 30;
 pub const TRANSLATION_CACHE_FILE_NAME: &str = "local_mod_translations.json";


### PR DESCRIPTION
## Summary
- 将 `TRANSLATION_CACHE_EXPIRY_HOURS` 从 `24` 调整为 `24 * 30`（30 天），减少模组列表加载时对翻译 API 的请求频率，提升加载速度
- 模组名称与描述的翻译内容变化极少，延长缓存不会显著影响用户可见的翻译时效性

## Context
Closes #1525。原先 24 小时的值自首次引入（b154317e）以来从未调整过，git 历史中也无任何注释或讨论说明为何选择 24 小时，属于随手设置的默认值。

## Test plan
- [ ] 本地构建通过
- [ ] 首次加载模组列表触发翻译 fetch 并写入缓存
- [ ] 30 天内重复加载不再发起远程请求，直接使用缓存

## Summary by Sourcery

Enhancements:
- Extend the mod translation cache lifetime from 24 hours to 30 days for more efficient reuse of translation results.