### PR TITLE
feat(instance): register .mrpack file association for system-level op…

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -14,6 +14,43 @@
         </array>
       </dict>
     </array>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+      <dict>
+        <key>CFBundleTypeName</key>
+        <string>Modrinth Modpack</string>
+        <key>CFBundleTypeRole</key>
+        <string>Editor</string>
+        <key>LSHandlerRank</key>
+        <string>Default</string>
+        <key>LSItemContentTypes</key>
+        <array>
+          <string>com.modrinth.mrpack</string>
+        </array>
+      </dict>
+    </array>
+    <key>UTExportedTypeDeclarations</key>
+    <array>
+      <dict>
+        <key>UTTypeIdentifier</key>
+        <string>com.modrinth.mrpack</string>
+        <key>UTTypeTagSpecification</key>
+        <dict>
+          <key>public.filename-extension</key>
+          <array>
+            <string>mrpack</string>
+          </array>
+          <key>public.mime-type</key>
+          <string>application/zip</string>
+        </dict>
+        <key>UTTypeDescription</key>
+        <string>Modrinth Modpack</string>
+        <key>UTTypeConformsTo</key>
+        <array>
+          <string>public.zip-archive</string>
+        </array>
+      </dict>
+    </array>
     <key>CFBundleLocalizations</key>
     <array>
       <string>en</string>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,7 +32,7 @@ use utils::web::build_sjmcl_client;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 use tauri::path::BaseDirectory;
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 
 #[cfg(target_os = "windows")]
 use tauri_plugin_decorum::WebviewWindowExt;
