### PR TITLE
feat(extension): support moving home widgets down

### DIFF
--- a/src/components/extension/home-widget-container.tsx
+++ b/src/components/extension/home-widget-container.tsx
@@ -341,32 +341,22 @@ const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
     [persistHomeWidgetState]
   );
 
-  const handleMoveWidgetUp = useCallback(
-    (widgetIdentifier: string) => {
+  const handleMoveWidget = useCallback(
+    (widgetIdentifier: string, direction: -1 | 1) => {
       const currentOrder = [...orderedWidgetIdentifiers];
       const currentIndex = currentOrder.indexOf(widgetIdentifier);
-      if (currentIndex <= 0) return;
+      const nextIndex = currentIndex + direction;
 
-      [currentOrder[currentIndex - 1], currentOrder[currentIndex]] = [
-        currentOrder[currentIndex],
-        currentOrder[currentIndex - 1],
-      ];
+      if (
+        currentIndex < 0 ||
+        nextIndex < 0 ||
+        nextIndex >= currentOrder.length
+      ) {
+        return;
+      }
 
-      widgetOrderRef.current = currentOrder;
-      setWidgetOrder(currentOrder);
-      persistHomeWidgetState(currentOrder);
-    },
-    [orderedWidgetIdentifiers, persistHomeWidgetState]
-  );
-
-  const handleMoveWidgetDown = useCallback(
-    (widgetIdentifier: string) => {
-      const currentOrder = [...orderedWidgetIdentifiers];
-      const currentIndex = currentOrder.indexOf(widgetIdentifier);
-      if (currentIndex < 0 || currentIndex >= currentOrder.length - 1) return;
-
-      [currentOrder[currentIndex], currentOrder[currentIndex + 1]] = [
-        currentOrder[currentIndex + 1],
+      [currentOrder[currentIndex], currentOrder[nextIndex]] = [
+        currentOrder[nextIndex],
         currentOrder[currentIndex],
       ];
 
@@ -429,9 +419,9 @@ const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
                 handleWidgetCollapsedChange(widget.identifier, collapsed)
               }
               canMoveUp={widget.identifier !== topWidgetIdentifier}
-              onMoveUp={() => handleMoveWidgetUp(widget.identifier)}
+              onMoveUp={() => handleMoveWidget(widget.identifier, -1)}
               canMoveDown={widget.identifier !== bottomWidgetIdentifier}
-              onMoveDown={() => handleMoveWidgetDown(widget.identifier)}
+              onMoveDown={() => handleMoveWidget(widget.identifier, 1)}
             />
           ))}
         </VStack>

--- a/src/components/extension/home-widget-container.tsx
+++ b/src/components/extension/home-widget-container.tsx
@@ -359,12 +359,32 @@ const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
     [orderedWidgetIdentifiers, persistHomeWidgetState]
   );
 
+  const handleMoveWidgetDown = useCallback(
+    (widgetIdentifier: string) => {
+      const currentOrder = [...orderedWidgetIdentifiers];
+      const currentIndex = currentOrder.indexOf(widgetIdentifier);
+      if (currentIndex < 0 || currentIndex >= currentOrder.length - 1) return;
+
+      [currentOrder[currentIndex], currentOrder[currentIndex + 1]] = [
+        currentOrder[currentIndex + 1],
+        currentOrder[currentIndex],
+      ];
+
+      widgetOrderRef.current = currentOrder;
+      setWidgetOrder(currentOrder);
+      persistHomeWidgetState(currentOrder);
+    },
+    [orderedWidgetIdentifiers, persistHomeWidgetState]
+  );
+
   const containerWidth = useMemo(
     () => Math.max(0, ...widgetLayouts.map((layout) => layout.width)),
     [widgetLayouts]
   );
 
   const topWidgetIdentifier = orderedWidgetIdentifiers[0];
+  const bottomWidgetIdentifier =
+    orderedWidgetIdentifiers[orderedWidgetIdentifiers.length - 1];
 
   const shouldHideWidgetList =
     config.mocked || homeWidgets.length === 0 || !isHydrated;
