### PR TITLE
feat(intelligence): add mcp tools

### DIFF
--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/account.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/account.rs
@@ -1,11 +1,8 @@
-use crate::account::commands::{
-  add_auth_server, add_player_offline, delete_auth_server, delete_player, fetch_auth_server,
-  import_external_account_info, refresh_player, retrieve_auth_server_list,
-  retrieve_other_launcher_account_info, retrieve_player_list, update_player_skin_offline_preset,
-};
+use crate::account::commands::*;
 use crate::account::helpers::import::misc::ACCESS_TOKEN_EXPIRED;
 use crate::account::models::{AccountError, Player, PresetRole};
 use crate::intelligence::mcp_server::launcher::McpContext;
+use crate::intelligence::mcp_server::model::MCPError;
 use crate::mcp_tool;
 use rmcp::handler::server::tool::ToolRoute;
 
@@ -98,7 +95,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
         confirm: bool,
       } => async move {
         if !params.confirm {
-          return Err(AccountError::Invalid.into());
+          return Err(MCPError::ToolNeedsConfirmation.into());
         }
 
         delete_player(app, params.player_id).await
@@ -144,7 +141,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
         confirm: bool,
       } => async move {
         if !params.confirm {
-          return Err(AccountError::Invalid.into());
+          return Err(MCPError::ToolNeedsConfirmation.into());
         }
 
         delete_auth_server(app, params.url)
@@ -169,32 +166,31 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
           retrieve_other_launcher_account_info(app.clone(), launcher_type).await?;
 
         let mut imported_players = Vec::new();
-        let mut expired_player_ids = Vec::new();
         let mut expired_player_names = Vec::new();
         for player in players {
           if player.access_token.as_deref() == Some(ACCESS_TOKEN_EXPIRED) {
-            expired_player_ids.push(player.id);
             expired_player_names.push(player.name);
           } else {
             imported_players.push(player);
           }
         }
 
-        let player_count = imported_players.len();
-        let auth_server_count = auth_servers.len();
-        let player_names = imported_players
+        let imported_player_count = imported_players.len();
+        let imported_auth_server_count = auth_servers.len();
+        let imported_player_names = imported_players
           .iter()
           .map(|player| player.name.clone())
           .collect::<Vec<_>>();
+        let expired_player_count = expired_player_names.len();
 
         import_external_account_info(app.clone(), imported_players, auth_servers).await?;
 
         Ok(serde_json::json!({
-          "importedPlayers": player_count,
-          "importedPlayerNames": player_names,
-          "importedAuthServers": auth_server_count,
-          "ExpiredPlayers": expired_player_names.len(),
-          "ExpiredPlayerNames": expired_player_names,
+          "importedPlayers": imported_player_count,
+          "importedPlayerNames": imported_player_names,
+          "importedAuthServers": imported_auth_server_count,
+          "expiredPlayers": expired_player_count,
+          "expiredPlayerNames": expired_player_names,
         }))
       }
     ),

--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/account.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/account.rs
@@ -1,8 +1,9 @@
 use crate::account::commands::{
-  add_auth_server, add_player_offline, delete_auth_server, delete_player, refresh_player,
-  retrieve_auth_server_list, retrieve_other_launcher_account_info, retrieve_player_list,
-  update_player_skin_offline_preset,
+  add_auth_server, add_player_offline, delete_auth_server, delete_player, fetch_auth_server,
+  import_external_account_info, refresh_player, retrieve_auth_server_list,
+  retrieve_other_launcher_account_info, retrieve_player_list, update_player_skin_offline_preset,
 };
+use crate::account::helpers::import::misc::ACCESS_TOKEN_EXPIRED;
 use crate::account::models::{AccountError, Player, PresetRole};
 use crate::intelligence::mcp_server::launcher::McpContext;
 use crate::mcp_tool;
