### PR TITLE
feat: 支持微软账户在 AccessToken 过期后自动轮换

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ async-trait = "0.1.89"
 axum = "0.8.6"
 base64 = "0.22.1"
 cafebabe = "0.8.1"
-chrono = "0.4.40"
+chrono = { version = "0.4.40", features = ["serde"] }
 config = "0.15.18"
 csv = "1.3"
 flume = { version = "0.11.1", features = ["async", "select"] }

--- a/src-tauri/src/account/commands.rs
+++ b/src-tauri/src/account/commands.rs
@@ -463,28 +463,7 @@ pub async fn retrieve_microsoft_friend_list(
     return Err(AccountError::Invalid.into());
   }
 
-  let maybe_refreshed = if player
-    .access_token_expires
-    .map(|expires| expires < chrono::Utc::now())
-    .unwrap_or(false)
-  {
-    let refreshed_player = microsoft::oauth::refresh(&app, player).await?;
-    let mut account_state = account_binding.lock()?;
-    if let Some(state_player) = account_state
-      .players
-      .iter_mut()
-      .find(|p| p.id == refreshed_player.id)
-    {
-      *state_player = refreshed_player.clone();
-      account_state.save()?;
-    }
-    Some(refreshed_player)
-  } else {
-    None
-  };
-
-  let player_to_use = maybe_refreshed.as_ref().unwrap_or(player);
-  microsoft::friends::retrieve_friend_list(&app, player_to_use).await
+  microsoft::friends::retrieve_friend_list(&app, player).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/account/commands.rs
+++ b/src-tauri/src/account/commands.rs
@@ -404,15 +404,7 @@ pub async fn delete_player(app: AppHandle, player_id: String) -> SJMCLResult<()>
 
 #[tauri::command]
 pub async fn refresh_player(app: AppHandle, player_id: String) -> SJMCLResult<()> {
-  let account_binding = app.state::<Mutex<AccountInfo>>();
-
-  let cloned_account_state = account_binding.lock()?.clone();
-
-  let player = cloned_account_state
-    .players
-    .iter()
-    .find(|player| player.id == player_id)
-    .ok_or(AccountError::NotFound)?;
+  let player = misc::get_player_by_id(&app, &player_id)?.ok_or(AccountError::NotFound)?;
 
   let refreshed_player = match player.player_type {
     PlayerType::ThirdParty => {
@@ -421,26 +413,17 @@ pub async fn refresh_player(app: AppHandle, player_id: String) -> SJMCLResult<()
         player.auth_server_url.clone().unwrap_or_default(),
       )?);
 
-      authlib_injector::common::refresh(&app, player, &auth_server).await?
+      authlib_injector::common::refresh(&app, &player, &auth_server).await?
     }
 
-    PlayerType::Microsoft => microsoft::oauth::refresh(&app, player).await?,
+    PlayerType::Microsoft => microsoft::oauth::refresh(&app, &player).await?,
 
     PlayerType::Offline => {
       return Err(AccountError::Invalid.into());
     }
   };
 
-  let mut account_state = account_binding.lock()?;
-
-  if let Some(player) = account_state
-    .players
-    .iter_mut()
-    .find(|player| player.id == player_id)
-  {
-    *player = refreshed_player;
-    account_state.save()?;
-  }
+  misc::update_player_by_id(&app, &player_id, refreshed_player)?;
 
   Ok(())
 }
@@ -450,20 +433,13 @@ pub async fn retrieve_microsoft_friend_list(
   app: AppHandle,
   cur_player_id: String,
 ) -> SJMCLResult<MicrosoftFriendList> {
-  let account_binding = app.state::<Mutex<AccountInfo>>();
-  let cloned_account_state = account_binding.lock()?.clone();
-
-  let player = cloned_account_state
-    .players
-    .iter()
-    .find(|player| player.id == cur_player_id)
-    .ok_or(AccountError::NotFound)?;
+  let player = misc::get_player_by_id(&app, &cur_player_id)?.ok_or(AccountError::NotFound)?;
 
   if player.player_type != PlayerType::Microsoft {
     return Err(AccountError::Invalid.into());
   }
 
-  microsoft::friends::retrieve_friend_list(&app, player).await
+  microsoft::friends::retrieve_friend_list(&app, &player).await
 }
 
 #[tauri::command]
