### PR TITLE
refactor(release): add post-release workflow for AUR and Snap publishing

### DIFF
--- a/.github/workflows/post-release-publish.yml
+++ b/.github/workflows/post-release-publish.yml
@@ -1,6 +1,11 @@
 name: Post Release Publish
 
 on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag to publish from, for example v1.2.3"
+        required: true
   release:
     types:
       - published
@@ -9,7 +14,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.release.id }}
+  group: ${{ github.workflow }}-${{ github.event.release.id || inputs.release_tag || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -23,7 +28,7 @@ jobs:
         id: prepare
         shell: bash
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ inputs.release_tag || github.event.release.tag_name }}
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/post-release-publish.yml
+++ b/.github/workflows/post-release-publish.yml
@@ -1,0 +1,80 @@
+name: Post Release Publish
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.id }}
+  cancel-in-progress: false
+
+jobs:
+  Prepare-Release-Assets:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.prepare.outputs.version }}
+      release_tag: ${{ steps.prepare.outputs.release_tag }}
+    steps:
+      - name: Prepare release metadata
+        id: prepare
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+
+          assets=(
+            "SJMCL_${VERSION}_linux_x86_64.deb"
+            "SJMCL_${VERSION}_linux_aarch64.deb"
+          )
+
+          echo "Checking release assets for ${RELEASE_TAG}"
+          assets_json=$(gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json assets --jq '.assets[].name' 2>/dev/null || true)
+
+          missing=0
+          for asset in "${assets[@]}"; do
+            if ! printf '%s\n' "$assets_json" | grep -Fxq "$asset"; then
+              echo "Missing release asset: $asset"
+              missing=1
+            fi
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            echo "Required Linux release assets were not found for ${RELEASE_TAG}."
+            exit 1
+          fi
+
+          echo "All required release assets are present."
+
+  Publish-AUR:
+    needs: [Prepare-Release-Assets]
+    uses: ./.github/workflows/publish-aur.yml
+    with:
+      version: ${{ needs.Prepare-Release-Assets.outputs.version }}
+      release_tag: ${{ needs.Prepare-Release-Assets.outputs.release_tag }}
+    secrets:
+      AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+
+  Publish-Snap:
+    name: Publish Snap (${{ matrix.arch }})
+    needs: [Prepare-Release-Assets]
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86_64, aarch64]
+    uses: ./.github/workflows/publish-snap.yml
+    with:
+      version: ${{ needs.Prepare-Release-Assets.outputs.version }}
+      release_tag: ${{ needs.Prepare-Release-Assets.outputs.release_tag }}
+      arch: ${{ matrix.arch }}
+      channel: stable
+    secrets:
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}

--- a/.github/workflows/post-release-publish.yml
+++ b/.github/workflows/post-release-publish.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.release.id || inputs.release_tag || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.release.id || github.event.inputs.release_tag || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -28,7 +28,7 @@ jobs:
         id: prepare
         shell: bash
         env:
-          RELEASE_TAG: ${{ inputs.release_tag || github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.inputs.release_tag || github.event.release.tag_name }}
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -37,35 +37,42 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download linux release assets
+      - name: Read release asset digests
         shell: bash
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mkdir -p artifacts
-          gh release download "${{ inputs.release_tag }}" \
-            --repo "$GH_REPO" \
-            --pattern "SJMCL_${{ inputs.version }}_linux_x86_64.deb" \
-            --pattern "SJMCL_${{ inputs.version }}_linux_aarch64.deb" \
-            --dir artifacts
+          get_asset_digest() {
+            local asset_name="$1"
+            gh api "repos/${GH_REPO}/releases/tags/${{ inputs.release_tag }}" \
+              --jq ".assets[] | select(.name == \"${asset_name}\") | .digest"
+          }
+
+          X86_64_DEB_DIGEST=$(get_asset_digest "SJMCL_${{ inputs.version }}_linux_x86_64.deb")
+          AARCH64_DEB_DIGEST=$(get_asset_digest "SJMCL_${{ inputs.version }}_linux_aarch64.deb")
+
+          if [[ -z "$X86_64_DEB_DIGEST" || -z "$AARCH64_DEB_DIGEST" ]]; then
+            echo "Failed to read one or more release asset digests from GitHub."
+            exit 1
+          fi
+
+          echo "X86_64_DEB_DIGEST=$X86_64_DEB_DIGEST" >> $GITHUB_ENV
+          echo "AARCH64_DEB_DIGEST=$AARCH64_DEB_DIGEST" >> $GITHUB_ENV
 
       - name: Calculate hashes
