### PR TITLE
[WIP]feat(intelligence): add mcp tool

### DIFF
--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/account.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/account.rs
@@ -2,6 +2,15 @@ use crate::intelligence::mcp_server::launcher::McpContext;
 use crate::mcp_tool;
 use rmcp::handler::server::tool::ToolRoute;
 
+fn strip_sensitive_player_info(players: &mut [crate::account::models::Player]) {
+  for player in players {
+    player.avatar = Vec::new();
+    player.textures = Vec::new();
+    player.access_token = None;
+    player.refresh_token = None;
+  }
+}
+
 pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
   vec![
     mcp_tool!(
@@ -10,12 +19,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
       |app, _params: rmcp::model::JsonObject| async move {
         let mut players = crate::account::commands::retrieve_player_list(app)?;
         // remove token and base64 texture data in MCP responses to reduce context length.
-        for player in &mut players {
-          player.avatar = Vec::new();
-          player.textures = Vec::new();
-          player.access_token = None;
-          player.refresh_token = None;
-        }
+        strip_sensitive_player_info(&mut players);
         Ok(players)
       }
     ),
@@ -49,6 +53,116 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
           "states.shared.selectedPlayerId".to_string(),
           value,
         )
+      }
+    ),
+    mcp_tool!(
+      "update_player_skin_offline_preset",
+      "Update an offline Minecraft player's skin to a built-in preset role. Only offline players are supported. Player ID can be obtained from retrieve_player_list tool.",
+      |app, params|
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Offline player profile ID returned by `retrieve_player_list`.")]
+        player_id: String,
+        #[schemars(description = "Built-in skin preset role. Accepted values: `steve`, `alex`.")]
+        preset_role: String,
+      } => async move {
+        let preset_role = match params.preset_role.trim().to_ascii_lowercase().as_str() {
+          "steve" => crate::account::models::PresetRole::Steve,
+          "alex" => crate::account::models::PresetRole::Alex,
+          _ => return Err(crate::account::models::AccountError::Invalid.into()),
+        };
+
+        crate::account::commands::update_player_skin_offline_preset(
+          app,
+          params.player_id,
+          preset_role,
+        )
+      }
+    ),
+    mcp_tool!(
+      "delete_player",
+      "Delete a Minecraft player account from the launcher by player ID. Requires confirm=true. Player ID can be obtained from retrieve_player_list tool.",
+      |app, params|
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Player profile ID returned by `retrieve_player_list`.")]
+        player_id: String,
+        #[schemars(description = "Must be true to confirm deleting this player account.")]
+        confirm: bool,
+      } => async move {
+        if !params.confirm {
+          return Err(crate::account::models::AccountError::Invalid.into());
+        }
+
+        crate::account::commands::delete_player(app, params.player_id).await
+      }
+    ),
+    mcp_tool!(
+      "refresh_player",
+      crate::account::commands::refresh_player,
+      "Refresh authentication for a Microsoft or 3rd-party player account. Offline players cannot be refreshed. Player ID can be obtained from retrieve_player_list tool.",
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Microsoft or 3rd-party player profile ID returned by `retrieve_player_list`.")]
+        player_id: String,
+      }
+    ),
+    mcp_tool!(
+      sync "retrieve_auth_server_list",
+      crate::account::commands::retrieve_auth_server_list,
+      "Retrieve configured 3rd-party authentication servers."
+    ),
+    mcp_tool!(
+      "add_auth_server",
+      crate::account::commands::add_auth_server,
+      "Add a 3rd-party authentication server by its normalized authlib-injector auth URL.",
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Authlib-injector authentication server URL.")]
+        auth_url: String,
+      }
+    ),
+    mcp_tool!(
+      "delete_auth_server",
+      "Delete a 3rd-party authentication server by URL. Requires confirm=true. This also removes all players using that server.",
+      |app, params|
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Authentication server URL returned by `retrieve_auth_server_list`.")]
+        url: String,
+        #[schemars(description = "Must be true to confirm deleting this auth server and all players using it.")]
+        confirm: bool,
+      } => async move {
+        if !params.confirm {
+          return Err(crate::account::models::AccountError::Invalid.into());
+        }
+
+        crate::account::commands::delete_auth_server(app, params.url)
+      }
+    ),
+    mcp_tool!(
+      "retrieve_other_launcher_account_info",
+      "Retrieve importable account information from another launcher. Supported launcher_type values: `HMCL`, `MultiMC`.",
+      |app, params|
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Source launcher type. Accepted values: `HMCL`, `MultiMC`.")]
+        launcher_type: String,
+      } => async move {
+        let launcher_type = match params.launcher_type.trim().to_ascii_lowercase().as_str() {
+          "hmcl" => crate::account::helpers::import::ImportLauncherType::HMCL,
+          "multimc" => crate::account::helpers::import::ImportLauncherType::MultiMC,
+          _ => return Err(crate::account::models::AccountError::Invalid.into()),
+        };
+
+        let (mut players, auth_servers) =
+          crate::account::commands::retrieve_other_launcher_account_info(app, launcher_type).await?;
+        strip_sensitive_player_info(&mut players);
+
+        Ok(serde_json::json!({
+          "players": players,
+          "authServers": auth_servers,
+        }))
       }
     ),
   ]


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> add mcp tool

## Summary by Sourcery

Extend MCP launcher account tools to support player and auth server management while standardizing removal of sensitive player data from responses.

New Features:
- Add MCP tool to update an offline player's skin to a built-in preset role.
- Add MCP tool to delete a player account with explicit confirmation.
- Expose MCP tool to refresh authentication for online player accounts.
- Expose MCP tool to retrieve configured third-party authentication servers.
- Add MCP tool to add a third-party authentication server by URL.
- Add MCP tool to delete a third-party authentication server with explicit confirmation and cascading player removal.
- Add MCP tool to retrieve importable account and auth server information from supported external launchers.

Enhancements:
- Extract and reuse a helper to strip sensitive fields from player objects before returning them in MCP responses.