### PR TITLE
fix(backend): delete wrong path prefix on windows

### DIFF
--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -235,10 +235,20 @@ pub fn get_app_resource_filepath(
     BaseDirectory::Resource
   };
 
-  app
+  let path = app
     .path()
     .resolve(relative_path, dir)
-    .map_err(io::Error::other)
+    .map_err(io::Error::other)?;
+
+  #[cfg(target_os = "windows")]
+  {
+    let path_str = path.to_string_lossy();
+    if let Some(stripped) = path_str.strip_prefix(r"\\?\") {
+      return Ok(PathBuf::from(stripped));
+    }
+  }
+
+  Ok(path)
 }
 
 /// Creates a cross-platform desktop shortcut that points to a URL (include deeplink).


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - fix #1551

## Summary by Sourcery

Bug Fixes:
- Strip the Windows `\\?\` path prefix from resolved application resource file paths to avoid incorrect path handling on Windows.