@@ -120,12 +121,15 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
     ),
     mcp_tool!(
       "add_auth_server",
-      add_auth_server,
-      "Add a 3rd-party authentication server by its normalized authlib-injector auth URL.",
+      "Fetch, validate, and add a 3rd-party authentication server from a user-provided URL.",
+      |app, params|
       #[serde(deny_unknown_fields)]
       {
-        #[schemars(description = "Authlib-injector authentication server URL.")]
+        #[schemars(description = "Authentication server URL or host to validate and add.")]
         auth_url: String,
+      } => async move {
+        let auth_server = fetch_auth_server(app.clone(), params.auth_url).await?;
+        add_auth_server(app, auth_server.auth_url).await
       }
     ),
     mcp_tool!(
@@ -147,8 +151,8 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
       }
     ),
     mcp_tool!(
-      "retrieve_other_launcher_account_info",
-      "Retrieve importable account information from another launcher. Supported launcher_type values: `HMCL`, `MultiMC`.",
+      "import_other_launcher_account_info",
+      "Retrieve account information from another launcher and import it directly into SJMCL. Supported launcher_type values: `HMCL`, `MultiMC`.",
       |app, params|
       #[serde(deny_unknown_fields)]
       {
@@ -161,13 +165,36 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
           _ => return Err(AccountError::Invalid.into()),
         };
 
-        let (mut players, auth_servers) =
-          retrieve_other_launcher_account_info(app, launcher_type).await?;
-        strip_sensitive_player_info(&mut players);
+        let (players, auth_servers) =
+          retrieve_other_launcher_account_info(app.clone(), launcher_type).await?;
+
+        let mut imported_players = Vec::new();
+        let mut expired_player_ids = Vec::new();
+        let mut expired_player_names = Vec::new();
+        for player in players {
+          if player.access_token.as_deref() == Some(ACCESS_TOKEN_EXPIRED) {
+            expired_player_ids.push(player.id);
+            expired_player_names.push(player.name);
+          } else {
+            imported_players.push(player);
+          }
+        }
+
+        let player_count = imported_players.len();
+        let auth_server_count = auth_servers.len();
+        let player_names = imported_players
+          .iter()
+          .map(|player| player.name.clone())
+          .collect::<Vec<_>>();
+
+        import_external_account_info(app.clone(), imported_players, auth_servers).await?;
 
         Ok(serde_json::json!({
-          "players": players,
-          "authServers": auth_servers,
+          "importedPlayers": player_count,
+          "importedPlayerNames": player_names,
+          "importedAuthServers": auth_server_count,
+          "ExpiredPlayers": expired_player_names.len(),
+          "ExpiredPlayerNames": expired_player_names,
         }))
       }
     ),

--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/account.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/account.rs
@@ -1,8 +1,14 @@
+use crate::account::commands::{
+  add_auth_server, add_player_offline, delete_auth_server, delete_player, refresh_player,
+  retrieve_auth_server_list, retrieve_other_launcher_account_info, retrieve_player_list,
+  update_player_skin_offline_preset,
+};
+use crate::account::models::{AccountError, Player, PresetRole};
 use crate::intelligence::mcp_server::launcher::McpContext;
 use crate::mcp_tool;
 use rmcp::handler::server::tool::ToolRoute;
 