@@ -45,6 +45,8 @@ static IS_PORTABLE: LazyLock<bool> = LazyLock::new(|| is_portable().unwrap_or(fa
 
 static APP_DATA_DIR: OnceLock<PathBuf> = OnceLock::new();
 
+static PENDING_MODPACK_IMPORT: LazyLock<Mutex<Option<String>>> = LazyLock::new(|| Mutex::new(None));
+
 pub async fn run() {
   let exit_code = {
     let builder = tauri::Builder::default()
@@ -56,11 +58,20 @@ pub async fn run() {
       .plugin(tauri_plugin_opener::init())
       .plugin(tauri_plugin_os::init())
       .plugin(tauri_plugin_process::init())
-      .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+      .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
         let main_window = app.get_webview_window("main").expect("no main window");
         let _ = main_window.show(); // may hide by launcher_visibility settings
                                     // FIXME: this show() seems no use in macOS build mode (ref: https://github.com/tauri-apps/tauri/issues/13400#issuecomment-2866462355).
         let _ = main_window.set_focus();
+
+        // Handle .mrpack file association on warm re-launch
+        for arg in &args {
+          if arg.ends_with(".mrpack") {
+            let encoded = urlencoding::encode(arg);
+            let deep_link = format!("sjmcl://import-modpack?path={}", encoded);
+            let _ = app.emit("sjmcl://import", deep_link);
+          }
+        }
       }))
       .plugin(
         tauri_plugin_window_state::Builder::new()
@@ -190,6 +201,7 @@ pub async fn run() {
         utils::commands::delete_directory,
         utils::commands::read_file,
         utils::commands::write_file,
+        utils::commands::check_pending_modpack_import,
       ])
       .setup(|app| {
         // init APP_DATA_DIR
@@ -332,18 +344,46 @@ pub async fn run() {
           intelligence::mcp_server::launcher::run(app.handle().clone(), &launcher_mcp_config);
         }
 
+        // Handle .mrpack file association on cold start
+        // Store the deep link so the frontend can pick it up once loaded
+        let args: Vec<String> = std::env::args().collect();
+        for arg in &args {
+          if arg.ends_with(".mrpack") {
+            let encoded = urlencoding::encode(arg);
+            let deep_link = format!("sjmcl://import-modpack?path={}", encoded);
+            *PENDING_MODPACK_IMPORT.lock().unwrap() = Some(deep_link);
+            break;
+          }
+        }
+
         Ok(())
       })
       .build(tauri::generate_context!())
       .expect("error while building tauri application")
-      .run_return(|_, event| {
-        if let tauri::RunEvent::Exit = event {
+      .run_return(|app_handle, event| match event {
+        #[cfg(target_os = "macos")]
+        tauri::RunEvent::Opened { urls } => {
+          for url in urls {
+            if let Ok(path) = url.to_file_path() {
+              if path.extension().map_or(false, |ext| ext == "mrpack") {
+                if let Some(path_str) = path.to_str() {
+                  let encoded = urlencoding::encode(path_str);
+                  let deep_link = format!("sjmcl://import-modpack?path={}", encoded);
+                  *PENDING_MODPACK_IMPORT.lock().unwrap() = Some(deep_link.clone());
+                  let _ = app_handle.emit("sjmcl://import", deep_link);
+                }
+              }
+            }
+          }
+        }
+        tauri::RunEvent::Exit => {
           log::info!("Launcher exited normally.");
           let _ = LauncherConfig::load().map(|mut config| {
             config.last_run_exited_normally = true;
             let _ = config.save();
           });
         }
+        _ => {}
       })
   };
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -64,11 +64,12 @@ pub async fn run() {
                                     // FIXME: this show() seems no use in macOS build mode (ref: https://github.com/tauri-apps/tauri/issues/13400#issuecomment-2866462355).
         let _ = main_window.set_focus();
 
-        // Handle .mrpack file association on warm re-launch
+        // .mrpack file association (warm start)
         for arg in &args {
           if arg.ends_with(".mrpack") {
             let encoded = urlencoding::encode(arg);
             let deep_link = format!("sjmcl://import-modpack?path={}", encoded);
+            *PENDING_MODPACK_IMPORT.lock().unwrap() = Some(deep_link.clone());
             let _ = app.emit("sjmcl://import", deep_link);
           }
         }
@@ -201,7 +202,7 @@ pub async fn run() {
         utils::commands::delete_directory,
         utils::commands::read_file,
         utils::commands::write_file,
-        utils::commands::check_pending_modpack_import,
+        utils::commands::check_cold_start_mrpack,
       ])
       .setup(|app| {
         // init APP_DATA_DIR
@@ -344,46 +345,39 @@ pub async fn run() {
           intelligence::mcp_server::launcher::run(app.handle().clone(), &launcher_mcp_config);
         }
 
-        // Handle .mrpack file association on cold start
-        // Store the deep link so the frontend can pick it up once loaded
-        let args: Vec<String> = std::env::args().collect();
-        for arg in &args {
-          if arg.ends_with(".mrpack") {
-            let encoded = urlencoding::encode(arg);
-            let deep_link = format!("sjmcl://import-modpack?path={}", encoded);
-            *PENDING_MODPACK_IMPORT.lock().unwrap() = Some(deep_link);
-            break;
-          }
-        }
-
         Ok(())
       })
       .build(tauri::generate_context!())
       .expect("error while building tauri application")
-      .run_return(|app_handle, event| match event {
-        #[cfg(target_os = "macos")]
-        tauri::RunEvent::Opened { urls } => {
-          for url in urls {
-            if let Ok(path) = url.to_file_path() {
-              if path.extension().map_or(false, |ext| ext == "mrpack") {
-                if let Some(path_str) = path.to_str() {
-                  let encoded = urlencoding::encode(path_str);
-                  let deep_link = format!("sjmcl://import-modpack?path={}", encoded);
-                  *PENDING_MODPACK_IMPORT.lock().unwrap() = Some(deep_link.clone());
-                  let _ = app_handle.emit("sjmcl://import", deep_link);
+      .run_return(|app_handle, event| {
+        #[cfg(not(target_os = "macos"))]
+        let _ = &app_handle;
+        match event {
+          // macOS: file open is an Apple Event, not argv
+          #[cfg(target_os = "macos")]
+          tauri::RunEvent::Opened { urls } => {
+            for url in urls {
+              if let Ok(path) = url.to_file_path() {
+                if path.extension().map_or(false, |ext| ext == "mrpack") {
+                  if let Some(path_str) = path.to_str() {
+                    let encoded = urlencoding::encode(path_str);
+                    let deep_link = format!("sjmcl://import-modpack?path={}", encoded);
+                    *PENDING_MODPACK_IMPORT.lock().unwrap() = Some(deep_link.clone());
+                    let _ = app_handle.emit("sjmcl://import", deep_link);
+                  }
                 }
               }
             }
           }
+          tauri::RunEvent::Exit => {
+            log::info!("Launcher exited normally.");
+            let _ = LauncherConfig::load().map(|mut config| {
+              config.last_run_exited_normally = true;
+              let _ = config.save();
+            });
+          }
+          _ => {}
         }
-        tauri::RunEvent::Exit => {
-          log::info!("Launcher exited normally.");
-          let _ = LauncherConfig::load().map(|mut config| {
-            config.last_run_exited_normally = true;
-            let _ = config.save();
-          });
-        }
-        _ => {}
       })
   };
 

--- a/src-tauri/src/utils/commands.rs
+++ b/src-tauri/src/utils/commands.rs
@@ -85,8 +85,21 @@ pub fn write_file(path: String, content: String, mode: Option<String>) -> SJMCLR
   }
 }
 
+// Check whether the app was started by opening a .mrpack file.
+// macOS: RunEvent::Opened stores the URL before frontend loads (emit would be lost).
+// Windows/Linux: just read argv — it's available at any time without pre-storage.
 #[tauri::command]
-pub fn check_pending_modpack_import() -> SJMCLResult<Option<String>> {
-  let pending = crate::PENDING_MODPACK_IMPORT.lock().unwrap().take();
-  Ok(pending)
+pub fn check_cold_start_mrpack() -> SJMCLResult<Option<String>> {
+  if let Some(pending) = crate::PENDING_MODPACK_IMPORT.lock().unwrap().take() {
+    return Ok(Some(pending));
+  }
+  for arg in std::env::args() {
+    if arg.ends_with(".mrpack") {
+      return Ok(Some(format!(
+        "sjmcl://import-modpack?path={}",
+        urlencoding::encode(&arg)
+      )));
+    }
+  }
+  Ok(None)
 }

--- a/src-tauri/src/utils/commands.rs
+++ b/src-tauri/src/utils/commands.rs
@@ -84,3 +84,9 @@ pub fn write_file(path: String, content: String, mode: Option<String>) -> SJMCLR
     value => Err(SJMCLError(format!("Unsupported mode: {value}"))),
   }
 }
+
+#[tauri::command]
+pub fn check_pending_modpack_import() -> SJMCLResult<Option<String>> {
+  let pending = crate::PENDING_MODPACK_IMPORT.lock().unwrap().take();
+  Ok(pending)
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,6 +42,16 @@
     ],
     "licenseFile": "../LICENSE",
     "license": "GPLv3",
+    "fileAssociations": [
+      {
+        "ext": ["mrpack"],
+        "name": "Modrinth Modpack",
+        "description": "Modrinth Modpack File",
+        "role": "Editor",
+        "mimeType": "application/zip",
+        "rank": "Default"
+      }
+    ],
     "resources": {
       "assets/skins/*": "assets/skins/",
       "assets/game/*": "assets/game/",

--- a/src/components/special/global-event-handler.tsx
+++ b/src/components/special/global-event-handler.tsx
@@ -3,7 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo } from "react";
 import { useSharedModals } from "@/contexts/shared-modal";
-import useDeepLink from "@/hooks/deep-link";
+import useDeepLink, { emitDeepLink } from "@/hooks/deep-link";
 import useKeyboardShortcut from "@/hooks/keyboard-shortcut";
 
 // Handle global keyboard shortcuts, DnD events, etc.
@@ -135,43 +135,19 @@ const GlobalEventHandler: React.FC<{ children: React.ReactNode }> = ({
     onCall: importModpackByDeeplink,
   });
 
-  // Helper: open the import-modpack modal from a deep-link URL
-  const openModpackImportFromUrl = useCallback(
-    (url: string) => {
-      const filePath = new URL(url).searchParams.get("path") || "";
-      if (!isStandAlone && filePath) {
-        setTimeout(() => {
-          openSharedModal("import-modpack", { path: filePath });
-        }, 500);
-      }
-    },
-    [isStandAlone, openSharedModal]
-  );
-
-  // Listen for file association events from the Rust backend (warm start)
   useEffect(() => {
     let unlisten: (() => void) | undefined;
     (async () => {
+      const pending = await invoke<string | null>("check_cold_start_mrpack");
+      if (pending) emitDeepLink([pending]);
       unlisten = await listen<string>("sjmcl://import", (event) => {
-        openModpackImportFromUrl(event.payload);
+        emitDeepLink([event.payload]);
       });
     })();
     return () => {
       if (unlisten) unlisten();
     };
-  }, [openModpackImportFromUrl]);
-
-  // Check for pending modpack import from cold start
-  useEffect(() => {
-    (async () => {
-      const pending = await invoke<string | null>(
-        "check_pending_modpack_import"
-      );
-      if (pending) {
-        openModpackImportFromUrl(pending);
-      }
-    })();
-  }, [openModpackImportFromUrl]);
+  }, []);
 
   return <>{children}</>;
 };

--- a/src/components/special/global-event-handler.tsx
+++ b/src/components/special/global-event-handler.tsx
@@ -1,5 +1,7 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { useRouter } from "next/router";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useSharedModals } from "@/contexts/shared-modal";
 import useDeepLink from "@/hooks/deep-link";
 import useKeyboardShortcut from "@/hooks/keyboard-shortcut";
@@ -109,6 +111,67 @@ const GlobalEventHandler: React.FC<{ children: React.ReactNode }> = ({
     trigger: launchTrigger,
     onCall: quickLaunchGame,
   });
+
+  const importModpackTrigger = useMemo(
+    () => /^import-modpack\/?(?:\?.*)?$/,
+    []
+  );
+
+  const importModpackByDeeplink = useCallback(
+    (path: string | URL) => {
+      const url = new URL(path);
+      const filePath = url.searchParams.get("path") || "";
+      if (!isStandAlone && filePath) {
+        setTimeout(() => {
+          openSharedModal("import-modpack", { path: filePath });
+        }, 500);
+      }
+    },
+    [isStandAlone, openSharedModal]
+  );
+
+  useDeepLink({
+    trigger: importModpackTrigger,
+    onCall: importModpackByDeeplink,
+  });
+
+  // Helper: open the import-modpack modal from a deep-link URL
+  const openModpackImportFromUrl = useCallback(
+    (url: string) => {
+      const filePath = new URL(url).searchParams.get("path") || "";
+      if (!isStandAlone && filePath) {
+        setTimeout(() => {
+          openSharedModal("import-modpack", { path: filePath });
+        }, 500);
+      }
+    },
+    [isStandAlone, openSharedModal]
+  );
+
+  // Listen for file association events from the Rust backend (warm start)
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    (async () => {
+      unlisten = await listen<string>("sjmcl://import", (event) => {
+        openModpackImportFromUrl(event.payload);
+      });
+    })();
+    return () => {
+      if (unlisten) unlisten();
+    };
+  }, [openModpackImportFromUrl]);
+
+  // Check for pending modpack import from cold start
+  useEffect(() => {
+    (async () => {
+      const pending = await invoke<string | null>(
+        "check_pending_modpack_import"
+      );
+      if (pending) {
+        openModpackImportFromUrl(pending);
+      }
+    })();
+  }, [openModpackImportFromUrl]);
 
   return <>{children}</>;
 };


