### PR TITLE
chore(macOS): define i18n locale support in macOS bundle settings

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -14,6 +14,16 @@
         </array>
       </dict>
     </array>
+    <key>CFBundleLocalizations</key>
+    <array>
+      <string>en</string>
+      <string>fr</string>
+      <string>ja</string>
+      <string>zh-Hans</string>
+      <string>zh-Hant</string>
+    </array>
+    <key>CFBundleAllowMixedLocalizations</key>
+    <true/>
     <key>NSCameraUsageDescription</key>
     <string>A Minecraft mod wants to access your camera.</string>
     <key>NSMicrophoneUsageDescription</key>

--- a/src-tauri/infoplist/en.lproj/InfoPlist.strings
+++ b/src-tauri/infoplist/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"NSCameraUsageDescription" = "A Minecraft mod wants to access your camera.";
+"NSMicrophoneUsageDescription" = "A Minecraft mod wants to access your microphone.";

--- a/src-tauri/infoplist/fr.lproj/InfoPlist.strings
+++ b/src-tauri/infoplist/fr.lproj/InfoPlist.strings
@@ -1,2 +1,2 @@
-"NSCameraUsageDescription" = "Un mod Minecraft souhaite acceder a votre camera.";
-"NSMicrophoneUsageDescription" = "Un mod Minecraft souhaite acceder a votre microphone.";
+"NSCameraUsageDescription" = "Un mod Minecraft souhaite accéder à votre caméra.";
+"NSMicrophoneUsageDescription" = "Un mod Minecraft souhaite accéder à votre microphone.";

--- a/src-tauri/infoplist/fr.lproj/InfoPlist.strings
+++ b/src-tauri/infoplist/fr.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"NSCameraUsageDescription" = "Un mod Minecraft souhaite acceder a votre camera.";
+"NSMicrophoneUsageDescription" = "Un mod Minecraft souhaite acceder a votre microphone.";

--- a/src-tauri/infoplist/ja.lproj/InfoPlist.strings
+++ b/src-tauri/infoplist/ja.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"NSCameraUsageDescription" = "Minecraft の Mod がカメラへのアクセスを求めています。";
+"NSMicrophoneUsageDescription" = "Minecraft の Mod がマイクへのアクセスを求めています。";

--- a/src-tauri/infoplist/zh-Hans.lproj/InfoPlist.strings
+++ b/src-tauri/infoplist/zh-Hans.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"NSCameraUsageDescription" = "某个 Minecraft 模组想要访问你的摄像头。";
+"NSMicrophoneUsageDescription" = "某个 Minecraft 模组想要访问你的麦克风。";

--- a/src-tauri/infoplist/zh-Hant.lproj/InfoPlist.strings
+++ b/src-tauri/infoplist/zh-Hant.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"NSCameraUsageDescription" = "某個 Minecraft 模組想要存取你的相機。";
+"NSMicrophoneUsageDescription" = "某個 Minecraft 模組想要存取你的麥克風。";

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -43,14 +43,14 @@
     ],
     "licenseFile": "../LICENSE",
     "license": "GPLv3",
-    "resources": [
-      "assets/skins/*",
-      "assets/game/*",
-      "assets/icons/icon.ico",
-      "assets/icons/icon.png",
-      "assets/icons/variants/square.png",
-      "assets/db/*"
-    ]
+    "resources": {
+      "assets/skins/*": "assets/skins/",
+      "assets/game/*": "assets/game/",
+      "assets/icons/icon.ico": "assets/icons/icon.ico",
+      "assets/icons/icon.png": "assets/icons/icon.png",
+      "assets/icons/variants/square.png": "assets/icons/variants/square.png",
+      "assets/db/*": "assets/db/"
+    }
   },
   "plugins": {
     "deep-link": {

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,6 +1,9 @@
 {
   "identifier": "SJMCL",
   "bundle": {
+    "resources": {
+      "infoplist/**": "./"
+    },
     "macOS": {
       "dmg": {
         "background": "assets/misc/dmg_bg.png",


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

fix #530

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

- 需要测试 windows 和 linux 平台是否编译正常，有没有在资源目录展开和 assets 同级的冗余 infoplist 文件夹
- 需要测试 CI 产物在 macOS 上是否解决了问题

## Summary by Sourcery

Define explicit locale support for the macOS app bundle to fix locale handling issues.

Bug Fixes:
- Specify supported macOS bundle localizations and allow mixed localizations to resolve incorrect locale behavior on macOS.

Enhancements:
- Add localized InfoPlist string resource files for English, French, Japanese, Simplified Chinese, and Traditional Chinese in the macOS bundle.