### PR TITLE
feat(extension): add api for extension to dynamically update widget's display title

### DIFF
--- a/src/contexts/extension/host.tsx
+++ b/src/contexts/extension/host.tsx
@@ -843,6 +843,39 @@ const ActiveExtensionHostContextProvider: React.FC<{
     delete extensionStateListenerRef.current[identifier];
   }, []);
 
+  // allow extensions to update their home widget title.
+  const setExtensionHomeWidgetTitle = useCallback(
+    (extension: ExtensionInfo, widgetId: string, title: string) => {
+      const identifier = `${extension.identifier}:${widgetId}`;
+
+      setHomeWidgetMap((prev) => {
+        const widgets = prev[extension.identifier];
+        if (!widgets) {
+          return prev;
+        }
+
+        const targetIndex = widgets.findIndex(
+          (widget) => widget.identifier === identifier
+        );
+        if (targetIndex === -1 || widgets[targetIndex].title === title) {
+          return prev;
+        }
+
+        const nextWidgets = [...widgets];
+        nextWidgets[targetIndex] = {
+          ...nextWidgets[targetIndex],
+          title,
+        };
+
+        return {
+          ...prev,
+          [extension.identifier]: nextWidgets,
+        };
+      });
+    },
+    []
+  );
+
   // ------------- Extension-scoped state management -------------
   const getExtensionStateValue = useCallback(
     <T,>(identifier: string, key: string, initialValue: T): T => {
@@ -984,6 +1017,8 @@ const ActiveExtensionHostContextProvider: React.FC<{
         hostActionRefs.current.openSharedModal(key, params),
       openCustomModal: (key, params) =>
         handleOpenCustomModalRef.current(extension, key, params),
+      setHomeWidgetTitle: (widgetId, title) =>
+        setExtensionHomeWidgetTitle(extension, widgetId, title),
       request,
       requestText,
       invoke,
@@ -1029,6 +1064,7 @@ const ActiveExtensionHostContextProvider: React.FC<{
       requestText,
       runExtensionFileCommand,
       scheduleExtensionUpdate,
+      setExtensionHomeWidgetTitle,
     ]
   );
 

--- a/src/contexts/extension/host.tsx
+++ b/src/contexts/extension/host.tsx
@@ -844,19 +844,18 @@ const ActiveExtensionHostContextProvider: React.FC<{
   }, []);
 
   // allow extensions to update their home widget title.
-  const setExtensionHomeWidgetTitle = useCallback(
-    (extension: ExtensionInfo, widgetId: string, title: string) => {
-      const identifier = `${extension.identifier}:${widgetId}`;
-
+  const updateHomeWidgetTitle = useCallback(
+    (extension: ExtensionInfo, title: string, key?: string) => {
       setHomeWidgetMap((prev) => {
         const widgets = prev[extension.identifier];
         if (!widgets) {
           return prev;
         }
 
-        const targetIndex = widgets.findIndex(
-          (widget) => widget.identifier === identifier
-        );
+        const targetIndex =
+          widgets.length === 1
+            ? 0
+            : widgets.findIndex((widget) => widget.key === key);
         if (targetIndex === -1 || widgets[targetIndex].title === title) {
           return prev;
         }
@@ -1017,8 +1016,8 @@ const ActiveExtensionHostContextProvider: React.FC<{
         hostActionRefs.current.openSharedModal(key, params),
       openCustomModal: (key, params) =>
         handleOpenCustomModalRef.current(extension, key, params),
-      setHomeWidgetTitle: (widgetId, title) =>
-        setExtensionHomeWidgetTitle(extension, widgetId, title),
+      setHomeWidgetTitle: (title, key) =>
+        updateHomeWidgetTitle(extension, title, key),
       request,
       requestText,
       invoke,
@@ -1064,7 +1063,7 @@ const ActiveExtensionHostContextProvider: React.FC<{
       requestText,
       runExtensionFileCommand,
       scheduleExtensionUpdate,
-      setExtensionHomeWidgetTitle,
+      updateHomeWidgetTitle,
     ]
   );
 

--- a/src/models/extension/index.ts
+++ b/src/models/extension/index.ts
@@ -52,7 +52,7 @@ export interface ExtensionAbilityActions {
   openExternalLink: (url: string) => Promise<void>;
   openSharedModal: (key: string, params?: any) => void;
   openCustomModal: (key: string, params?: any) => void;
-  setHomeWidgetTitle: (widgetId: string, title: string) => void;
+  setHomeWidgetTitle: (title: string, key?: string) => void;
   // file system and request
   readFile: (path: string, mode?: "string" | "base64") => Promise<string>;
   writeFile: (

--- a/src/models/extension/index.ts
+++ b/src/models/extension/index.ts
@@ -52,6 +52,7 @@ export interface ExtensionAbilityActions {
   openExternalLink: (url: string) => Promise<void>;
   openSharedModal: (key: string, params?: any) => void;
   openCustomModal: (key: string, params?: any) => void;
+  setHomeWidgetTitle: (widgetId: string, title: string) => void;
   // file system and request
   readFile: (path: string, mode?: "string" | "base64") => Promise<string>;
   writeFile: (


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

close #1592

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Allow extensions to dynamically update the display title of their home widgets.

New Features:
- Expose a new extension ability action for updating a home widget's title at runtime.

Enhancements:
- Update the extension host context to manage and propagate title changes for existing home widgets.