### PR DESCRIPTION
…en with

Add OS-level file handler for .mrpack (Modrinth modpack) files so that double-clicking a .mrpack file in the file manager launches SJMCL and opens the import-modpack modal.

- Add bundle.fileAssociations in tauri.conf.json for .mrpack
- Add UTExportedTypeDeclarations in Info.plist for macOS custom UTI
- Handle cold start via std::env::args() (Windows/Linux) and RunEvent::Opened (macOS)
- Handle warm start via single-instance plugin callback (Windows/Linux)
- Add check_pending_modpack_import Tauri command for cold-start race condition
- Add sjmcl://import-modpack deep link handler in GlobalEventHandler
- Add Tauri event bridge (sjmcl://import) for Rust-to-frontend communication

<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally (windows) and work as expected.


### This PR is a ..

- [x] 🆕 New feature

### Related Issues

> - close #1618

## Summary by Sourcery

Add OS-level .mrpack file association handling so opening Modrinth modpack files launches the app and opens the import-modpack flow across supported platforms.

New Features:
- Support importing Modrinth .mrpack files via OS-level file associations and custom deep links, opening the import-modpack modal automatically.

Enhancements:
- Wire Tauri backend events and a new check_pending_modpack_import command to notify the frontend about pending modpack imports on both cold and warm starts.
- Register macOS document type and custom UTI for .mrpack files so the app can be set as the default handler.