### PR TITLE
fix bug#1533

### DIFF
--- a/src-tauri/src/tasks/events.rs
+++ b/src-tauri/src/tasks/events.rs
@@ -222,7 +222,7 @@ impl Sink for TauriEventSink {
       task_group,
       percentage as f64 / 100.0,
       current,
-      estimated_time.map(Duration::from_secs_f64),
+      estimated_time.map(|x| Duration::from_secs_f64(x.max(0.0))),
       speed,
     );
   }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x ] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - issue #1533 

### Description

> - 在"下载任务"页面时，TauriEventSink的Sink Trait实现中，report_progress的estimated_time可能存在负值，Duration::from_secs_f64函数在参数为负值时会panic, 我增加了对estimated_time调用max(0.0)进行处理避免负值问题

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Bug Fixes:
- Avoid a panic in the download tasks progress reporting when a negative estimated_time is passed to Duration::from_secs_f64.