-        id: calculate_hashes
         run: |
-          ls -la artifacts
-          X86_64_DEB_HASH=$(sha512sum artifacts/SJMCL_${{ inputs.version }}_linux_x86_64.deb)
-          AARCH64_DEB_HASH=$(sha512sum artifacts/SJMCL_${{ inputs.version }}_linux_aarch64.deb)
+          X86_64_DEB_HASH=${X86_64_DEB_DIGEST#sha256:}
+          AARCH64_DEB_HASH=${AARCH64_DEB_DIGEST#sha256:}
+          LICENSE_HASH=$(sha256sum LICENSE.EXTRA | awk '{print $1}')
+
           echo "X86_64_DEB_HASH=$X86_64_DEB_HASH"
           echo "AARCH64_DEB_HASH=$AARCH64_DEB_HASH"
-          LICENSE_HASH=$(sha512sum LICENSE.EXTRA)
           echo "LICENSE_HASH=$LICENSE_HASH"
+
           echo "X86_64_DEB_HASH=$X86_64_DEB_HASH" >> $GITHUB_ENV
-          echo "deb_hash_x86_64=$X86_64_DEB_HASH" >> $GITHUB_OUTPUT
           echo "AARCH64_DEB_HASH=$AARCH64_DEB_HASH" >> $GITHUB_ENV
-          echo "deb_hash_aarch64=$AARCH64_DEB_HASH" >> $GITHUB_OUTPUT
           echo "LICENSE_HASH=$LICENSE_HASH" >> $GITHUB_ENV
-          echo "license_hash=$LICENSE_HASH" >> $GITHUB_OUTPUT
 
       - name: Generate PKGBUILD
         id: gen_template
@@ -74,17 +81,17 @@ jobs:
         run: |
           sed -i "s/^pkgver=.*/pkgver=${VERSION//-/}/" PKGBUILD
           sed -i "s/^_github_pkgver=.*/_github_pkgver=${VERSION}/" PKGBUILD
-          awk -v license_hash="${LICENSE_HASH%% *}" \
-              -v x86_64_hash="${X86_64_DEB_HASH%% *}" \
-              -v aarch64_hash="${AARCH64_DEB_HASH%% *}" '
+          awk -v license_hash="${LICENSE_HASH}" \
+              -v x86_64_hash="${X86_64_DEB_HASH}" \
+              -v aarch64_hash="${AARCH64_DEB_HASH}" '
             BEGIN {
-              sums["sha512sums"] = license_hash
-              sums["sha512sums_x86_64"] = x86_64_hash
-              sums["sha512sums_aarch64"] = aarch64_hash
+              sums["sha256sums"] = license_hash
+              sums["sha256sums_x86_64"] = x86_64_hash
+              sums["sha256sums_aarch64"] = aarch64_hash
               
-              processed["sha512sums"] = 0
-              processed["sha512sums_x86_64"] = 0
-              processed["sha512sums_aarch64"] = 0
+              processed["sha256sums"] = 0
+              processed["sha256sums_x86_64"] = 0
+              processed["sha256sums_aarch64"] = 0
             }
             
             $0 ~ "^[[:blank:]]*[a-z0-9]+sums(_[^=]+)?\\+?=", $0 ~ "\\)[[:blank:]]*(#.*)?$" {

--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -6,19 +6,20 @@ permissions:
 on:
   workflow_dispatch:
     inputs:
-      deb_hash_x86_64:
-        description: "SHA512 hash of the .deb file for x86_64 architecture"
-        required: true
-      deb_hash_aarch64:
-        description: "SHA512 hash of the .deb file for aarch64 architecture"
-        required: true
       version:
         description: "Version to publish"
+        required: true
+      release_tag:
+        description: "Release tag to download assets from"
         required: true
   workflow_call:
     inputs:
       version:
         description: "Version to publish"
+        required: true
+        type: string
+      release_tag:
+        description: "Release tag to download assets from"
         required: true
         type: string
     secrets:
@@ -29,9 +30,6 @@ on:
 jobs:
   publish_aur_package:
     name: Publish AUR package
-    outputs:
-      version: ${{ steps.gen_template.outputs.version }}
-
     runs-on: ubuntu-latest
 
     steps:
@@ -39,36 +37,25 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download linux x86 artifacts
-        if: ${{ inputs.deb_hash_x86_64 == '' }}
-        uses: actions/download-artifact@v4
-        with:
-          pattern: "SJMCL_${{ inputs.version }}_linux_x86_64"
-          path: artifacts
-          merge-multiple: true
-
-      - name: Download linux aarch64 artifacts
-        if: ${{ inputs.deb_hash_aarch64 == '' }}
-        uses: actions/download-artifact@v4
-        with:
-          pattern: "SJMCL_${{ inputs.version }}_linux_aarch64"
-          path: artifacts
-          merge-multiple: true
+      - name: Download linux release assets
+        shell: bash
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p artifacts
+          gh release download "${{ inputs.release_tag }}" \
+            --repo "$GH_REPO" \
+            --pattern "SJMCL_${{ inputs.version }}_linux_x86_64.deb" \
+            --pattern "SJMCL_${{ inputs.version }}_linux_aarch64.deb" \
+            --dir artifacts
 
       - name: Calculate hashes
         id: calculate_hashes
         run: |
-          X86_64_DEB_HASH=${{ inputs.deb_hash_x86_64 }} # Use input deb_hash if provided
-          AARCH64_DEB_HASH=${{ inputs.deb_hash_aarch64 }} # Use input deb_hash if provided
-          if [[ -z "$X86_64_DEB_HASH" || -z "$AARCH64_DEB_HASH" ]]; then
-            ls -la artifacts
-            if [[ -z "$X86_64_DEB_HASH" ]]; then
-              X86_64_DEB_HASH=$(sha512sum artifacts/SJMCL_${{ inputs.version }}_linux_x86_64.deb)
-            fi
-            if [[ -z "$AARCH64_DEB_HASH" ]]; then
-              AARCH64_DEB_HASH=$(sha512sum artifacts/SJMCL_${{ inputs.version }}_linux_aarch64.deb)
-            fi
-          fi
+          ls -la artifacts
+          X86_64_DEB_HASH=$(sha512sum artifacts/SJMCL_${{ inputs.version }}_linux_x86_64.deb)
+          AARCH64_DEB_HASH=$(sha512sum artifacts/SJMCL_${{ inputs.version }}_linux_aarch64.deb)
           echo "X86_64_DEB_HASH=$X86_64_DEB_HASH"
           echo "AARCH64_DEB_HASH=$AARCH64_DEB_HASH"
           LICENSE_HASH=$(sha512sum LICENSE.EXTRA)

--- a/.github/workflows/publish-snap.yml
+++ b/.github/workflows/publish-snap.yml
@@ -7,6 +7,10 @@ on:
         description: "Version to publish"
         required: true
         type: string
+      release_tag:
+        description: "Release tag to download assets from"
+        required: true
+        type: string
       arch:
         description: "Target architecture (x86_64 or aarch64)"
         required: true
@@ -28,11 +32,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: SJMCL_${{ inputs.version }}_linux_${{ inputs.arch }}
-          path: artifacts
+      - name: Download release asset
+        shell: bash
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p artifacts
+          gh release download "${{ inputs.release_tag }}" \
+            --repo "$GH_REPO" \
+            --pattern "SJMCL_${{ inputs.version }}_linux_${{ inputs.arch }}.deb" \
+            --dir artifacts
 
       - name: Prepare Snap payload
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,33 +81,8 @@ jobs:
       MACOS_NOTARY_PASSWORD: ${{ secrets.MACOS_NOTARY_PASSWORD }}
       MACOS_NOTARY_TEAM_ID: ${{ secrets.MACOS_NOTARY_TEAM_ID }}
 
-  Upload-release-to-AUR:
-    needs: [Version-Check, Build-and-Release]
-    if: always() && needs.Build-and-Release.result == 'success'
-    uses: ./.github/workflows/publish-aur.yml
-    with:
-      version: ${{ needs.Version-Check.outputs.version }}
-    secrets:
-      AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-
-  Publish-Snap:
-    name: Publish Snap (${{ matrix.arch }})
-    needs: [Version-Check, Build-and-Release]
-    if: always() && needs.Build-and-Release.result == 'success'
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [x86_64, aarch64]
-    uses: ./.github/workflows/publish-snap.yml
-    with:
-      version: ${{ needs.Version-Check.outputs.version }}
-      arch: ${{ matrix.arch }}
-      channel: edge
-    secrets:
-      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
-
   Create-Release:
-    needs: [Version-Check, Build-and-Release, Code-Sign-macOS, Upload-release-to-AUR, Publish-Snap]
+    needs: [Version-Check, Build-and-Release, Code-Sign-macOS]
     if: always() && needs.Build-and-Release.result == 'success'
     runs-on: ubuntu-latest
     
@@ -206,8 +181,6 @@ jobs:
         id: changelog
         env:
           SIGNING_SUCCESS: ${{ needs.Code-Sign-macOS.result == 'success' }}
-          UPLOAD_AUR_SUCCESS: ${{ needs.Upload-release-to-AUR.result == 'success' }}
-          PUBLISH_SNAP_SUCCESS: ${{ needs.Publish-Snap.result == 'success' }}
         run: |
           pip install requests packaging
           python scripts/release/generate_changelog_draft.py > release-notes.md
@@ -219,18 +192,6 @@ jobs:
             echo "" >> release-notes.md
             echo "⚠️ **Note:** macOS artifacts in this release are **not code-signed**. macOS users may see security warnings when running the application." >> release-notes.md
           fi
-          if [ "${{ env.UPLOAD_AUR_SUCCESS }}" != "true" ]; then
-            echo "" >> release-notes.md
-            echo "---" >> release-notes.md
-            echo "" >> release-notes.md
-            echo "⚠️ **Note:** version of this release are **not updated** in AUR. The AUR package may be outdated." >> release-notes.md
-          fi
-          if [ "${{ env.PUBLISH_SNAP_SUCCESS }}" != "true" ]; then
-            echo "" >> release-notes.md
-            echo "---" >> release-notes.md
-            echo "" >> release-notes.md
-            echo "⚠️ **Note:** this release was **not fully published** to the Snap Store. One or more Snap channels may be outdated." >> release-notes.md
-          fi
         shell: bash
 
       - name: Create Release
@@ -238,13 +199,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.Version-Check.outputs.version }}
         run: |
-          RELEASE_TAG="${{ env.VERSION }}"
-          
           # Create the release
           gh release create "$GITHUB_REF_NAME" \
             --title "SJMCL ${{ env.VERSION }}" \
             --draft \
-            $PRERELEASE \
             --notes-file release-notes.md \
             ./release-artifacts/*
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -13,9 +13,9 @@ url='https://github.com/UNIkeEN/SJMCL'
 _baseurl="${url}/releases/download/v${_github_pkgver}"
 _source="SJMCL_${_github_pkgver}_linux_${CARCH}.deb"
 
-sha512sums=('SKIP')
-sha512sums_x86_64=('SKIP')
-sha512sums_aarch64=('SKIP')
+sha256sums=('SKIP')
+sha256sums_x86_64=('SKIP')
+sha256sums_aarch64=('SKIP')
 
 source=('LICENSE.EXTRA')
 source_x86_64=("${_baseurl}/${_source}")


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

#1606 

### Description

1. 重构发布流程，将snap/aur的发布从构建中移除，增加post release workflow
2. AUR改为使用sha256作为校验，以复用github release元数据

### Additional Context

## Summary by Sourcery

Decouple AUR and Snap publishing from the main release workflow by moving them into a dedicated post-release workflow that operates on published release assets.

Enhancements:
- Update AUR and Snap publishing workflows to download .deb artifacts from GitHub release assets using a release tag instead of build artifacts.
- Simplify AUR hash calculation by always computing hashes from downloaded .deb files.
- Introduce a post-release workflow that validates required Linux release assets and then triggers AUR and Snap publishing for both architectures.