-fn strip_sensitive_player_info(players: &mut [crate::account::models::Player]) {
+fn strip_sensitive_player_info(players: &mut [Player]) {
   for player in players {
     player.avatar = Vec::new();
     player.textures = Vec::new();
@@ -17,7 +23,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
       "retrieve_player_list",
       "Retrieve all Minecraft account(player) profiles stored in the launcher, including offline, Microsoft and 3rd-party authenticated accounts.",
       |app, _params: rmcp::model::JsonObject| async move {
-        let mut players = crate::account::commands::retrieve_player_list(app)?;
+        let mut players = retrieve_player_list(app)?;
         // remove token and base64 texture data in MCP responses to reduce context length.
         strip_sensitive_player_info(&mut players);
         Ok(players)
@@ -25,7 +31,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
     ),
     mcp_tool!(
       "add_player_offline",
-      crate::account::commands::add_player_offline,
+      add_player_offline,
       "Add a new offline Minecraft player account to the launcher. Offline accounts do not require Microsoft or 3rd-party authentication and can be used for local/LAN play.",
       #[serde(deny_unknown_fields)]
       {
@@ -67,12 +73,12 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
         preset_role: String,
       } => async move {
         let preset_role = match params.preset_role.trim().to_ascii_lowercase().as_str() {
-          "steve" => crate::account::models::PresetRole::Steve,
-          "alex" => crate::account::models::PresetRole::Alex,
-          _ => return Err(crate::account::models::AccountError::Invalid.into()),
+          "steve" => PresetRole::Steve,
+          "alex" => PresetRole::Alex,
+          _ => return Err(AccountError::Invalid.into()),
         };
 
-        crate::account::commands::update_player_skin_offline_preset(
+        update_player_skin_offline_preset(
           app,
           params.player_id,
           preset_role,
@@ -91,15 +97,15 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
         confirm: bool,
       } => async move {
         if !params.confirm {
-          return Err(crate::account::models::AccountError::Invalid.into());
+          return Err(AccountError::Invalid.into());
         }
 
-        crate::account::commands::delete_player(app, params.player_id).await
+        delete_player(app, params.player_id).await
       }
     ),
     mcp_tool!(
       "refresh_player",
-      crate::account::commands::refresh_player,
+      refresh_player,
       "Refresh authentication for a Microsoft or 3rd-party player account. Offline players cannot be refreshed. Player ID can be obtained from retrieve_player_list tool.",
       #[serde(deny_unknown_fields)]
       {
@@ -109,12 +115,12 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
     ),
     mcp_tool!(
       sync "retrieve_auth_server_list",
-      crate::account::commands::retrieve_auth_server_list,
+      retrieve_auth_server_list,
       "Retrieve configured 3rd-party authentication servers."
     ),
     mcp_tool!(
       "add_auth_server",
-      crate::account::commands::add_auth_server,
+      add_auth_server,
       "Add a 3rd-party authentication server by its normalized authlib-injector auth URL.",
       #[serde(deny_unknown_fields)]
       {
@@ -134,10 +140,10 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
         confirm: bool,
       } => async move {
         if !params.confirm {
-          return Err(crate::account::models::AccountError::Invalid.into());
+          return Err(AccountError::Invalid.into());
         }
 
-        crate::account::commands::delete_auth_server(app, params.url)
+        delete_auth_server(app, params.url)
       }
     ),
     mcp_tool!(
@@ -152,11 +158,11 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
         let launcher_type = match params.launcher_type.trim().to_ascii_lowercase().as_str() {
           "hmcl" => crate::account::helpers::import::ImportLauncherType::HMCL,
           "multimc" => crate::account::helpers::import::ImportLauncherType::MultiMC,
-          _ => return Err(crate::account::models::AccountError::Invalid.into()),
+          _ => return Err(AccountError::Invalid.into()),
         };
 
         let (mut players, auth_servers) =
-          crate::account::commands::retrieve_other_launcher_account_info(app, launcher_type).await?;
+          retrieve_other_launcher_account_info(app, launcher_type).await?;
         strip_sensitive_player_info(&mut players);
 
         Ok(serde_json::json!({

--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/account.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/account.rs
@@ -2,6 +2,15 @@ use crate::intelligence::mcp_server::launcher::McpContext;
 use crate::mcp_tool;
 use rmcp::handler::server::tool::ToolRoute;
 
+fn strip_sensitive_player_info(players: &mut [crate::account::models::Player]) {
+  for player in players {
+    player.avatar = Vec::new();
+    player.textures = Vec::new();
+    player.access_token = None;
+    player.refresh_token = None;
+  }
+}
+
 pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
   vec![
     mcp_tool!(
@@ -10,12 +19,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
       |app, _params: rmcp::model::JsonObject| async move {
         let mut players = crate::account::commands::retrieve_player_list(app)?;
         // remove token and base64 texture data in MCP responses to reduce context length.
-        for player in &mut players {
-          player.avatar = Vec::new();
-          player.textures = Vec::new();
-          player.access_token = None;
-          player.refresh_token = None;
-        }
+        strip_sensitive_player_info(&mut players);
         Ok(players)
       }
     ),
@@ -49,6 +53,116 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
           "states.shared.selectedPlayerId".to_string(),
           value,
         )
+      }
+    ),
+    mcp_tool!(
+      "update_player_skin_offline_preset",
+      "Update an offline Minecraft player's skin to a built-in preset role. Only offline players are supported. Player ID can be obtained from retrieve_player_list tool.",
+      |app, params|
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Offline player profile ID returned by `retrieve_player_list`.")]
+        player_id: String,
+        #[schemars(description = "Built-in skin preset role. Accepted values: `steve`, `alex`.")]
+        preset_role: String,
+      } => async move {
+        let preset_role = match params.preset_role.trim().to_ascii_lowercase().as_str() {
+          "steve" => crate::account::models::PresetRole::Steve,
+          "alex" => crate::account::models::PresetRole::Alex,
+          _ => return Err(crate::account::models::AccountError::Invalid.into()),
+        };
+
+        crate::account::commands::update_player_skin_offline_preset(
+          app,
+          params.player_id,
+          preset_role,
+        )
+      }
+    ),
+    mcp_tool!(
+      "delete_player",
+      "Delete a Minecraft player account from the launcher by player ID. Requires confirm=true. Player ID can be obtained from retrieve_player_list tool.",
+      |app, params|
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Player profile ID returned by `retrieve_player_list`.")]
+        player_id: String,
+        #[schemars(description = "Must be true to confirm deleting this player account.")]
+        confirm: bool,
+      } => async move {
+        if !params.confirm {
+          return Err(crate::account::models::AccountError::Invalid.into());
+        }
+
+        crate::account::commands::delete_player(app, params.player_id).await
+      }
+    ),
+    mcp_tool!(
+      "refresh_player",
+      crate::account::commands::refresh_player,
+      "Refresh authentication for a Microsoft or 3rd-party player account. Offline players cannot be refreshed. Player ID can be obtained from retrieve_player_list tool.",
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Microsoft or 3rd-party player profile ID returned by `retrieve_player_list`.")]
+        player_id: String,
+      }
+    ),
+    mcp_tool!(
+      sync "retrieve_auth_server_list",
+      crate::account::commands::retrieve_auth_server_list,
+      "Retrieve configured 3rd-party authentication servers."
+    ),
+    mcp_tool!(
+      "add_auth_server",
+      crate::account::commands::add_auth_server,
+      "Add a 3rd-party authentication server by its normalized authlib-injector auth URL.",
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Authlib-injector authentication server URL.")]
+        auth_url: String,
+      }
+    ),
+    mcp_tool!(
+      "delete_auth_server",
+      "Delete a 3rd-party authentication server by URL. Requires confirm=true. This also removes all players using that server.",
+      |app, params|
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Authentication server URL returned by `retrieve_auth_server_list`.")]
+        url: String,
+        #[schemars(description = "Must be true to confirm deleting this auth server and all players using it.")]
+        confirm: bool,
+      } => async move {
+        if !params.confirm {
+          return Err(crate::account::models::AccountError::Invalid.into());
+        }
+
+        crate::account::commands::delete_auth_server(app, params.url)
+      }
+    ),
+    mcp_tool!(
+      "retrieve_other_launcher_account_info",
+      "Retrieve importable account information from another launcher. Supported launcher_type values: `HMCL`, `MultiMC`.",
+      |app, params|
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Source launcher type. Accepted values: `HMCL`, `MultiMC`.")]
+        launcher_type: String,
+      } => async move {
+        let launcher_type = match params.launcher_type.trim().to_ascii_lowercase().as_str() {
+          "hmcl" => crate::account::helpers::import::ImportLauncherType::HMCL,
+          "multimc" => crate::account::helpers::import::ImportLauncherType::MultiMC,
+          _ => return Err(crate::account::models::AccountError::Invalid.into()),
+        };
+
+        let (mut players, auth_servers) =
+          crate::account::commands::retrieve_other_launcher_account_info(app, launcher_type).await?;
+        strip_sensitive_player_info(&mut players);
+
+        Ok(serde_json::json!({
+          "players": players,
+          "authServers": auth_servers,
+        }))
       }
     ),
   ]

--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/discover.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/discover.rs
@@ -33,7 +33,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
       |app, params|
       #[serde(deny_unknown_fields)]
       {
-        #[schemars(description = "News source requests. Each item contains a source endpoint URL and optional cursor for paginated loading.")]
+        #[schemars(description = "News source requests.")]
         requests: Vec<McpNewsPostRequest>,
       } => async move {
         let requests = params

--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/discover.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/discover.rs
@@ -1,29 +1,71 @@
+use crate::discover::commands::{fetch_news_post_summaries, fetch_news_sources_info};
 use crate::discover::helpers::mc_news::{fetch_mc_news_page, MC_NEWS_ENDPOINT};
+use crate::discover::models::NewsPostRequest;
 use crate::intelligence::mcp_server::launcher::McpContext;
 use crate::mcp_tool;
 use crate::utils::web::with_retry;
 use rmcp::handler::server::tool::ToolRoute;
+use serde::Deserialize;
 use tauri::{Manager, State};
 use tauri_plugin_http::reqwest;
 
-pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
-  vec![mcp_tool!(
-    "fetch_minecraft_official_news",
-    "Fetch official Minecraft news with cursor pagination.",
-    |app, params|
-    #[serde(deny_unknown_fields)]
-    {
-      #[schemars(description = "Cursor for the next page. Omit on the first request. To load more, pass the previous response's `next`.")]
-      cursor: Option<u64>,
-    } => async move {
-      let client_state: State<reqwest::Client> = app.state();
-      let client = with_retry(client_state.inner().clone());
-
-      let (_, response) = fetch_mc_news_page(&client, MC_NEWS_ENDPOINT, params.cursor)
-        .await
-        .ok_or_else(|| crate::error::SJMCLError("failed to fetch Minecraft official news".to_string()))?;
-
-      Ok::<_, crate::error::SJMCLError>(response)
-    }
+#[derive(Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct McpNewsPostRequest {
+  #[schemars(description = "News source endpoint URL returned by `fetch_news_sources_info`.")]
+  url: String,
+  #[schemars(
+    description = "Cursor for this source. Omit on the first request; use the previous response's `cursors[url]` value to load more."
   )]
+  cursor: Option<u64>,
+}
+
+pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
+  vec![
+    mcp_tool!(
+      "fetch_news_sources_info",
+      fetch_news_sources_info,
+      "Retrieve configured news source metadata, including endpoint URLs used by fetch_news_post_summaries."
+    ),
+    mcp_tool!(
+      "fetch_news_post_summaries",
+      "Fetch news post summaries from one or more Discover page source endpoints. Use fetch_news_sources_info first to get source endpoint URLs.",
+      |app, params|
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "News source requests. Each item contains a source endpoint URL and optional cursor.")]
+        requests: Vec<McpNewsPostRequest>,
+      } => async move {
+        let requests = params
+          .requests
+          .into_iter()
+          .map(|request| NewsPostRequest {
+            url: request.url,
+            cursor: request.cursor,
+          })
+          .collect();
+
+        fetch_news_post_summaries(app, requests).await
+      }
+    ),
+    mcp_tool!(
+      "fetch_minecraft_official_news",
+      "Fetch official Minecraft news with cursor pagination.",
+      |app, params|
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Cursor for the next page. Omit on the first request. To load more, pass the previous response's `next`.")]
+        cursor: Option<u64>,
+      } => async move {
+        let client_state: State<reqwest::Client> = app.state();
+        let client = with_retry(client_state.inner().clone());
+
+        let (_, response) = fetch_mc_news_page(&client, MC_NEWS_ENDPOINT, params.cursor)
+          .await
+          .ok_or_else(|| crate::error::SJMCLError("failed to fetch Minecraft official news".to_string()))?;
+
+        Ok::<_, crate::error::SJMCLError>(response)
+      }
+    ),
+  ]
 }

