### PR TITLE
fix(frontend): retrieve config after update listener is set, avoid missing updates during initial loading phase

### DIFF
--- a/src/contexts/config.tsx
+++ b/src/contexts/config.tsx
@@ -65,9 +65,55 @@ export const LauncherConfigContextProvider: React.FC<{
     });
   }, [setConfig, toast]);
 
+  // from frontend to call backend update
+  const handleUpdateLauncherConfig = (path: string, value: any) => {
+    // save to the backend
+    ConfigService.updateLauncherConfig(path, value).then((response) => {
+      // if success, backend will emit signal, the logic below will be executed
+      if (response.status !== "success") {
+        toast({
+          title: response.message,
+          description: response.details,
+          status: "error",
+        });
+      }
+    });
+  };
+
+  // listen from backend to update frontend's config state
+  const handleConfigPartialUpdate = useCallback((payload: any) => {
+    const { path, value } = payload;
+    setConfig((prevConfig) => {
+      const newConfig = { ...prevConfig };
+      updateByKeyPath(newConfig, path, JSON.parse(value));
+      return newConfig;
+    });
+  }, []);
+
+  // retrieve config after partial update listener is set, to avoid missing updates during the initial loading phase. (#1615)
   useEffect(() => {
-    handleRetrieveLauncherConfig();
-  }, [handleRetrieveLauncherConfig]);
+    let cancelled = false;
+    let unlisten: (() => void) | undefined;
+
+    void ConfigService.onConfigPartialUpdate(handleConfigPartialUpdate)
+      .then((cleanup) => {
+        unlisten = cleanup;
+        if (cancelled) {
+          unlisten();
+          return;
+        }
+
+        handleRetrieveLauncherConfig();
+      })
+      .catch(() => {
+        handleRetrieveLauncherConfig();
+      });
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [handleConfigPartialUpdate, handleRetrieveLauncherConfig]);
 
   useEffect(() => {
     i18n.changeLanguage(language);
@@ -92,38 +138,6 @@ export const LauncherConfigContextProvider: React.FC<{
       return () => media.removeEventListener("change", applyColorMode);
     }
   }, [userSelectedColorMode, colorMode, toggleColorMode]);
-
-  // from frontend to call backend update
-  const handleUpdateLauncherConfig = (path: string, value: any) => {
-    // Save to the backend
-    ConfigService.updateLauncherConfig(path, value).then((response) => {
-      // if success, backend will emit signal, the logic below will be executed
-      if (response.status !== "success") {
-        toast({
-          title: response.message,
-          description: response.details,
-          status: "error",
-        });
-      }
-    });
-  };
-
-  // listen from backend to update frontend's config state
-  const handleConfigPartialUpdate = useCallback((payload: any) => {
-    const { path, value } = payload;
-    setConfig((prevConfig) => {
-      const newConfig = { ...prevConfig };
-      updateByKeyPath(newConfig, path, JSON.parse(value));
-      return newConfig;
-    });
-  }, []);
-
-  useEffect(() => {
-    const unlisten = ConfigService.onConfigPartialUpdate(
-      handleConfigPartialUpdate
-    );
-    return () => unlisten();
-  }, [handleConfigPartialUpdate]);
 
   // java list cache and retriever
   const handleRetrieveJavaList = useCallback(() => {

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -209,18 +209,18 @@ export class ConfigService {
    * Listens for backend-initiated changes to the `config` field.
    * @param callback - Callback function invoked whenever the config is updated by the backend.
    */
-  static onConfigPartialUpdate(
+  static async onConfigPartialUpdate(
     callback: (payload: { path: string; value: any }) => void
   ) {
-    const unlisten = getCurrentWebview().listen<{ path: string; value: any }>(
-      CONFIG_PARTIAL_UPDATE_EVENT,
-      (event) => {
-        callback(event.payload);
-      }
-    );
+    const unlisten = await getCurrentWebview().listen<{
+      path: string;
+      value: any;
+    }>(CONFIG_PARTIAL_UPDATE_EVENT, (event) => {
+      callback(event.payload);
+    });
 
     return () => {
-      unlisten.then((f) => f());
+      unlisten();
     };
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [x] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

fix #1615

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Ensure launcher configuration is retrieved only after the backend partial-update listener is registered to avoid missing initial updates.

Bug Fixes:
- Prevent loss of configuration updates during the initial loading phase by delaying config retrieval until after the partial-update listener is set up.

Enhancements:
- Make the config partial-update subscription API asynchronous with a direct cleanup function for improved reliability and clarity.