@@ -474,14 +450,7 @@ pub async fn update_microsoft_friend(
   tgt_player_uuid: Option<String>,
   action: MicrosoftFriendAction,
 ) -> SJMCLResult<MicrosoftFriendList> {
-  let account_binding = app.state::<Mutex<AccountInfo>>();
-  let cloned_account_state = account_binding.lock()?.clone();
-
-  let player = cloned_account_state
-    .players
-    .iter()
-    .find(|player| player.id == cur_player_id)
-    .ok_or(AccountError::NotFound)?;
+  let player = misc::get_player_by_id(&app, &cur_player_id)?.ok_or(AccountError::NotFound)?;
 
   if player.player_type != PlayerType::Microsoft {
     return Err(AccountError::Invalid.into());
@@ -497,7 +466,7 @@ pub async fn update_microsoft_friend(
     _ => None,
   };
 
-  microsoft::friends::update_friend(&app, player, tgt_player_name, tgt_player_uuid, action).await
+  microsoft::friends::update_friend(&app, &player, tgt_player_name, tgt_player_uuid, action).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/account/commands.rs
+++ b/src-tauri/src/account/commands.rs
@@ -463,7 +463,28 @@ pub async fn retrieve_microsoft_friend_list(
     return Err(AccountError::Invalid.into());
   }
 
-  microsoft::friends::retrieve_friend_list(&app, player).await
+  let maybe_refreshed = if player
+    .access_token_expires
+    .map(|expires| expires < chrono::Utc::now())
+    .unwrap_or(false)
+  {
+    let refreshed_player = microsoft::oauth::refresh(&app, player).await?;
+    let mut account_state = account_binding.lock()?;
+    if let Some(state_player) = account_state
+      .players
+      .iter_mut()
+      .find(|p| p.id == refreshed_player.id)
+    {
+      *state_player = refreshed_player.clone();
+      account_state.save()?;
+    }
+    Some(refreshed_player)
+  } else {
+    None
+  };
+
+  let player_to_use = maybe_refreshed.as_ref().unwrap_or(player);
+  microsoft::friends::retrieve_friend_list(&app, player_to_use).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/account/helpers/authlib_injector/common.rs
+++ b/src-tauri/src/account/helpers/authlib_injector/common.rs
@@ -95,6 +95,7 @@ pub async fn parse_profile(
       player_type: PlayerType::ThirdParty,
       auth_account,
       access_token,
+      access_token_expires: None,
       refresh_token,
       textures,
       auth_server_url,

--- a/src-tauri/src/account/helpers/import/hmcl.rs
+++ b/src-tauri/src/account/helpers/import/hmcl.rs
@@ -77,6 +77,7 @@ async fn offline_to_player(app: &AppHandle, acc: &HmclOfflineAccount) -> SJMCLRe
       auth_account: None,
       auth_server_url: None,
       access_token: None,
+      access_token_expires: None,
       refresh_token: None,
       textures,
     }
@@ -100,6 +101,7 @@ async fn microsoft_to_player(
           player_type: PlayerType::Microsoft,
           auth_account: None,
           access_token: Some(ACCESS_TOKEN_EXPIRED.to_string()),
+          access_token_expires: Some(chrono::Utc::now()),
           refresh_token: Some(acc.refresh_token.clone()),
           textures: load_preset_skin(app, PresetRole::Steve)?,
           auth_server_url: None,
@@ -148,6 +150,9 @@ async fn microsoft_to_player(
       player_type: PlayerType::Microsoft,
       auth_account: Some(profile.name.clone()),
       access_token: Some(acc.access_token.clone()),
+      access_token_expires: Some(
+        chrono::DateTime::from_timestamp_millis(acc.not_after).unwrap_or(chrono::Utc::now()),
+      ),
       refresh_token: Some(acc.refresh_token.clone()),
       textures,
       auth_server_url: None,

--- a/src-tauri/src/account/helpers/import/multimc.rs
+++ b/src-tauri/src/account/helpers/import/multimc.rs
@@ -64,6 +64,7 @@ async fn microsoft_to_player(
           player_type: PlayerType::Microsoft,
           auth_account: None,
           access_token: Some(ACCESS_TOKEN_EXPIRED.to_string()),
+          access_token_expires: Some(chrono::Utc::now()),
           refresh_token: Some(acc.msa.refresh_token.clone()),
           textures: load_preset_skin(app, PresetRole::Steve)?,
           auth_server_url: None,
@@ -112,6 +113,9 @@ async fn microsoft_to_player(
       player_type: PlayerType::Microsoft,
       auth_account: Some(profile.name.clone()),
       access_token: Some(acc.msa.token.clone()),
+      access_token_expires: Some(
+        chrono::DateTime::from_timestamp_secs(acc.msa.exp).unwrap_or(chrono::Utc::now()),
+      ),
       refresh_token: Some(acc.msa.refresh_token.clone()),
       textures,
       auth_server_url: None,

--- a/src-tauri/src/account/helpers/microsoft/friends.rs
+++ b/src-tauri/src/account/helpers/microsoft/friends.rs
@@ -1,5 +1,6 @@
 use crate::account::helpers::authlib_injector::common::parse_profile;
 use crate::account::helpers::authlib_injector::models::MinecraftProfile;
+use crate::account::helpers::microsoft;
 use crate::account::helpers::microsoft::constants::{FRIENDS_ENDPOINT, PRESENCE_ENDPOINT};
 use crate::account::helpers::microsoft::models::{
   MicrosoftFriend, MicrosoftFriendAction, MicrosoftFriendList, MicrosoftPresenceStatus,
@@ -171,7 +172,7 @@ async fn attach_presence(
   player: &PlayerInfo,
   friends_response: MicrosoftFriendsResponse,
 ) -> SJMCLResult<MicrosoftFriendList> {
-  let access_token = player.access_token.clone().ok_or(AccountError::Invalid)?;
+  let access_token = microsoft::oauth::get_access_token(app, player).await?;
   let client = app.state::<reqwest::Client>();
 
   let mut presence_map = HashMap::<_, MicrosoftPresenceProfile>::new();
@@ -289,7 +290,7 @@ pub async fn retrieve_friend_list(
   app: &AppHandle,
   player: &PlayerInfo,
 ) -> SJMCLResult<MicrosoftFriendList> {
-  let access_token = player.access_token.clone().ok_or(AccountError::Invalid)?;
+  let access_token = microsoft::oauth::get_access_token(app, player).await?;
   let client = app.state::<reqwest::Client>();
 
   let response = client
@@ -318,7 +319,7 @@ pub async fn update_friend(
   tgt_player_uuid: Option<Uuid>,
   action: MicrosoftFriendAction,
 ) -> SJMCLResult<MicrosoftFriendList> {
-  let access_token = player.access_token.clone().ok_or(AccountError::Invalid)?;
+  let access_token = microsoft::oauth::get_access_token(app, player).await?;
   let client = app.state::<reqwest::Client>();
   let request = build_friend_action_request(tgt_player_name, tgt_player_uuid, action)?;
 

--- a/src-tauri/src/account/helpers/microsoft/oauth.rs
+++ b/src-tauri/src/account/helpers/microsoft/oauth.rs
@@ -297,9 +297,10 @@ pub async fn validate(app: &AppHandle, player: &PlayerInfo) -> SJMCLResult<bool>
   Ok(response.status().is_success())
 }
 
+/// Returns the access token for the player, refreshing it if necessary.
 pub async fn get_access_token(app: &AppHandle, player: &PlayerInfo) -> SJMCLResult<String> {
   let need_refresh = player.access_token.is_none()
-    | player
+    || player
       .access_token_expires
       .map(|x| x <= chrono::Utc::now())
       .unwrap_or(false);

--- a/src-tauri/src/account/helpers/microsoft/oauth.rs
+++ b/src-tauri/src/account/helpers/microsoft/oauth.rs
@@ -156,10 +156,7 @@ async fn fetch_minecraft_token(
 
   let access_token = response["access_token"].as_str().unwrap_or("").to_string();
   let expires_in = chrono::Utc::now().add(chrono::Duration::seconds(
-    response["expires_in"]
-      .as_str()
-      .and_then(|f| f.parse().ok())
-      .unwrap_or(3600), // 1 hour default if no expires_in is provided
+    response["expires_in"].as_i64().unwrap_or(3600), // 1 hour default if no expires_in is provided
   ));
   Ok((access_token, expires_in))
 }

--- a/src-tauri/src/account/helpers/microsoft/oauth.rs
+++ b/src-tauri/src/account/helpers/microsoft/oauth.rs
@@ -13,6 +13,7 @@ use crate::account::models::{
 };
 use crate::error::SJMCLResult;
 use serde_json::{json, Value};
+use std::ops::Add;
 use std::str::FromStr;
 use tauri::{AppHandle, Manager};
 use tauri_plugin_clipboard_manager::ClipboardExt;
@@ -138,7 +139,7 @@ async fn fetch_minecraft_token(
   app: &AppHandle,
   xsts_userhash: String,
   xsts_token: String,
-) -> SJMCLResult<String> {
+) -> SJMCLResult<(String, chrono::DateTime<chrono::Utc>)> {
   let client = app.state::<reqwest::Client>();
 
   let response: Value = client
@@ -153,7 +154,14 @@ async fn fetch_minecraft_token(
     .await
     .map_err(|_| AccountError::ParseError)?;
 
-  Ok(response["access_token"].as_str().unwrap_or("").to_string())
+  let access_token = response["access_token"].as_str().unwrap_or("").to_string();
+  let expires_in = chrono::Utc::now().add(chrono::Duration::seconds(
+    response["expires_in"]
+      .as_str()
+      .and_then(|f| f.parse().ok())
+      .unwrap_or(3600), // 1 hour default if no expires_in is provided
+  ));
+  Ok((access_token, expires_in))
 }
 
 pub async fn fetch_minecraft_profile(
@@ -180,7 +188,8 @@ pub async fn fetch_minecraft_profile(
 async fn parse_profile(app: &AppHandle, tokens: &OAuthTokens) -> SJMCLResult<PlayerInfo> {
   let xbl_token = fetch_xbl_token(app, tokens.access_token.clone()).await?;
   let (xsts_userhash, xsts_token) = fetch_xsts_token(app, xbl_token).await?;
-  let minecraft_token = fetch_minecraft_token(app, xsts_userhash, xsts_token).await?;
+  let (minecraft_token, minecraft_token_expires_in) =
+    fetch_minecraft_token(app, xsts_userhash, xsts_token).await?;
   let profile = fetch_minecraft_profile(app, minecraft_token.clone()).await?;
 
   let mut textures = vec![];
@@ -222,6 +231,7 @@ async fn parse_profile(app: &AppHandle, tokens: &OAuthTokens) -> SJMCLResult<Pla
       player_type: PlayerType::Microsoft,
       auth_account: Some(profile.name.clone()),
       access_token: Some(minecraft_token.clone()),
+      access_token_expires: Some(minecraft_token_expires_in),
       refresh_token: Some(tokens.refresh_token.clone()),
       textures,
       auth_server_url: None,

--- a/src-tauri/src/account/helpers/microsoft/oauth.rs
+++ b/src-tauri/src/account/helpers/microsoft/oauth.rs
@@ -288,7 +288,7 @@ pub async fn validate(app: &AppHandle, player: &PlayerInfo) -> SJMCLResult<bool>
     .get(PROFILE_ENDPOINT)
     .header(
       "Authorization",
-      format!("Bearer {}", player.access_token.clone().unwrap_or_default()),
+      format!("Bearer {}", get_access_token(app, player).await?),
     )
     .send()
     .await

--- a/src-tauri/src/account/helpers/microsoft/oauth.rs
+++ b/src-tauri/src/account/helpers/microsoft/oauth.rs
@@ -8,15 +8,13 @@ use crate::account::helpers::microsoft::models::{
 use crate::account::helpers::misc::{self, fetch_image, oauth_polling};
 use crate::account::helpers::offline::load_preset_skin;
 use crate::account::models::{
-  AccountError, AccountInfo, DeviceAuthResponse, DeviceAuthResponseInfo, OAuthTokens, PlayerInfo,
-  PlayerType, PresetRole, SkinModel, Texture, TextureType,
+  AccountError, DeviceAuthResponse, DeviceAuthResponseInfo, OAuthTokens, PlayerInfo, PlayerType,
+  PresetRole, SkinModel, Texture, TextureType,
 };
 use crate::error::SJMCLResult;
-use crate::storage::Storage;
 use serde_json::{json, Value};
 use std::ops::Add;
 use std::str::FromStr;
-use std::sync::Mutex;
 use tauri::{AppHandle, Manager};
 use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_http::reqwest;

--- a/src-tauri/src/account/helpers/microsoft/oauth.rs
+++ b/src-tauri/src/account/helpers/microsoft/oauth.rs
@@ -5,7 +5,7 @@ use crate::account::helpers::microsoft::constants::{
 use crate::account::helpers::microsoft::models::{
   MinecraftProfile, XstsErrorResponse, XstsResponse,
 };
-use crate::account::helpers::misc::{fetch_image, oauth_polling};
+use crate::account::helpers::misc::{self, fetch_image, oauth_polling};
 use crate::account::helpers::offline::load_preset_skin;
 use crate::account::models::{
   AccountError, AccountInfo, DeviceAuthResponse, DeviceAuthResponseInfo, OAuthTokens, PlayerInfo,
@@ -299,30 +299,24 @@ pub async fn validate(app: &AppHandle, player: &PlayerInfo) -> SJMCLResult<bool>
 
 /// Returns the access token for the player, refreshing it if necessary.
 pub async fn get_access_token(app: &AppHandle, player: &PlayerInfo) -> SJMCLResult<String> {
+  if player.player_type != PlayerType::Microsoft {
+    return Err(AccountError::Invalid.into());
+  }
+
   let need_refresh = player.access_token.is_none()
     || player
       .access_token_expires
       .map(|x| x <= chrono::Utc::now())
-      .unwrap_or(false);
+      .unwrap_or(true);
 
   if need_refresh {
+    let player_id = player.id.as_str();
     let refreshed_player = refresh(app, player).await?;
     let access_token = refreshed_player
       .access_token
       .clone()
       .ok_or(AccountError::Invalid)?;
-    let account_binding = app.state::<Mutex<AccountInfo>>();
-    let mut account_state = account_binding.lock()?;
-    if let Some(state_player) = account_state
-      .players
-      .iter_mut()
-      .find(|p| p.id == refreshed_player.id)
-    {
-      *state_player = refreshed_player.clone();
-      account_state.save()?;
-    } else {
-      return Err(AccountError::NotFound.into());
-    }
+    misc::update_player_by_id(app, player_id, refreshed_player)?;
 
     Ok(access_token)
   } else {

--- a/src-tauri/src/account/helpers/microsoft/oauth.rs
+++ b/src-tauri/src/account/helpers/microsoft/oauth.rs
@@ -8,13 +8,15 @@ use crate::account::helpers::microsoft::models::{
 use crate::account::helpers::misc::{fetch_image, oauth_polling};
 use crate::account::helpers::offline::load_preset_skin;
 use crate::account::models::{
-  AccountError, DeviceAuthResponse, DeviceAuthResponseInfo, OAuthTokens, PlayerInfo, PlayerType,
-  PresetRole, SkinModel, Texture, TextureType,
+  AccountError, AccountInfo, DeviceAuthResponse, DeviceAuthResponseInfo, OAuthTokens, PlayerInfo,
+  PlayerType, PresetRole, SkinModel, Texture, TextureType,
 };
 use crate::error::SJMCLResult;
+use crate::storage::Storage;
 use serde_json::{json, Value};
 use std::ops::Add;
 use std::str::FromStr;
+use std::sync::Mutex;
 use tauri::{AppHandle, Manager};
 use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_http::reqwest;
@@ -293,4 +295,36 @@ pub async fn validate(app: &AppHandle, player: &PlayerInfo) -> SJMCLResult<bool>
     .map_err(|_| AccountError::NetworkError)?;
 
   Ok(response.status().is_success())
+}
+
+pub async fn get_access_token(app: &AppHandle, player: &PlayerInfo) -> SJMCLResult<String> {
+  let need_refresh = player.access_token.is_none()
+    | player
+      .access_token_expires
+      .map(|x| x <= chrono::Utc::now())
+      .unwrap_or(false);
+
+  if need_refresh {
+    let refreshed_player = refresh(app, player).await?;
+    let access_token = refreshed_player
+      .access_token
+      .clone()
+      .ok_or(AccountError::Invalid)?;
+    let account_binding = app.state::<Mutex<AccountInfo>>();
+    let mut account_state = account_binding.lock()?;
+    if let Some(state_player) = account_state
+      .players
+      .iter_mut()
+      .find(|p| p.id == refreshed_player.id)
+    {
+      *state_player = refreshed_player.clone();
+      account_state.save()?;
+    } else {
+      return Err(AccountError::NotFound.into());
+    }
+
+    Ok(access_token)
+  } else {
+    Ok(player.access_token.clone().ok_or(AccountError::Invalid)?)
+  }
 }

--- a/src-tauri/src/account/helpers/misc.rs
+++ b/src-tauri/src/account/helpers/misc.rs
@@ -92,6 +92,34 @@ pub fn add_player(app: &AppHandle, new_player: PlayerInfo) -> SJMCLResult<()> {
   Ok(())
 }
 
+pub fn get_player_by_id(app: &AppHandle, player_id: &str) -> SJMCLResult<Option<PlayerInfo>> {
+  let account_binding = app.state::<Mutex<AccountInfo>>();
+  let account_state = account_binding.lock()?;
+
+  Ok(
+    account_state
+      .players
+      .iter()
+      .find(|player| player.id == player_id)
+      .cloned(),
+  )
+}
+
+pub fn update_player_by_id(app: &AppHandle, player_id: &str, info: PlayerInfo) -> SJMCLResult<()> {
+  let account_binding = app.state::<Mutex<AccountInfo>>();
+  let mut account_state = account_binding.lock()?;
+
+  if let Some(index) = account_state
+    .players
+    .iter()
+    .position(|player| player.id == player_id)
+  {
+    account_state.players[index] = info;
+    account_state.save()?;
+  }
+  Ok(())
+}
+
 pub async fn check_full_login_availability(app: &AppHandle) -> SJMCLResult<()> {
   let loc_flag = is_china_mainland_ip(app).await;
 

--- a/src-tauri/src/account/helpers/offline/mod.rs
+++ b/src-tauri/src/account/helpers/offline/mod.rs
@@ -53,6 +53,7 @@ pub async fn login(app: &AppHandle, username: String, raw_uuid: String) -> SJMCL
       auth_account: None,
       auth_server_url: None,
       access_token: None,
+      access_token_expires: None,
       refresh_token: None,
       textures: load_preset_skin(app, preset_role)?,
     }

--- a/src-tauri/src/account/models.rs
+++ b/src-tauri/src/account/models.rs
@@ -86,6 +86,7 @@ pub struct Player {
   pub auth_account: Option<String>,
   pub auth_server: Option<AuthServer>,
   pub access_token: Option<String>,
+  pub access_token_expires: Option<chrono::DateTime<chrono::Utc>>,
   pub refresh_token: Option<String>,
   pub textures: Vec<Texture>,
 }
@@ -123,6 +124,7 @@ impl Player {
       player_type: player_info.player_type,
       auth_account: player_info.auth_account,
       access_token: player_info.access_token,
+      access_token_expires: player_info.access_token_expires,
       refresh_token: player_info.refresh_token,
       auth_server,
       textures: player_info.textures,
@@ -147,6 +149,7 @@ pub struct PlayerInfo {
   pub auth_account: Option<String>,
   pub auth_server_url: Option<String>,
   pub access_token: Option<String>,
+  pub access_token_expires: Option<chrono::DateTime<chrono::Utc>>,
   pub refresh_token: Option<String>,
   pub textures: Vec<Texture>,
 }
@@ -174,6 +177,7 @@ impl From<Player> for PlayerInfo {
       auth_account: player.auth_account,
       textures: player.textures,
       access_token: player.access_token,
+      access_token_expires: player.access_token_expires,
       refresh_token: player.refresh_token,
       auth_server_url: player
         .auth_server

--- a/src-tauri/src/launch/commands.rs
+++ b/src-tauri/src/launch/commands.rs
@@ -193,7 +193,7 @@ pub async fn validate_selected_player(
   launching_queue_state: State<'_, Mutex<Vec<LaunchingState>>>,
   local_ygg_server_state: State<'_, Mutex<YggdrasilServer>>,
 ) -> SJMCLResult<bool> {
-  let mut player = get_selected_player_info(&app)?.clone();
+  let mut player = get_selected_player_info(&app)?;
 
   let metadata = if player.player_type == PlayerType::ThirdParty {
     authlib_injector::jar::check_authlib_jar(&app)


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

None

### Description

获取好友列表时不会自动刷新令牌
```
[ERROR] Invoke retrieveMicrosoftFriendList failed: 获取微软好友列表失败 - 令牌已过期，请重新登录
```
然后发现怎么没 AccessToken 的自动轮换 Orz


### Additional Context

~~嗯……还需要优化下代码风格~~

## Summary by Sourcery

Ensure Microsoft friend list retrieval refreshes expired access tokens and tracks their expiry across account types.

Bug Fixes:
- Refresh Microsoft access tokens when expired before retrieving the friend list to prevent failures due to token expiry.

Enhancements:
- Store and propagate access token expiry timestamps for players, including during Microsoft, HMCL, MultiMC, offline, and third-party account handling.

## Summary by Sourcery

Add automatic refresh and expiry tracking for Microsoft access tokens when they are used, including for friend list operations and imported accounts.

New Features:
- Persist access token expiry timestamps on players to enable automatic refresh before use.

Bug Fixes:
- Prevent Microsoft friend list and presence operations from failing by refreshing expired access tokens on demand.

Enhancements:
- Propagate and normalize access token expiry data across Microsoft, offline, MultiMC, and third-party account imports.