--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/discover.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/discover.rs
@@ -25,15 +25,15 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
     mcp_tool!(
       "fetch_news_sources_info",
       fetch_news_sources_info,
-      "Retrieve configured news source metadata, including endpoint URLs used by fetch_news_post_summaries."
+      "Retrieve configured community news source metadata, including endpoint URLs used by fetch_news_post_summaries."
     ),
     mcp_tool!(
       "fetch_news_post_summaries",
-      "Fetch news post summaries from one or more Discover page source endpoints. Use fetch_news_sources_info first to get source endpoint URLs.",
+      "Fetch news post summaries from one or more community news source endpoints with cursor pagination. Use fetch_news_sources_info first to get source endpoint URLs. To load more, pass each source's previous response cursor from `cursors[url]` into that request's `cursor` field.",
       |app, params|
       #[serde(deny_unknown_fields)]
       {
-        #[schemars(description = "News source requests. Each item contains a source endpoint URL and optional cursor.")]
+        #[schemars(description = "News source requests. Each item contains a source endpoint URL and optional cursor for paginated loading.")]
         requests: Vec<McpNewsPostRequest>,
       } => async move {
         let requests = params

--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/extension.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/extension.rs
@@ -1,0 +1,39 @@
+use crate::extension::commands::{delete_extension, retrieve_extension_list};
+use crate::extension::models::ExtensionError;
+use crate::intelligence::mcp_server::launcher::McpContext;
+use crate::mcp_tool;
+use rmcp::handler::server::tool::ToolRoute;
+
+pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
+  vec![
+    mcp_tool!(
+      "retrieve_extension_list",
+      "Retrieve installed launcher extensions. Icon image payloads are stripped from MCP responses to reduce context length.",
+      |app, _params: rmcp::model::JsonObject| async move {
+        let mut extensions = retrieve_extension_list(app)?;
+        for extension in &mut extensions {
+          extension.icon_src = Default::default();
+        }
+        Ok(extensions)
+      }
+    ),
+    mcp_tool!(
+      "delete_extension",
+      "Delete an installed launcher extension by identifier. Requires confirm=true.",
+      |app, params|
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Extension identifier returned by `retrieve_extension_list`.")]
+        identifier: String,
+        #[schemars(description = "Must be true to confirm deleting this extension.")]
+        confirm: bool,
+      } => async move {
+        if !params.confirm {
+          return Err(ExtensionError::InvalidIdentifier.into());
+        }
+
+        delete_extension(app, params.identifier)
+      }
+    ),
+  ]
+}

