### PR TITLE
fix(window): re-add main window title after customize window title bar

### DIFF
--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -4,7 +4,7 @@
     "windows": [
       {
         "label": "main",
-        "title": " ",
+        "title": "SJMC Launcher",
         "url": "/",
         "width": 800,
         "height": 550,

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -19,7 +19,7 @@
     "windows": [
       {
         "label": "main",
-        "title": " ",
+        "title": "SJMC Launcher",
         "url": "/",
         "width": 800,
         "height": 550,

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -18,7 +18,7 @@
     "windows": [
       {
         "label": "main",
-        "title": " ",
+        "title": "SJMC Launcher",
         "url": "/",
         "width": 820,
         "height": 550,


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

#1636 

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Bug Fixes:
- Ensure the main window title is correctly restored after customizing the window title bar on Linux, macOS, and Windows via Tauri configuration updates.