### PR TITLE
fix(frontend): fix frontend state sync error after renaming instance

### DIFF
--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -299,16 +299,20 @@ pub async fn rename_instance(
   instance_id: String,
   new_name: String,
 ) -> SJMCLResult<PathBuf> {
-  let binding = app.state::<Mutex<HashMap<String, Instance>>>();
-  let mut state = binding.lock().unwrap();
-  let instance = match state.get_mut(&instance_id) {
-    Some(x) => x,
-    None => return Err(InstanceError::InstanceNotFoundByID.into()),
-  };
-  let new_path = unify_instance_name(&instance.version_path, &new_name)?;
+  let new_path = {
+    let binding = app.state::<Mutex<HashMap<String, Instance>>>();
+    let mut state = binding.lock().unwrap();
+    let instance = match state.get_mut(&instance_id) {
+      Some(x) => x,
+      None => return Err(InstanceError::InstanceNotFoundByID.into()),
+    };
+    let new_path = unify_instance_name(&instance.version_path, &new_name)?;
 
-  instance.version_path = new_path.clone();
-  instance.name = new_name;
+    instance.version_path = new_path.clone();
+    instance.name = new_name;
+    new_path
+  };
+  refresh_and_update_instances(&app, false).await;
   Ok(new_path)
 }
 

