### PR TITLE
fix(frontend): change default resolution from 1280x720 to 854x480

### DIFF
--- a/src-tauri/src/launcher_config/models.rs
+++ b/src-tauri/src/launcher_config/models.rs
@@ -105,9 +105,9 @@ structstruck::strike! {
     },
     pub game_window: struct {
       pub resolution: struct {
-        #[default = 1280]
+        #[default = 854]
         pub width: u32,
-        #[default = 720]
+        #[default = 480]
         pub height: u32,
         pub fullscreen: bool,
       },

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -191,8 +191,8 @@ export const defaultGameConfig: GameConfig = {
   },
   gameWindow: {
     resolution: {
-      width: 1280,
-      height: 720,
+      width: 854,
+      height: 480,
       fullscreen: false,
     },
     customTitle: "",


### PR DESCRIPTION
- [x] Changes have been tested locally and work as expected.

### This PR is a ..


- [x] 🐞 Bug fix


### Related Issues

> fix #1565

## Summary by Sourcery

Bug Fixes:
- Adjust default game window size from 1280x720 to 854x480 to align with expected frontend resolution defaults.