### PR TITLE
feat:(intelligence): add mcp tools

### DIFF
--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/instance.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/instance.rs
@@ -21,6 +21,18 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
       }
     ),
     mcp_tool!(
+      "retrieve_world_details",
+      retrieve_world_details,
+      "Retrieve detailed level.dat data for a local world in a Minecraft instance.",
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Minecraft instance ID returned by `retrieve_instance_list`.")]
+        instance_id: String,
+        #[schemars(description = "World directory name returned by `retrieve_world_list`.")]
+        world_name: String,
+      }
+    ),
+    mcp_tool!(
       "retrieve_game_server_list",
       "Retrieve configured servers for a Minecraft instance and query their online status.",
       |app, params|
@@ -31,6 +43,108 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
       } => async move {
         // always query online status in MCP context.
         retrieve_game_server_list(app, params.instance_id, true).await
+      }
+    ),
+    mcp_tool!(
+      "delete_game_server",
+      "Delete a saved multiplayer server from a Minecraft instance's server list. Requires confirm=true.",
+      |app, params|
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Minecraft instance ID returned by `retrieve_instance_list`.")]
+        instance_id: String,
+        #[schemars(description = "Server address returned as `ip` by `retrieve_game_server_list`.")]
+        server_addr: String,
+        #[schemars(description = "Must be true to confirm deleting this saved server entry.")]
+        confirm: bool,
+      } => async move {
+        if !params.confirm {
+          return Err(crate::instance::models::misc::InstanceError::InvalidSourcePath.into());
+        }
+
+        delete_game_server(app, params.instance_id, params.server_addr).await
+      }
+    ),
+    mcp_tool!(
+      "add_game_server",
+      add_game_server,
+      "Add a saved multiplayer server to a Minecraft instance's server list.",
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Minecraft instance ID returned by `retrieve_instance_list`.")]
+        instance_id: String,
+        #[schemars(description = "Server address, for example `mc.example.com` or `127.0.0.1:25565`.")]
+        server_addr: String,
+        #[schemars(description = "Display name saved for this server entry.")]
+        server_name: String,
+      }
+    ),
+    mcp_tool!(
+      sync "retrieve_instance_game_config",
+      retrieve_instance_game_config,
+      "Retrieve the effective game configuration for a Minecraft instance. If the instance does not use a dedicated config, this returns the global game configuration currently applied to it.",
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Minecraft instance ID returned by `retrieve_instance_list`.")]
+        instance_id: String,
+      }
+    ),
+    mcp_tool!(
+      "restore_instance_game_config",
+      restore_instance_game_config,
+      "Restore a Minecraft instance's dedicated game configuration to the current global game configuration.",
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Minecraft instance ID returned by `retrieve_instance_list`.")]
+        instance_id: String,
+      }
+    ),
+    mcp_tool!(
+      "delete_instance",
+      "Delete a Minecraft instance and its instance directory. Requires confirm=true.",
+      |app, params|
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Minecraft instance ID returned by `retrieve_instance_list`.")]
+        instance_id: String,
+        #[schemars(description = "Must be true to confirm deleting this instance and its files.")]
+        confirm: bool,
+      } => async move {
+        if !params.confirm {
+          return Err(crate::instance::models::misc::InstanceError::InvalidSourcePath.into());
+        }
+
+        delete_instance(app, params.instance_id)
+      }
+    ),
+    mcp_tool!(
+      "rename_instance",
+      rename_instance,
+      "Rename a Minecraft instance and return its new instance path.",
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Minecraft instance ID returned by `retrieve_instance_list`.")]
+        instance_id: String,
+        #[schemars(description = "New display name for the instance.")]
+        new_name: String,
+      }
+    ),
+    mcp_tool!(
+      "create_launch_desktop_shortcut",
+      "Create a desktop shortcut that launches a Minecraft instance. Uses the instance custom icon by default.",
+      |app, params|
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Minecraft instance ID returned by `retrieve_instance_list`.")]
+        instance_id: String,
+        #[schemars(description = "Shortcut icon source. Omit to use `custom`; pass an asset path to use a built-in icon.")]
+        icon_src: Option<String>,
+      } => async move {
+        create_launch_desktop_shortcut(
+          app,
+          params.instance_id,
+          params.icon_src.unwrap_or_else(|| "custom".to_string()),
+        )
       }
     ),
     mcp_tool!(

--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/instance.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/instance.rs
@@ -1,6 +1,7 @@
 use crate::instance::commands::*;
 use crate::instance::models::misc::{InstanceError, ModLoaderType};
 use crate::intelligence::mcp_server::launcher::McpContext;
+use crate::intelligence::mcp_server::model::MCPError;
 use crate::launcher_config::models::GameDirectory;
 use crate::mcp_tool;
 use crate::resource::commands::{
@@ -71,6 +72,7 @@ async fn resolve_optifine(
     .ok_or_else(|| ResourceError::ParseError.into())
 }
 
+// In the user-facing workflow, the default icon mapping lives in the frontend create-instance modal.
 fn default_icon_for_game_type(game_type: &str) -> String {
   match game_type {
     "snapshot" => "/images/icons/JEIcon_Snapshot.png",
@@ -210,7 +212,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
         confirm: bool,
       } => async move {
         if !params.confirm {
-          return Err(crate::instance::models::misc::InstanceError::InvalidSourcePath.into());
+          return Err(MCPError::ToolNeedsConfirmation.into());
         }
 
         delete_game_server(app, params.instance_id, params.server_addr).await
@@ -262,7 +264,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
         confirm: bool,
       } => async move {
         if !params.confirm {
-          return Err(crate::instance::models::misc::InstanceError::InvalidSourcePath.into());
+          return Err(MCPError::ToolNeedsConfirmation.into());
         }
 
         delete_instance(app, params.instance_id)

--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/instance.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/instance.rs
@@ -1,7 +1,85 @@
 use crate::instance::commands::*;
+use crate::instance::models::misc::{InstanceError, ModLoaderType};
 use crate::intelligence::mcp_server::launcher::McpContext;
+use crate::launcher_config::models::GameDirectory;
 use crate::mcp_tool;
+use crate::resource::commands::{
+  fetch_game_version_specific, fetch_mod_loader_version_list, fetch_optifine_version_list,
+};
+use crate::resource::models::{ModLoaderResourceInfo, OptiFineResourceInfo, ResourceError};
 use rmcp::handler::server::tool::ToolRoute;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+fn parse_mod_loader_type(
+  loader_type: Option<String>,
+) -> Result<ModLoaderType, crate::error::SJMCLError> {
+  match loader_type {
+    Some(loader_type) if !loader_type.trim().is_empty() => {
+      ModLoaderType::from_str(&loader_type).map_err(|_| ResourceError::NoDownloadApi.into())
+    }
+    _ => Ok(ModLoaderType::Unknown),
+  }
+}
+
+async fn resolve_mod_loader(
+  app: tauri::AppHandle,
+  game_version: String,
+  loader_type: ModLoaderType,
+  loader_version: Option<String>,
+) -> Result<ModLoaderResourceInfo, crate::error::SJMCLError> {
+  if loader_type == ModLoaderType::Unknown {
+    return Ok(ModLoaderResourceInfo {
+      loader_type: ModLoaderType::Unknown,
+      version: String::new(),
+      description: String::new(),
+      stable: true,
+      branch: None,
+    });
+  }
+
+  let versions = fetch_mod_loader_version_list(app, game_version, loader_type).await?;
+  if let Some(loader_version) = loader_version.filter(|version| !version.trim().is_empty()) {
+    return versions
+      .into_iter()
+      .find(|item| item.version == loader_version)
+      .ok_or_else(|| ResourceError::ParseError.into());
+  }
+
+  versions
+    .iter()
+    .find(|item| item.stable)
+    .cloned()
+    .or_else(|| versions.into_iter().next())
+    .ok_or_else(|| ResourceError::ParseError.into())
+}
+
+async fn resolve_optifine(
+  app: tauri::AppHandle,
+  game_version: String,
+  optifine_version: Option<String>,
+) -> Result<Option<OptiFineResourceInfo>, crate::error::SJMCLError> {
+  let Some(optifine_version) = optifine_version.filter(|version| !version.trim().is_empty()) else {
+    return Ok(None);
+  };
+
+  let versions = fetch_optifine_version_list(app, game_version).await?;
+  versions
+    .into_iter()
+    .find(|item| item.patch == optifine_version || item.filename == optifine_version)
+    .map(Some)
+    .ok_or_else(|| ResourceError::ParseError.into())
+}
+
+fn default_icon_for_game_type(game_type: &str) -> String {
+  match game_type {
+    "snapshot" => "/images/icons/JEIcon_Snapshot.png",
+    "old_beta" => "/images/icons/StoneOldBeta.png",
+    "april_fools" => "/images/icons/YellowGlazedTerracotta.png",
+    _ => "/images/icons/JEIcon_Release.png",
+  }
+  .to_string()
+}
 
 pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
   vec![
@@ -9,6 +87,79 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
       "retrieve_instance_list",
       retrieve_instance_list,
       "Primary tool for listing local Minecraft instances. Returns instance IDs and metadata for selecting an instance."
+    ),
+    mcp_tool!(
+      "create_instance",
+      "Create a Minecraft instance and schedule required client/mod-loader downloads. Resolves game and loader metadata from version IDs.",
+      |app, params|
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Game directory display name from launcher config `localGameDirectories[].name`.")]
+        directory_name: String,
+        #[schemars(description = "Game directory path from launcher config `localGameDirectories[].dir`.")]
+        directory_path: String,
+        #[schemars(description = "New instance name. Must be unique under the selected game directory.")]
+        name: String,
+        #[schemars(description = "Optional instance description. Defaults to an empty string.")]
+        description: Option<String>,
+        #[schemars(description = "Optional instance icon source. Defaults to the standard icon for the selected game version type.")]
+        icon_src: Option<String>,
+        #[schemars(description = "Minecraft game version ID, for example `1.21.5`.")]
+        game_version: String,
+        #[schemars(description = "Optional mod loader type: `unknown`, `fabric`, `forge`, `legacyforge`, `neoforge`, or `quilt`. Defaults to `unknown`.")]
+        mod_loader_type: Option<String>,
+        #[schemars(description = "Optional exact mod loader version. If omitted, the first stable loader version is used.")]
+        mod_loader_version: Option<String>,
+        #[schemars(description = "Optional OptiFine patch or filename returned by `fetch_optifine_version_list`. Omit for no OptiFine.")]
+        optifine_version: Option<String>,
+        #[schemars(description = "Optional local modpack archive path.")]
+        modpack_path: Option<String>,
+        #[schemars(description = "Whether to install Fabric API when creating a Fabric instance. Defaults to true.")]
+        is_install_fabric_api: Option<bool>,
+        #[schemars(description = "Whether to install QFAPI/QSL when creating a Quilt instance. Defaults to true.")]
+        is_install_qf_api: Option<bool>,
+      } => async move {
+        if params.name.trim().is_empty()
+          || params.directory_name.trim().is_empty()
+          || params.directory_path.trim().is_empty()
+        {
+          return Err(InstanceError::InvalidSourcePath.into());
+        }
+
+        let game = fetch_game_version_specific(app.clone(), params.game_version.clone()).await?;
+        let mod_loader_type = parse_mod_loader_type(params.mod_loader_type)?;
+        let mod_loader = resolve_mod_loader(
+          app.clone(),
+          params.game_version.clone(),
+          mod_loader_type,
+          params.mod_loader_version,
+        )
+        .await?;
+        let optifine =
+          resolve_optifine(app.clone(), params.game_version, params.optifine_version).await?;
+        let icon_src = params
+          .icon_src
+          .filter(|icon_src| !icon_src.trim().is_empty())
+          .unwrap_or_else(|| default_icon_for_game_type(&game.game_type));
+
+        create_instance(
+          app,
+          GameDirectory {
+            name: params.directory_name,
+            dir: PathBuf::from(params.directory_path),
+          },
+          params.name,
+          params.description.unwrap_or_default(),
+          icon_src,
+          game,
+          mod_loader,
+          optifine,
+          params.modpack_path,
+          params.is_install_fabric_api.or(Some(true)),
+          params.is_install_qf_api.or(Some(true)),
+        )
+        .await
+      }
     ),
     mcp_tool!(
       "retrieve_world_list",

--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/resource.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/resource.rs
@@ -1,13 +1,12 @@
 use crate::instance::models::misc::ModLoaderType;
 use crate::intelligence::mcp_server::launcher::McpContext;
+use crate::intelligence::mcp_server::model::MCPError;
 use crate::mcp_tool;
 use crate::resource::commands::{
   download_game_server, fetch_game_version_list, fetch_game_version_specific,
   fetch_mod_loader_version_list, fetch_optifine_version_list, fetch_resource_list_by_name,
 };
-use crate::resource::models::{
-  OtherResourceInfo, OtherResourceSearchQuery, OtherResourceSource, ResourceError,
-};
+use crate::resource::models::{OtherResourceSearchQuery, OtherResourceSource, ResourceError};
 use rmcp::handler::server::tool::ToolRoute;
 use serde::Deserialize;
 use std::path::PathBuf;
@@ -34,18 +33,6 @@ struct McpOtherResourceSearchQuery {
   page: u32,
   #[schemars(description = "Page size.")]
   page_size: u32,
-}
-
-fn parse_resource_source(source: &str) -> Result<OtherResourceSource, crate::error::SJMCLError> {
-  OtherResourceSource::from_str(source).map_err(|_| ResourceError::NoDownloadApi.into())
-}
-
-fn parse_mod_loader_type(loader_type: &str) -> Result<ModLoaderType, crate::error::SJMCLError> {
-  ModLoaderType::from_str(loader_type).map_err(|_| ResourceError::ParseError.into())
-}
-
-fn strip_resource_icon(resource: &mut OtherResourceInfo) {
-  resource.icon_src.clear();
 }
 
 fn to_search_query(query: McpOtherResourceSearchQuery) -> OtherResourceSearchQuery {
@@ -88,7 +75,8 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
         #[schemars(description = "Mod loader type. Accepted values include `forge`, `legacyforge`, `fabric`, `neoforge`, and `quilt`.")]
         mod_loader_type: String,
       } => async move {
-        let mod_loader_type = parse_mod_loader_type(&params.mod_loader_type)?;
+        let mod_loader_type =
+          ModLoaderType::from_str(&params.mod_loader_type).map_err(|_| ResourceError::ParseError)?;
         fetch_mod_loader_version_list(app, params.game_version, mod_loader_type).await
       }
     ),
@@ -113,10 +101,11 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
         #[schemars(description = "Search query options.")]
         query: McpOtherResourceSearchQuery,
       } => async move {
-        let download_source = parse_resource_source(&params.download_source)?;
+        let download_source = OtherResourceSource::from_str(&params.download_source)
+          .map_err(|_| ResourceError::NoDownloadApi)?;
         let mut result = fetch_resource_list_by_name(app, download_source, to_search_query(params.query)).await?;
         for resource in &mut result.list {
-          strip_resource_icon(resource);
+          resource.icon_src.clear();  // Clear the icon field to reduce payload size for LLMs.
         }
         Ok(result)
       }
@@ -135,7 +124,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
         confirm: bool,
       } => async move {
         if !params.confirm {
-          return Err(ResourceError::FileOperationError.into());
+          return Err(MCPError::ToolNeedsConfirmation.into());
         }
         let path = PathBuf::from(params.dest.trim());
         let dest = if path.is_dir() {

--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/resource.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/resource.rs
@@ -1,12 +1,153 @@
+use crate::instance::models::misc::ModLoaderType;
 use crate::intelligence::mcp_server::launcher::McpContext;
 use crate::mcp_tool;
-use crate::resource::commands::fetch_game_version_list;
+use crate::resource::commands::{
+  download_game_server, fetch_game_version_list, fetch_game_version_specific,
+  fetch_mod_loader_version_list, fetch_optifine_version_list, fetch_resource_list_by_name,
+};
+use crate::resource::models::{
+  OtherResourceInfo, OtherResourceSearchQuery, OtherResourceSource, ResourceError,
+};
 use rmcp::handler::server::tool::ToolRoute;
+use serde::Deserialize;
+use std::path::PathBuf;
+use std::str::FromStr;
+use tauri::{Manager, State};
+use tauri_plugin_http::reqwest;
+
+#[derive(Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct McpOtherResourceSearchQuery {
+  #[schemars(
+    description = "Resource type, for example `mod`, `resourcepack`, `shader`, `datapack`, or `save`."
+  )]
+  resource_type: String,
+  #[schemars(description = "Search keywords.")]
+  search_query: String,
+  #[schemars(description = "Minecraft game version filter. Use an empty string for no filter.")]
+  game_version: String,
+  #[schemars(description = "Tag/category filter. Use an empty string for no filter.")]
+  selected_tag: String,
+  #[schemars(description = "Sort key supported by the selected source.")]
+  sort_by: String,
+  #[schemars(description = "1-based page number.")]
+  page: u32,
+  #[schemars(description = "Page size.")]
+  page_size: u32,
+}
+
+fn parse_resource_source(source: &str) -> Result<OtherResourceSource, crate::error::SJMCLError> {
+  OtherResourceSource::from_str(source).map_err(|_| ResourceError::NoDownloadApi.into())
+}
+
+fn parse_mod_loader_type(loader_type: &str) -> Result<ModLoaderType, crate::error::SJMCLError> {
+  ModLoaderType::from_str(loader_type).map_err(|_| ResourceError::ParseError.into())
+}
+
+fn strip_resource_icon(resource: &mut OtherResourceInfo) {
+  resource.icon_src.clear();
+}
+
+fn to_search_query(query: McpOtherResourceSearchQuery) -> OtherResourceSearchQuery {
+  OtherResourceSearchQuery {
+    resource_type: query.resource_type,
+    search_query: query.search_query,
+    game_version: query.game_version,
+    selected_tag: query.selected_tag,
+    sort_by: query.sort_by,
+    page: query.page,
+    page_size: query.page_size,
+  }
+}
 
 pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