--- a/src/contexts/instance.tsx
+++ b/src/contexts/instance.tsx
@@ -123,17 +123,16 @@ export const InstanceContextProvider: React.FC<{
   const updateSummaryInContext = useCallback(
     (path: string, value: any) => {
       // for frontend-only state update to sync with backend if needed.
-      if (path === "id") return; // forbid update id here
-
       setInstanceSummary((prevSummary) => {
         if (!prevSummary) return prevSummary;
 
+        const prevSummaryId = prevSummary.id;
         const newSummary = { ...prevSummary };
         updateByKeyPath(newSummary, path, value);
 
         const instanceList = getInstanceList() || [];
         const updatedList = instanceList.map((instance) =>
-          instance.id === newSummary.id ? newSummary : instance
+          instance.id === prevSummaryId ? newSummary : instance
         );
         setInstanceList(updatedList as InstanceSummary[]);
 

--- a/src/pages/instances/details/[id]/settings/index.tsx
+++ b/src/pages/instances/details/[id]/settings/index.tsx
@@ -21,6 +21,7 @@ import {
 import GameSettingsGroups from "@/components/game-settings-groups";
 import { InstanceIconSelectorPopover } from "@/components/instance-icon-selector";
 import { useLauncherConfig } from "@/contexts/config";
+import { useGlobalData } from "@/contexts/global-data";
 import { useInstanceSharedData } from "@/contexts/instance";
 import { useSharedModals } from "@/contexts/shared-modal";
 import { useToast } from "@/contexts/toast";
@@ -31,7 +32,8 @@ const InstanceSettingsPage = () => {
   const router = useRouter();
   const toast = useToast();
   const { t } = useTranslation();
-  const { config } = useLauncherConfig();
+  const { config, update } = useLauncherConfig();
+  const { getInstanceList } = useGlobalData();
   const primaryColor = config.appearance.theme.primaryColor;
   const { openGenericConfirmDialog } = useSharedModals();
 
@@ -52,8 +54,26 @@ const InstanceSettingsPage = () => {
       if (!instanceId) return;
       InstanceService.renameInstance(instanceId, name).then((response) => {
         if (response.status === "success") {
+          const newInstanceId = instanceId.replace(/:[^:]*$/, `:${name}`);
+
+          // firstly sync the current detail context immediately; the instance list refresh below is async.
+          updateSummaryInContext("id", newInstanceId);
           updateSummaryInContext("versionPath", response.data);
           updateSummaryInContext("name", name);
+
+          if (config.states.shared.selectedInstanceId === instanceId) {
+            update("states.shared.selectedInstanceId", newInstanceId);
+          } // update in frontend to prevent error toast
+          getInstanceList(true);
+
+          router.replace(
+            router.asPath.replace(
+              encodeURIComponent(instanceId),
+              encodeURIComponent(newInstanceId)
+            ),
+            undefined,
+            { shallow: true }
+          );
         } else
           toast({
             title: response.message,
@@ -62,7 +82,15 @@ const InstanceSettingsPage = () => {
           });
       });
     },
-    [instanceId, toast, updateSummaryInContext]
+    [
+      config.states.shared.selectedInstanceId,
+      getInstanceList,
+      instanceId,
+      router,
+      toast,
+      update,
+      updateSummaryInContext,
+    ]
   );
 
   const instanceSpecSettingsGroups: OptionItemGroupProps[] = [

--- a/src/pages/instances/details/[id]/settings/index.tsx
+++ b/src/pages/instances/details/[id]/settings/index.tsx
@@ -21,7 +21,6 @@ import {
 import GameSettingsGroups from "@/components/game-settings-groups";
 import { InstanceIconSelectorPopover } from "@/components/instance-icon-selector";
 import { useLauncherConfig } from "@/contexts/config";
-import { useGlobalData } from "@/contexts/global-data";
 import { useInstanceSharedData } from "@/contexts/instance";
 import { useSharedModals } from "@/contexts/shared-modal";
 import { useToast } from "@/contexts/toast";
@@ -33,7 +32,6 @@ const InstanceSettingsPage = () => {
   const toast = useToast();
   const { t } = useTranslation();
   const { config, update } = useLauncherConfig();
-  const { getInstanceList } = useGlobalData();
   const primaryColor = config.appearance.theme.primaryColor;
   const { openGenericConfirmDialog } = useSharedModals();
 
@@ -50,41 +48,38 @@ const InstanceSettingsPage = () => {
   const useSpecGameConfig = summary?.useSpecGameConfig || false;
 
   const handleRenameInstance = useCallback(
-    (name: string) => {
+    async (name: string) => {
       if (!instanceId) return;
-      InstanceService.renameInstance(instanceId, name).then((response) => {
-        if (response.status === "success") {
-          const newInstanceId = instanceId.replace(/:[^:]*$/, `:${name}`);
+      const response = await InstanceService.renameInstance(instanceId, name);
+      if (response.status === "success") {
+        const newInstanceId = instanceId.replace(/:[^:]*$/, `:${name}`);
 
-          // firstly sync the current detail context immediately; the instance list refresh below is async.
-          updateSummaryInContext("id", newInstanceId);
-          updateSummaryInContext("versionPath", response.data);
-          updateSummaryInContext("name", name);
+        await router.replace(
+          {
+            pathname: router.pathname,
+            query: { ...router.query, id: newInstanceId },
+          },
+          undefined,
+          { shallow: true }
+        );
 
-          if (config.states.shared.selectedInstanceId === instanceId) {
-            update("states.shared.selectedInstanceId", newInstanceId);
-          } // update in frontend to prevent error toast
-          getInstanceList(true);
+        // Sync frontend state after both backend state and route id are updated.
+        updateSummaryInContext("versionPath", response.data);
+        updateSummaryInContext("name", name);
+        updateSummaryInContext("id", newInstanceId);
 
-          router.replace(
-            router.asPath.replace(
-              encodeURIComponent(instanceId),
-              encodeURIComponent(newInstanceId)
-            ),
-            undefined,
-            { shallow: true }
-          );
-        } else
-          toast({
-            title: response.message,
-            description: response.details,
-            status: "error",
-          });
-      });
+        if (config.states.shared.selectedInstanceId === instanceId) {
+          update("states.shared.selectedInstanceId", newInstanceId);
+        } // update in frontend to prevent error toast
+      } else
+        toast({
+          title: response.message,
+          description: response.details,
+          status: "error",
+        });
     },
     [
       config.states.shared.selectedInstanceId,
-      getInstanceList,
       instanceId,
       router,
       toast,


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

fix #484 fix #1011

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Fix frontend state synchronization when renaming an instance by ensuring IDs and navigation are updated consistently.

Bug Fixes:
- Ensure instance summary and selected instance ID stay in sync after renaming an instance to avoid stale state and error toasts.
- Correct instance list updates in context by matching and replacing entries using the previous instance ID instead of the new one during in-memory updates.

Enhancements:
- Trigger a shallow route replacement and refresh the instance list after renaming to keep the URL and list view consistent with the new instance ID.