### PR TITLE
fix: unify error handling for mod loader network errors

### DIFF
--- a/src-tauri/src/resource/helpers/loader_meta/fabric.rs
+++ b/src-tauri/src/resource/helpers/loader_meta/fabric.rs
@@ -1,4 +1,4 @@
-use crate::error::{SJMCLError, SJMCLResult};
+use crate::error::SJMCLResult;
 use crate::instance::models::misc::ModLoaderType;
 use crate::resource::helpers::misc::get_download_api;
 use crate::resource::models::{ModLoaderResourceInfo, ResourceError, ResourceType, SourceType};
@@ -60,5 +60,5 @@ pub async fn get_fabric_meta_by_game_version(
       Err(_) => continue,
     }
   }
-  Err(SJMCLError(String::new()))
+  Err(ResourceError::NetworkError.into())
 }

--- a/src-tauri/src/resource/helpers/loader_meta/forge.rs
+++ b/src-tauri/src/resource/helpers/loader_meta/forge.rs
@@ -79,5 +79,5 @@ pub async fn get_forge_meta_by_game_version(
       }
     }
   }
-  Err(ResourceError::NoDownloadApi.into())
+  Err(ResourceError::NetworkError.into())
 }

--- a/src-tauri/src/resource/helpers/loader_meta/optifine.rs
+++ b/src-tauri/src/resource/helpers/loader_meta/optifine.rs
@@ -39,5 +39,5 @@ pub async fn get_optifine_meta_by_game_version(
       _ => continue,
     }
   }
-  Err(ResourceError::NoDownloadApi.into())
+  Err(ResourceError::NetworkError.into())
 }

--- a/src-tauri/src/resource/helpers/loader_meta/quilt.rs
+++ b/src-tauri/src/resource/helpers/loader_meta/quilt.rs
@@ -1,4 +1,4 @@
-use crate::error::{SJMCLError, SJMCLResult};
+use crate::error::SJMCLResult;
 use crate::instance::models::misc::ModLoaderType;
 use crate::resource::helpers::misc::get_download_api;
 use crate::resource::models::{ModLoaderResourceInfo, ResourceError, ResourceType, SourceType};
@@ -59,5 +59,5 @@ pub async fn get_quilt_meta_by_game_version(
     }
   }
 
-  Err(SJMCLError(String::new()))
+  Err(ResourceError::NetworkError.into())
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2475,6 +2475,14 @@
           }
         }
       },
+      "fetchOptiFineVersionList": {
+        "error": {
+          "title": "Failed to fetch OptiFine version list",
+          "description": {
+            "NETWORK_ERROR": "Failed to connect to the server"
+          }
+        }
+      },
       "fetchResourceListByName": {
         "error": {
           "title": "Failed to fetch resource list",

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -2475,6 +2475,14 @@
           }
         }
       },
+      "fetchOptiFineVersionList": {
+        "error": {
+          "title": "获取 OptiFine 列表失败",
+          "description": {
+            "NETWORK_ERROR": "无法连接到服务器"
+          }
+        }
+      },
       "fetchResourceListByName": {
         "error": {
           "title": "获取资源列表失败",


### PR DESCRIPTION
统一了不同加载器列表获取失败返回的错误信息。

## Summary by Sourcery

Unify network error handling for loader metadata fetch failures across different mod loaders.

Bug Fixes:
- Return a consistent ResourceError::NetworkError when fetching Fabric, Forge, OptiFine, or Quilt loader metadata fails instead of varying or empty error types.

Enhancements:
- Align localized error messages for loader list fetch failures in English and Simplified Chinese.