### PR TITLE
refactor(frontend): add constant for resource refresh event

### DIFF
--- a/src/contexts/task.tsx
+++ b/src/contexts/task.tsx
@@ -33,6 +33,7 @@ import {
   ExtensionService,
 } from "@/services/extension";
 import { InstanceService } from "@/services/instance";
+import { RESOURCE_REFRESH_EVENT } from "@/services/resource";
 import { TaskService } from "@/services/task";
 
 interface TaskContextType {
@@ -542,19 +543,13 @@ export const TaskContextProvider: React.FC<{ children: React.ReactNode }> = ({
                 break;
               case "mod":
               case "mod-update":
-                emit("instance:refresh-resource-list", OtherResourceType.Mod);
+                emit(RESOURCE_REFRESH_EVENT, OtherResourceType.Mod);
                 break;
               case "resourcepack":
-                emit(
-                  "instance:refresh-resource-list",
-                  OtherResourceType.ResourcePack
-                );
+                emit(RESOURCE_REFRESH_EVENT, OtherResourceType.ResourcePack);
                 break;
               case "shader":
-                emit(
-                  "instance:refresh-resource-list",
-                  OtherResourceType.ShaderPack
-                );
+                emit(RESOURCE_REFRESH_EVENT, OtherResourceType.ShaderPack);
                 break;
               case "modpack": {
                 let group = newTasks.find(

--- a/src/services/resource.ts
+++ b/src/services/resource.ts
@@ -15,6 +15,8 @@ import {
 import { InvokeResponse } from "@/models/response";
 import { responseHandler } from "@/utils/response";
 
+export const RESOURCE_REFRESH_EVENT = "instance:refresh-resource-list";
+
 /**
  * Service class for managing game & mod loader resources.
  */
@@ -197,7 +199,7 @@ export class ResourceService {
     callback: (payload: OtherResourceType) => void
   ): () => void {
     const unlisten = getCurrentWebview().listen<OtherResourceType>(
-      "instance:refresh-resource-list",
+      RESOURCE_REFRESH_EVENT,
       (event) => {
         callback(event.payload);
       }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

## Summary by Sourcery

Centralize the resource refresh event name and update usage across the frontend.

Enhancements:
- Introduce a shared RESOURCE_REFRESH_EVENT constant for the instance resource refresh event.
- Update task context and resource service listeners to use the new event constant instead of hard-coded strings.