### PR TITLE
chore(deps): bump rmcp from 0.15.0 to 1.7.0

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -81,10 +81,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link 0.2.1",
 ]
 
@@ -557,16 +555,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "iri-string"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,10 +562,12 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -770,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.23"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -789,7 +779,6 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-util",
@@ -805,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.15.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bef41ebc9ebed2c1b1d90203e9d1756091e8a00bbc3107676151f39868ca0ee"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "base64",
@@ -831,9 +820,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.15.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e88ad84b8b6237a934534a62b379a5be6388915663c0cc598ceb9b3292bbbfe"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -860,12 +849,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "schemars"
@@ -951,18 +934,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -1157,20 +1128,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -1275,48 +1246,32 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1324,31 +1279,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -1359,9 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,6 +13,6 @@ codegen-units = 1
 [dependencies]
 comfy-table = "7"
 indicatif = "0.17"
-rmcp = { version = "0.15.0", features = ["client", "transport-streamable-http-client-reqwest"] }
+rmcp = { version = "1.7.0", features = ["client", "transport-streamable-http-client-reqwest"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -83,12 +83,7 @@ async fn run() -> Result<(), String> {
       let client = with_spinner(async { connect_launcher(&invocation.options).await }).await?;
       let result = with_spinner(async {
         client
-          .call_tool(CallToolRequestParams {
-            meta: None,
-            name: name.clone().into(),
-            arguments: Some(arguments),
-            task: None,
-          })
+          .call_tool(CallToolRequestParams::new(name.clone()).with_arguments(arguments))
           .await
           .map_err(service_error_to_string)
       })

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4718,12 +4718,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.15.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bef41ebc9ebed2c1b1d90203e9d1756091e8a00bbc3107676151f39868ca0ee"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
- "axum",
  "base64 0.22.1",
  "bytes",
  "chrono",
@@ -4733,7 +4732,7 @@ dependencies = [
  "http-body-util",
  "pastey",
  "pin-project-lite",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rmcp-macros",
  "schemars 1.2.1",
  "serde",
@@ -4750,9 +4749,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.15.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e88ad84b8b6237a934534a62b379a5be6388915663c0cc598ceb9b3292bbbfe"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,7 +53,7 @@ rand = "0.9.3"
 regex = "1.11"
 reqwest-middleware = "0.4.2"
 reqwest-retry = "0.7.0"
-rmcp = { version = "0.15.0", features = ["server", "transport-streamable-http-server"] }
+rmcp = { version = "1.7.0", features = ["server", "transport-streamable-http-server"] }
 rsa = "0.9.10"
 sanitize-filename = "0.6.0"
 schemars = "1.0.4"

--- a/src-tauri/src/intelligence/mcp_server/launcher/mod.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/mod.rs
@@ -29,22 +29,15 @@ impl McpContext {
 
 impl ServerHandler for McpContext {
   fn get_info(&self) -> ServerInfo {
-    ServerInfo {
-      capabilities: ServerCapabilities::builder().enable_tools().build(),
-      server_info: Implementation {
-        name: "sjmcl-mcp".to_string(),
-        title: Some("SJMCL MCP".to_string()),
-        version: env!("CARGO_PKG_VERSION").to_string(),
-        description: Some("MCP tools exposed by SJMCL, a modern Minecraft launcher".to_string()),
-        icons: None,
-        website_url: None,
-      },
-      instructions: Some(
+    ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+      .with_server_info(
+        Implementation::new("sjmcl-mcp", env!("CARGO_PKG_VERSION"))
+          .with_title("SJMCL MCP")
+          .with_description("MCP tools exposed by SJMCL, a modern Minecraft launcher"),
+      )
+      .with_instructions(
         "Use tools to query Minecraft instances and accounts managed by SJMC Launcher. When a tool requires instance_id, first list available instances and then pass one returned id. This server is intended for local trusted clients."
-          .to_string(),
-      ),
-      ..Default::default()
-    }
+      )
   }
 }
 
@@ -136,10 +129,7 @@ async fn serve(
         )
       },
       Default::default(),
-      StreamableHttpServerConfig {
-        stateful_mode: true,
-        ..Default::default()
-      },
+      StreamableHttpServerConfig::default().with_stateful_mode(true),
     );
 
   let axum_router = axum::Router::new().nest_service(MCP_SERVER_PATH, service);


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

## Summary by Sourcery

Upgrade the rmcp client and server dependencies to v1.7.0 and adjust usage to the updated API.

New Features:
- Leverage new rmcp API helpers for constructing server info, HTTP server configuration, and tool call parameters.

Enhancements:
- Simplify MCP server metadata construction using the new rmcp builder-style API.
- Streamline CLI tool invocation by using the new CallToolRequestParams constructor and chained argument configuration.

Build:
- Update rmcp dependency versions to 1.7.0 in both CLI and Tauri crates and refresh lockfiles.