@@ -410,6 +430,8 @@ const HomeWidgetContainer = ({ maxWidth }: HomeWidgetContainerProps) => {
               }
               canMoveUp={widget.identifier !== topWidgetIdentifier}
               onMoveUp={() => handleMoveWidgetUp(widget.identifier)}
+              canMoveDown={widget.identifier !== bottomWidgetIdentifier}
+              onMoveDown={() => handleMoveWidgetDown(widget.identifier)}
             />
           ))}
         </VStack>

--- a/src/components/extension/home-widget.tsx
+++ b/src/components/extension/home-widget.tsx
@@ -14,7 +14,13 @@ import {
 import { useRouter } from "next/router";
 import { type MouseEvent as ReactMouseEvent, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import { LuChevronRight, LuInfo, LuSettings, LuTriangle } from "react-icons/lu";
+import {
+  LuArrowDown,
+  LuArrowUp,
+  LuChevronRight,
+  LuInfo,
+  LuSettings,
+} from "react-icons/lu";
 import AdvancedCard from "@/components/common/advanced-card";
 import { CommonIconButton } from "@/components/common/common-icon-button";
 import ExtensionContributionWrapper from "@/components/extension/contribution-wrapper";
@@ -38,18 +44,24 @@ interface HomeWidgetProps {
   onCollapsedChange: (collapsed: boolean) => void;
   canMoveUp: boolean;
   onMoveUp: () => void;
+  canMoveDown: boolean;
+  onMoveDown: () => void;
 }
 
 interface ExtraOperationMenuProps {
   widget: ExtensionHomeWidgetContribution;
   canMoveUp: boolean;
   onMoveUp: () => void;
+  canMoveDown: boolean;
+  onMoveDown: () => void;
 }
 
 const ExtraOperationMenu = ({
   widget,
   canMoveUp,
   onMoveUp,
+  canMoveDown,
+  onMoveDown,
 }: ExtraOperationMenuProps) => {
   const { t } = useTranslation();
   const router = useRouter();
@@ -64,8 +76,17 @@ const ExtraOperationMenu = ({
       ? [
           {
             key: "moveUp",
-            icon: LuTriangle,
+            icon: LuArrowUp,
             onClick: onMoveUp,
+          },
+        ]
+      : []),
+    ...(canMoveDown
+      ? [
+          {
+            key: "moveDown",
+            icon: LuArrowDown,
+            onClick: onMoveDown,
           },
         ]
       : []),
@@ -125,6 +146,8 @@ const HomeWidget = ({
   onCollapsedChange,
   canMoveUp,
   onMoveUp,
+  canMoveDown,
+  onMoveDown,
 }: HomeWidgetProps) => {
   const resizeHandlersRef = useRef<(() => void) | null>(null);
   useEffect(() => {
@@ -211,6 +234,8 @@ const HomeWidget = ({
             widget={widget}
             canMoveUp={canMoveUp}
             onMoveUp={onMoveUp}
+            canMoveDown={canMoveDown}
+            onMoveDown={onMoveDown}
           />
         </HStack>
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1356,6 +1356,7 @@
   "HomeWidget": {
     "extraOpMenu": {
       "moveUp": "Move This Widget Up",
+      "moveDown": "Move This Widget Down",
       "extensionInfo": "View Extension Info",
       "settings": "Open Extension Settings"
     }

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -1356,6 +1356,7 @@
   "HomeWidget": {
     "extraOpMenu": {
       "moveUp": "上移此卡片",
+      "moveDown": "下移此卡片",
       "extensionInfo": "查看扩展信息",
       "settings": "设置此扩展"
     }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

## Summary by Sourcery

Add support for moving home extension widgets down in the list and expose corresponding controls in the widget UI.

New Features:
- Allow users to move home widgets down within the ordered widget list.
- Expose move-down actions in the home widget extra operations menu with appropriate icons and state handling.

Enhancements:
- Prevent move-up and move-down actions when the widget is already at the top or bottom of the list.