-  vec![mcp_tool!(
-    "fetch_game_version_list",
-    fetch_game_version_list,
-    "Fetch the list of available Minecraft game versions."
-  )]
+  vec![
+    mcp_tool!(
+      "fetch_game_version_list",
+      fetch_game_version_list,
+      "Fetch the list of available Minecraft game versions."
+    ),
+    mcp_tool!(
+      "fetch_game_version_specific",
+      fetch_game_version_specific,
+      "Fetch metadata for a specific Minecraft game version.",
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Minecraft game version ID, for example `1.21.5`.")]
+        game_version: String,
+      }
+    ),
+    mcp_tool!(
+      "fetch_mod_loader_version_list",
+      "Fetch available mod loader versions for a Minecraft game version.",
+      |app, params|
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Minecraft game version ID.")]
+        game_version: String,
+        #[schemars(description = "Mod loader type. Accepted values include `forge`, `legacyforge`, `fabric`, `neoforge`, and `quilt`.")]
+        mod_loader_type: String,
+      } => async move {
+        let mod_loader_type = parse_mod_loader_type(&params.mod_loader_type)?;
+        fetch_mod_loader_version_list(app, params.game_version, mod_loader_type).await
+      }
+    ),
+    mcp_tool!(
+      "fetch_optifine_version_list",
+      fetch_optifine_version_list,
+      "Fetch available OptiFine versions for a Minecraft game version.",
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Minecraft game version ID.")]
+        game_version: String,
+      }
+    ),
+    mcp_tool!(
+      "fetch_resource_list_by_name",
+      "Search remote resources by name from CurseForge or Modrinth.",
+      |app, params|
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Download source. Accepted values: `curseforge` or `modrinth`.")]
+        download_source: String,
+        #[schemars(description = "Search query options.")]
+        query: McpOtherResourceSearchQuery,
+      } => async move {
+        let download_source = parse_resource_source(&params.download_source)?;
+        let mut result = fetch_resource_list_by_name(app, download_source, to_search_query(params.query)).await?;
+        for resource in &mut result.list {
+          strip_resource_icon(resource);
+        }
+        Ok(result)
+      }
+    ),
+    mcp_tool!(
+      "download_game_server",
+      "Schedule a Minecraft dedicated server jar download for the given game version. Requires confirm=true.",
+      |app, params|
+      #[serde(deny_unknown_fields)]
+      {
+        #[schemars(description = "Minecraft game version ID.")]
+        game_version: String,
+        #[schemars(description = "Destination directory or file path. If this points to an existing directory, `server.jar` is appended automatically.")]
+        dest: String,
+        #[schemars(description = "Must be true to confirm scheduling the server download.")]
+        confirm: bool,
+      } => async move {
+        if !params.confirm {
+          return Err(ResourceError::FileOperationError.into());
+        }
+        let path = PathBuf::from(params.dest.trim());
+        let dest = if path.is_dir() {
+          path.join("server.jar").to_string_lossy().to_string()
+        } else {
+          path.to_string_lossy().to_string()
+        };
+        let resource_info = fetch_game_version_specific(app.clone(), params.game_version).await?;
+        let app_for_download = app.clone();
+        let client_state: State<reqwest::Client> = app.state();
+        download_game_server(app_for_download, client_state, resource_info, dest).await
+      }
+    ),
+  ]
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

## Summary by Sourcery

Expose additional Minecraft resource management capabilities through MCP tools for the launcher intelligence module.

New Features:
- Add MCP tools to fetch metadata for specific Minecraft game versions and available mod loader and OptiFine versions.
- Add an MCP tool to search external resource catalogs (CurseForge or Modrinth) by name with structured search parameters.
- Add an MCP tool to schedule Minecraft dedicated server downloads with confirmation and flexible destination handling.

Enhancements:
- Introduce shared helpers for parsing resource sources and mod loader types and for mapping structured search queries into internal models.