### PR TITLE
feat(frontend): support control display style of discover page on home head navbar

### DIFF
--- a/src-tauri/src/launcher_config/models.rs
+++ b/src-tauri/src/launcher_config/models.rs
@@ -267,6 +267,8 @@ structstruck::strike! {
         pub language: String,
       },
       pub functionality: struct {
+        #[default = "on"]
+        pub discover_page: String,
         #[default = "instance"]
         pub instances_nav_type: String,
         #[default = true]

--- a/src/components/head-navbar-v2.tsx
+++ b/src/components/head-navbar-v2.tsx
@@ -14,15 +14,18 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
 import type { CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
+import { IconType } from "react-icons";
 import {
   LuBox,
   LuCircleUserRound,
   LuCompass,
+  LuSearch,
   LuSettings,
   LuZap,
 } from "react-icons/lu";
@@ -30,21 +33,15 @@ import AdvancedCard from "@/components/common/advanced-card";
 import { DownloadIndicator } from "@/components/download-indicator";
 import { TitleShort } from "@/components/logo-title";
 import { useLauncherConfig } from "@/contexts/config";
+import { useSharedModals } from "@/contexts/shared-modal";
 import { useTaskContext } from "@/contexts/task";
 import styles from "@/styles/head-navbar.module.css";
-
-const NAV_LIST = [
-  { icon: LuZap, label: "launch", path: "/launch" },
-  { icon: LuBox, label: "instances", path: "/instances" },
-  { icon: LuCircleUserRound, label: "accounts", path: "/accounts" },
-  { icon: LuCompass, label: "discover", path: "/discover" },
-  { icon: LuSettings, label: "settings", path: "/settings" },
-] as const;
 
 const HeadNavBar = () => {
   const router = useRouter();
   const { t, i18n } = useTranslation();
   const { config } = useLauncherConfig();
+  const { openSharedModal } = useSharedModals();
   const { tasks } = useTaskContext();
 
   const primaryColor = config.appearance.theme.primaryColor;
@@ -84,6 +81,35 @@ const HeadNavBar = () => {
     "rgba(255, 255, 255, 0.08)"
   );
 
+  const navList = useMemo<
+    Array<{
+      icon: IconType;
+      label: string;
+      path?: string;
+      onClick?: () => void;
+    }>
+  >(() => {
+    const discoverPageMode = config.general.functionality.discoverPage;
+
+    return [
+      { icon: LuZap, label: "launch", path: "/launch" },
+      { icon: LuBox, label: "instances", path: "/instances" },
+      { icon: LuCircleUserRound, label: "accounts", path: "/accounts" },
+      ...(discoverPageMode === "on"
+        ? [{ icon: LuCompass, label: "discover", path: "/discover" }]
+        : discoverPageMode === "search-only"
+          ? [
+              {
+                icon: LuSearch,
+                label: "search",
+                onClick: () => openSharedModal("spotlight-search"),
+              },
+            ]
+          : []),
+      { icon: LuSettings, label: "settings", path: "/settings" },
+    ];
+  }, [config.general.functionality.discoverPage, openSharedModal]);
+
   // animation trigger
   useEffect(() => {
     setIsAnimating(true);
@@ -95,8 +121,8 @@ const HeadNavBar = () => {
     isSimplified,
   ]);
 
-  const selectedIndex = NAV_LIST.findIndex((item) =>
-    router.pathname.startsWith(item.path)
+  const selectedIndex = navList.findIndex(
+    (item) => item.path && router.pathname.startsWith(item.path)
   );
 
   const updateIndicator = useCallback(() => {
@@ -163,9 +189,13 @@ const HeadNavBar = () => {
   }, [updateIndicator, isSimplified, i18n.resolvedLanguage]);
 
   const handleTabChange = (index: number) => {
-    const target = NAV_LIST[index];
+    const target = navList[index];
     if (target) {
-      router.push(target.path);
+      if (target.onClick) {
+        target.onClick();
+      } else if (target.path) {
+        router.push(target.path);
+      }
     }
   };
 
@@ -197,11 +227,11 @@ const HeadNavBar = () => {
               transform={`translateX(${indicator.left}px)`}
               w={`${indicator.width}px`}
             />
-            {NAV_LIST.map((item, index) => {
+            {navList.map((item, index) => {
               const isSelected = selectedIndex === index;
               return (
                 <Tooltip
-                  key={item.path}
+                  key={`${item.label}-${item.path ?? "action"}`}
                   label={t(`HeadNavBar.navList.${item.label}`)}
                   placement="bottom"
                   isDisabled={!isSimplified || isSelected}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1118,6 +1118,13 @@
     "functions": {
       "title": "Functionality",
       "settings": {
+        "discoverPage": {
+          "title": "Discover Page",
+          "description": "Conveniently browse Minecraft and community news, search and download game resource from the Discover page.",
+          "on": "On",
+          "search-only": "Search Only",
+          "off": "Hidden"
+        },
         "instancesNavType": {
           "title": "Instance Page Navigation Mode",
           "description": "Change whether the instance page's left navigation bar is displayed and its grouping method.",

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -1118,6 +1118,13 @@
     "functions": {
       "title": "功能",
       "settings": {
+        "discoverPage": {
+          "title": "发现页",
+          "description": "在发现页便捷地查看 Minecraft 与社区新闻、搜索与下载游戏资源",
+          "on": "开启",
+          "search-only": "仅显示搜索",
+          "off": "隐藏"
+        },
         "instancesNavType": {
           "title": "实例页导航栏模式",
           "description": "更改实例页左侧导航栏是否显示、分组方式",

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -121,6 +121,7 @@ export interface LauncherConfig {
       language: string;
     };
     functionality: {
+      discoverPage: string;
       instancesNavType: string;
       launchPageQuickSwitch: boolean;
       autoDownloadJava: boolean;
@@ -295,6 +296,7 @@ export const defaultConfig: LauncherConfig = {
       language: "zh-Hans",
     },
     functionality: {
+      discoverPage: "on",
       instancesNavType: "instance",
       launchPageQuickSwitch: true,
       autoDownloadJava: true,

--- a/src/pages/settings/general.tsx
+++ b/src/pages/settings/general.tsx
@@ -3,7 +3,7 @@ import { appLogDir, join } from "@tauri-apps/api/path";
 import { openPath } from "@tauri-apps/plugin-opener";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { LuLanguages } from "react-icons/lu";
+import { LuCompass, LuLanguages } from "react-icons/lu";
 import { MenuSelector } from "@/components/common/menu-selector";
 import {
   OptionItemGroup,
@@ -41,6 +41,7 @@ const GeneralSettingsPage = () => {
   } = useDisclosure();
 
   const instancesNavTypes = ["instance", "directory", "tag", "hidden"];
+  const discoverPageModes = ["on", "search-only", "off"];
 
   const handleRestoreLauncherConfig = useCallback(async () => {
     ConfigService.restoreLauncherConfig().then((response) => {
@@ -153,6 +154,37 @@ const GeneralSettingsPage = () => {
       title: t("GeneralSettingsPage.functions.title"),
       items: [
         {
+          title: t("GeneralSettingsPage.functions.settings.discoverPage.title"),
+          description: t(
+            "GeneralSettingsPage.functions.settings.discoverPage.description"
+          ),
+          prefixElement: <LuCompass />,
+          children: (
+            <MenuSelector
+              options={discoverPageModes.map((mode) => ({
+                value: mode,
+                label: t(
+                  `GeneralSettingsPage.functions.settings.discoverPage.${mode}`
+                ),
+              }))}
+              value={generalConfigs.functionality.discoverPage}
+              onSelect={(value) => {
+                update("general.functionality.discoverPage", value as string);
+              }}
+              placeholder={t(
+                `GeneralSettingsPage.functions.settings.discoverPage.${generalConfigs.functionality.discoverPage}`
+              )}
+              buttonProps={{
+                flex: "0 0 auto",
+              }}
+            />
+          ),
+        },
+      ],
+    },
+    {
+      items: [
+        {
           title: t(
             "GeneralSettingsPage.functions.settings.instancesNavType.title"
           ),
@@ -174,12 +206,6 @@ const GeneralSettingsPage = () => {
                   value as string
                 );
                 removeHistory("/instances");
-              }}
-              placeholder={t(
-                `GeneralSettingsPage.functions.settings.instancesNavType.${generalConfigs.functionality.instancesNavType}`
-              )}
-              buttonProps={{
-                flex: "0 0 auto",
               }}
             />
           ),


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - e.g. close #xxxx, fix #xxxx

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Add configurable behavior for the discover/search entry in the head navbar based on launcher settings.

New Features:
- Allow configuring the discover page behavior (full discover tab, search-only entry, or disabled) via general settings.
- Update the head navbar to dynamically show either a Discover tab, a Search action, or nothing depending on the configured discover page mode.

Enhancements:
- Extend launcher configuration (frontend and backend) with a discover page mode setting and sensible defaults.