--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/extension.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/extension.rs
@@ -8,7 +8,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
   vec![
     mcp_tool!(
       "retrieve_extension_list",
-      "Retrieve installed launcher extensions. Icon image payloads are stripped from MCP responses to reduce context length.",
+      "Retrieve installed launcher extensions.",
       |app, _params: rmcp::model::JsonObject| async move {
         let mut extensions = retrieve_extension_list(app)?;
         for extension in &mut extensions {

--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/extension.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/extension.rs
@@ -1,6 +1,6 @@
 use crate::extension::commands::{delete_extension, retrieve_extension_list};
-use crate::extension::models::ExtensionError;
 use crate::intelligence::mcp_server::launcher::McpContext;
+use crate::intelligence::mcp_server::model::MCPError;
 use crate::mcp_tool;
 use rmcp::handler::server::tool::ToolRoute;
 
@@ -29,7 +29,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
         confirm: bool,
       } => async move {
         if !params.confirm {
-          return Err(ExtensionError::InvalidIdentifier.into());
+          return Err(MCPError::ToolNeedsConfirmation.into());
         }
 
         delete_extension(app, params.identifier)

--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/instance.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/instance.rs
@@ -1,3 +1,4 @@
+use crate::instance::commands::*;
 use crate::intelligence::mcp_server::launcher::McpContext;
 use crate::mcp_tool;
 use rmcp::handler::server::tool::ToolRoute;
@@ -6,12 +7,12 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
   vec![
     mcp_tool!(
       "retrieve_instance_list",
-      crate::instance::commands::retrieve_instance_list,
+      retrieve_instance_list,
       "Primary tool for listing local Minecraft instances. Returns instance IDs and metadata for selecting an instance."
     ),
     mcp_tool!(
       "retrieve_world_list",
-      crate::instance::commands::retrieve_world_list,
+      retrieve_world_list,
       "Retrieve local world metadata for a Minecraft instance.",
       #[serde(deny_unknown_fields)]
       {
@@ -29,7 +30,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
         instance_id: String,
       } => async move {
         // always query online status in MCP context.
-        crate::instance::commands::retrieve_game_server_list(app, params.instance_id, true).await
+        retrieve_game_server_list(app, params.instance_id, true).await
       }
     ),
     mcp_tool!(
@@ -41,8 +42,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
         #[schemars(description = "Minecraft instance ID.")]
         instance_id: String,
       } => async move {
-        let mut mods =
-          crate::instance::commands::retrieve_local_mod_list(app, params.instance_id).await?;
+        let mut mods = retrieve_local_mod_list(app, params.instance_id).await?;
         // strip icon binary payload in MCP responses to reduce context length.
         for mod_info in &mut mods {
           mod_info.icon_src = Default::default();
@@ -52,7 +52,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
     ),
     mcp_tool!(
       "retrieve_resource_pack_list",
-      crate::instance::commands::retrieve_resource_pack_list,
+      retrieve_resource_pack_list,
       "Retrieve resource packs for a Minecraft instance.",
       #[serde(deny_unknown_fields)]
       {
@@ -62,7 +62,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
     ),
     mcp_tool!(
       "retrieve_server_resource_pack_list",
-      crate::instance::commands::retrieve_server_resource_pack_list,
+      retrieve_server_resource_pack_list,
       "Retrieve server resource packs for a Minecraft instance.",
       #[serde(deny_unknown_fields)]
       {
@@ -72,7 +72,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
     ),
     mcp_tool!(
       sync "retrieve_schematic_list",
-      crate::instance::commands::retrieve_schematic_list,
+      retrieve_schematic_list,
       "Retrieve schematics for a Minecraft instance.",
       #[serde(deny_unknown_fields)]
       {
@@ -82,7 +82,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
     ),
     mcp_tool!(
       sync "retrieve_shader_pack_list",
-      crate::instance::commands::retrieve_shader_pack_list,
+      retrieve_shader_pack_list,
       "Retrieve shader packs for a Minecraft instance.",
       #[serde(deny_unknown_fields)]
       {
@@ -92,7 +92,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
     ),
     mcp_tool!(
       sync "retrieve_screenshot_list",
-      crate::instance::commands::retrieve_screenshot_list,
+      retrieve_screenshot_list,
       "Retrieve screenshots for a Minecraft instance.",
       #[serde(deny_unknown_fields)]
       {
@@ -111,10 +111,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
         #[schemars(description = "Set to true to enable the mod file, or false to disable it.")]
         enable: bool,
       } => async move {
-        crate::instance::commands::toggle_mod_by_extension(
-          std::path::PathBuf::from(params.file_path),
-          params.enable,
-        )
+        toggle_mod_by_extension(std::path::PathBuf::from(params.file_path), params.enable)
       }
     ),
   ]

--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/launcher_config.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/launcher_config.rs
@@ -1,4 +1,5 @@
 use crate::intelligence::mcp_server::launcher::McpContext;
+use crate::launcher_config::commands::{retrieve_launcher_config, update_launcher_config};
 use crate::mcp_tool;
 use rmcp::handler::server::tool::ToolRoute;
 
@@ -6,12 +7,12 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
   vec![
     mcp_tool!(
       sync "retrieve_launcher_config",
-      crate::launcher_config::commands::retrieve_launcher_config,
+      retrieve_launcher_config,
       "Retrieve full launcher configuration snapshot. This includes game launch settings, game directory settings, launcher app settings, currently selected instance/account, and other global preferences."
     ),
     mcp_tool!(
       sync "update_launcher_config",
-      crate::launcher_config::commands::update_launcher_config,
+      update_launcher_config,
       "Update a launcher config field by key_path. Use this to change game settings, launcher app settings, selected instance/account ID, and other config values.",
       #[serde(deny_unknown_fields)]
       {

--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/mod.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/mod.rs
@@ -1,6 +1,7 @@
 mod account;
 mod debug;
 mod discover;
+mod extension;
 mod instance;
 mod launch;
 mod launcher_config;
@@ -15,6 +16,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
   routes.extend(launcher_config::tool_routes());
   routes.extend(account::tool_routes());
   routes.extend(discover::tool_routes());
+  routes.extend(extension::tool_routes());
   routes.extend(instance::tool_routes());
   routes.extend(launch::tool_routes());
   routes.extend(resource::tool_routes());

--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/resource.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/resource.rs
@@ -1,11 +1,12 @@
 use crate::intelligence::mcp_server::launcher::McpContext;
 use crate::mcp_tool;
+use crate::resource::commands::fetch_game_version_list;
 use rmcp::handler::server::tool::ToolRoute;
 
 pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
   vec![mcp_tool!(
     "fetch_game_version_list",
-    crate::resource::commands::fetch_game_version_list,
+    fetch_game_version_list,
     "Fetch the list of available Minecraft game versions."
   )]
 }

--- a/src-tauri/src/intelligence/mcp_server/mod.rs
+++ b/src-tauri/src/intelligence/mcp_server/mod.rs
@@ -1,1 +1,2 @@
 pub mod launcher;
+pub mod model;

--- a/src-tauri/src/intelligence/mcp_server/model.rs
+++ b/src-tauri/src/intelligence/mcp_server/model.rs
@@ -1,0 +1,9 @@
+use strum_macros::Display;
+
+#[derive(Debug, Display)]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
+pub enum MCPError {
+  ToolNeedsConfirmation,
+}
+
+impl std::error::Error for MCPError {}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - add mcp tools

## Summary by Sourcery

Add MCP tools to manage launcher player accounts and 3rd-party auth servers, while ensuring sensitive player data is stripped from tool responses.

New Features:
- Expose tools to update offline player skins to preset roles, delete and refresh player accounts, and manage 3rd-party authentication servers via the MCP interface.
- Add a tool to retrieve importable accounts and auth servers from other launchers (HMCL and MultiMC) for migration into the launcher.

Enhancements:
- Centralize stripping of sensitive player fields (tokens and texture data) for reuse across MCP account-related tools to reduce context size and avoid leaking secrets.