### PR TITLE
feat(extension): support extension to read file within instance root by new command

### DIFF
--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -58,7 +58,7 @@ use crate::tasks::download::DownloadParam;
 use crate::tasks::PTaskParam;
 use crate::utils::fs::{
   copy_whole_dir, create_url_shortcut, generate_unique_filename, get_files_with_regex,
-  get_subdirectories,
+  get_subdirectories, normalize_relative_path,
 };
 use crate::utils::image::ImageWrapper;
 use lazy_static::lazy_static;
@@ -233,6 +233,27 @@ pub fn retrieve_instance_subdir_path(
     Some(path) => Ok(path),
     None => Err(InstanceError::InstanceNotFoundByID.into()),
   }
+}
+
+// Capability for extensions, CLI and external agents
+#[tauri::command]
+pub fn read_instance_file(
+  app: AppHandle,
+  instance_id: String,
+  dir_type: InstanceSubdirType,
+  path: String,
+) -> SJMCLResult<String> {
+  let subdir = get_instance_subdir_path_by_id(&app, &instance_id, &dir_type)
+    .ok_or(InstanceError::InstanceNotFoundByID)?;
+  let relative_path =
+    normalize_relative_path(Path::new(&path)).map_err(|_| InstanceError::InvalidSourcePath)?;
+  let cano_subdir = fs::canonicalize(subdir)?;
+  let cano_target = fs::canonicalize(cano_subdir.join(relative_path))?;
+
+  if !cano_target.starts_with(&cano_subdir) {
+    return Err(InstanceError::InvalidSourcePath.into());
+  }
+  fs::read_to_string(cano_target).map_err(Into::into)
 }
 
 #[tauri::command]

--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -243,8 +243,7 @@ pub fn read_instance_file(
   dir_type: InstanceSubdirType,
   path: String,
 ) -> SJMCLResult<String> {
-  let subdir = get_instance_subdir_path_by_id(&app, &instance_id, &dir_type)
-    .ok_or(InstanceError::InstanceNotFoundByID)?;
+  let subdir = retrieve_instance_subdir_path(app, instance_id, dir_type)?;
   let relative_path =
     normalize_relative_path(Path::new(&path)).map_err(|_| InstanceError::InvalidSourcePath)?;
   let cano_subdir = fs::canonicalize(subdir)?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -118,6 +118,7 @@ pub async fn run() {
         instance::commands::retrieve_instance_game_config,
         instance::commands::restore_instance_game_config,
         instance::commands::retrieve_instance_subdir_path,
+        instance::commands::read_instance_file,
         instance::commands::delete_instance,
         instance::commands::rename_instance,
         instance::commands::copy_resource_to_instances,

--- a/src-tauri/src/utils/commands.rs
+++ b/src-tauri/src/utils/commands.rs
@@ -48,6 +48,8 @@ pub fn extract_filename(path_str: String, with_ext: bool) -> SJMCLResult<String>
   Ok(extract_filename_helper(&path_str, with_ext))
 }
 
+// ------- Additional file commands for extensions. -------
+
 #[tauri::command]
 pub fn delete_file(path: String) -> SJMCLResult<()> {
   fs::remove_file(&path).map_err(Into::into)

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -122,6 +122,19 @@ pub fn extract_filename(path_str: &str, with_ext: bool) -> String {
   }
 }
 
+/// Normalizes a relative path by removing `.` segments and rejecting invalid components.
+///
+/// Rejects:
+/// - parent directory traversal (`..`)
+/// - absolute path prefixes or roots
+/// - empty / current-directory-only paths
+///
+/// # Examples
+///
+/// ```rust
+/// let path = normalize_relative_path(Path::new("./config/options.txt"))?;
+/// assert_eq!(path, PathBuf::from("config/options.txt"));
+/// ```
 pub fn normalize_relative_path(path: &Path) -> SJMCLResult<PathBuf> {
   let mut normalized = PathBuf::new();
 

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -5,7 +5,7 @@ use sha1::{Digest, Sha1};
 use sha2::Sha256;
 use std::ffi::OsStr;
 use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::{fs, io};
 use tauri::path::BaseDirectory;
 use tauri::{AppHandle, Manager};
@@ -120,6 +120,24 @@ pub fn extract_filename(path_str: &str, with_ext: bool) -> String {
       .unwrap_or("")
       .to_string()
   }
+}
+
+pub fn normalize_relative_path(path: &Path) -> SJMCLResult<PathBuf> {
+  let mut normalized = PathBuf::new();
+
+  for component in path.components() {
+    match component {
+      Component::Normal(part) => normalized.push(part),
+      Component::CurDir => {}
+      _ => return Err(SJMCLError("Invalid relative path".into())),
+    }
+  }
+
+  if normalized.as_os_str().is_empty() {
+    return Err(SJMCLError("Invalid relative path".into()));
+  }
+
+  Ok(normalized)
 }
 
 /// Retrieves a list of subdirectories within a given path.

--- a/src/services/instance.ts
+++ b/src/services/instance.ts
@@ -145,6 +145,28 @@ export class InstanceService {
   }
 
   /**
+   * READ a file under the specified instance directory type.
+   * @param {string} instanceId - The instance ID.
+   * @param {InstanceSubdirType} dirType - The directory type.
+   * @param {string} path - Relative path under the instance directory.
+   * @returns {Promise<InvokeResponse<string>>}
+   *
+   * This command is mainly designed for extensions, CLI and external agents.
+   */
+  @responseHandler("instance")
+  static async readInstanceFile(
+    instanceId: string,
+    dirType: InstanceSubdirType,
+    path: string
+  ): Promise<InvokeResponse<string>> {
+    return await invoke("read_instance_file", {
+      instanceId,
+      dirType,
+      path,
+    });
+  }
+
+  /**
    * DELETE the specified instance's version folder from disk.
    * @param {string} instanceId - The instance ID to delete.
    * @returns {Promise<InvokeResponse<void>>}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - e.g. close #xxxx, fix #xxxx

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Add support for reading text files within an instance’s directory via a new extension-friendly command with path normalization and safety checks.

New Features:
- Expose a new InstanceService API and Tauri command to read a file from a specified instance subdirectory for extensions, CLI, and external agents.

Enhancements:
- Introduce a filesystem utility to normalize and validate relative paths and enforce that requested files stay within the target instance directory.