### PR TITLE
fix(linux-build): bump to forked expat-sys

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1632,8 +1632,7 @@ dependencies = [
 [[package]]
 name = "expat-sys"
 version = "2.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658f19728920138342f68408b7cf7644d90d4784353d8ebc32e7e8663dbe45fa"
+source = "git+https://github.com/SJMC-dev/libexpat.git#24b7dca23a08467491a15e1055d491a8a7dce5ee"
 dependencies = [
  "cmake",
  "pkg-config",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,9 @@ strip = true
 lto = true
 panic = "abort"
 
+[patch.crates-io]
+expat-sys = { git = "https://github.com/SJMC-dev/libexpat.git" }
+
 [dependencies]
 async-speed-limit = "0.4.2"
 async-trait = "0.1.89"


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### This PR is a ..
- [x] 🐞 Bug fix

### Description

cmake 4.3 drop了 cmake_minimum_required < 3.5的支持，expat-sys的构建文件有问题，替换成我们fork的版本

## Summary by Sourcery

Build:
- Override the crates.io expat-sys crate with a forked git repository to fix CMake 4.3+ build issues on Linux.