### PR TITLE
feat(ci): add homebrew release

### DIFF
--- a/.github/homebrew/sjmcl.rb.template
+++ b/.github/homebrew/sjmcl.rb.template
@@ -1,0 +1,22 @@
+cask "sjmcl" do
+  arch arm: "aarch64", intel: "x86_64"
+
+  version "__VERSION__"
+
+  on_arm do
+    sha256 "__ARM_SHA256__"
+  end
+
+  on_intel do
+    sha256 "__INTEL_SHA256__"
+  end
+
+  url "https://github.com/UNIkeEN/SJMCL/releases/download/v#{version}/SJMCL_#{version}_macos_#{arch}.dmg",
+      verified: "github.com/UNIkeEN/SJMCL/"
+
+  name "SJMCL"
+  desc "A Minecraft launcher born from @SJMC-Dev, built with the community"
+  homepage "https://github.com/UNIkeEN/SJMCL"
+
+  app "SJMCL.app"
+end

--- a/.github/workflows/post-release-publish.yml
+++ b/.github/workflows/post-release-publish.yml
@@ -23,6 +23,7 @@ jobs:
     outputs:
       version: ${{ steps.prepare.outputs.version }}
       release_tag: ${{ steps.prepare.outputs.release_tag }}
+      is_prerelease: ${{ steps.prepare.outputs.is_prerelease }}
     steps:
       - name: Prepare release metadata
         id: prepare
@@ -35,6 +36,8 @@ jobs:
           VERSION="${RELEASE_TAG#v}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          IS_PRERELEASE=$(gh release view "$RELEASE_TAG" --repo "$GH_REPO" --json isPrerelease --jq '.isPrerelease')
+          echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
 
           assets=(
             "SJMCL_${VERSION}_linux_x86_64.deb"
@@ -83,3 +86,14 @@ jobs:
       channel: stable
     secrets:
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+
+  Publish-Homebrew:
+    needs: [Prepare-Release-Assets]
+    if: needs.Prepare-Release-Assets.outputs.is_prerelease == 'false'
+    uses: ./.github/workflows/publish-homebrew.yml
+    with:
+      version: ${{ needs.Prepare-Release-Assets.outputs.version }}
+      release_tag: ${{ needs.Prepare-Release-Assets.outputs.release_tag }}
+    secrets:
+      HOMEBREW_TAP_APP_ID: ${{ secrets.HOMEBREW_TAP_APP_ID }}
+      HOMEBREW_TAP_APP_PRIVATE_KEY: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -1,0 +1,127 @@
+name: Publish Homebrew Cask
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to publish"
+        required: true
+        type: string
+      release_tag:
+        description: "Release tag to read assets from"
+        required: true
+        type: string
+    secrets:
+      HOMEBREW_TAP_APP_ID:
+        description: "GitHub App ID with write access to the Homebrew tap repository"
+        required: true
+      HOMEBREW_TAP_APP_PRIVATE_KEY:
+        description: "GitHub App private key with write access to the Homebrew tap repository"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish_homebrew_cask:
+    name: Publish Homebrew cask
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v4
+
+      - name: Read macOS release asset digests
+        shell: bash
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          get_asset_digest() {
+            local asset_name="$1"
+            gh api "repos/${GH_REPO}/releases/tags/${RELEASE_TAG}" \
+              --jq ".assets[] | select(.name == \"${asset_name}\") | .digest"
+          }
+
+          ARM_DMG_DIGEST=$(get_asset_digest "SJMCL_${VERSION}_macos_aarch64.dmg")
+          INTEL_DMG_DIGEST=$(get_asset_digest "SJMCL_${VERSION}_macos_x86_64.dmg")
+
+          if [[ -z "$ARM_DMG_DIGEST" ]]; then
+            echo "Missing release asset digest: SJMCL_${VERSION}_macos_aarch64.dmg"
+            exit 1
+          fi
+
+          if [[ -z "$INTEL_DMG_DIGEST" ]]; then
+            echo "Missing release asset digest: SJMCL_${VERSION}_macos_x86_64.dmg"
+            exit 1
+          fi
+
+          if [[ "$ARM_DMG_DIGEST" != sha256:* || "$INTEL_DMG_DIGEST" != sha256:* ]]; then
+            echo "Unexpected release asset digest format. Expected sha256:<hex>."
+            exit 1
+          fi
+
+          echo "ARM_DMG_HASH=${ARM_DMG_DIGEST#sha256:}" >> "$GITHUB_ENV"
+          echo "INTEL_DMG_HASH=${INTEL_DMG_DIGEST#sha256:}" >> "$GITHUB_ENV"
+
+      - name: Create GitHub App token for Homebrew tap
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.HOMEBREW_TAP_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: SJMC-Dev
+          repositories: homebrew-SJMCL
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@v4
+        with:
+          repository: SJMC-Dev/homebrew-SJMCL
+          token: ${{ steps.app-token.outputs.token }}
+          path: homebrew-tap
+
+      - name: Update cask
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          mkdir -p homebrew-tap/Casks
+
+          ruby <<'RUBY'
+          template_path = ".github/homebrew/sjmcl.rb.template"
+          output_path = "homebrew-tap/Casks/sjmcl.rb"
+
+          content = File.read(template_path)
+          replacements = {
+            "__VERSION__" => ENV.fetch("VERSION"),
+            "__ARM_SHA256__" => ENV.fetch("ARM_DMG_HASH"),
+            "__INTEL_SHA256__" => ENV.fetch("INTEL_DMG_HASH")
+          }
+
+          replacements.each do |placeholder, value|
+            content = content.gsub(placeholder, value)
+          end
+
+          File.write(output_path, content)
+          RUBY
+
+          ruby -c homebrew-tap/Casks/sjmcl.rb
+          git -C homebrew-tap diff -- Casks/sjmcl.rb
+
+      - name: Commit and push tap update
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if git -C homebrew-tap diff --quiet -- Casks/sjmcl.rb; then
+            echo "Homebrew cask is already up to date."
+            exit 0
+          fi
+
+          git -C homebrew-tap config user.name "github-actions[bot]"
+          git -C homebrew-tap config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C homebrew-tap add Casks/sjmcl.rb
+          git -C homebrew-tap commit -m "Update SJMCL cask to ${VERSION}"
+          git -C homebrew-tap push


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

#1606

### Description

自动更新 https://github.com/SJMC-Dev/homebrew-SJMCL/blob/main/Casks/sjmcl.rb

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Integrate automated Homebrew cask publishing into the post-release pipeline, gated to run only for non-prerelease tags.

New Features:
- Add a reusable GitHub Actions workflow to publish and update the Homebrew cask from release assets.

CI:
- Extend the post-release workflow to detect prereleases and only trigger Homebrew publishing for stable releases.
- Set up a GitHub App–based authentication flow for updating the external Homebrew tap repository during cask publication.