### PR TITLE
feat(ci/cd): publish to winget

### DIFF
--- a/.github/winget/SJMC.SJMCL.installer.yaml.template
+++ b/.github/winget/SJMC.SJMCL.installer.yaml.template
@@ -1,0 +1,15 @@
+PackageIdentifier: SJMC.SJMCL
+PackageVersion: __VERSION__
+InstallerType: nullsoft
+Installers:
+  - Architecture: x64
+    InstallerUrl: __X64_INSTALLER_URL__
+    InstallerSha256: __X64_INSTALLER_SHA256__
+  - Architecture: x86
+    InstallerUrl: __X86_INSTALLER_URL__
+    InstallerSha256: __X86_INSTALLER_SHA256__
+  - Architecture: arm64
+    InstallerUrl: __ARM64_INSTALLER_URL__
+    InstallerSha256: __ARM64_INSTALLER_SHA256__
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/.github/winget/SJMC.SJMCL.locale.en-US.yaml.template
+++ b/.github/winget/SJMC.SJMCL.locale.en-US.yaml.template
@@ -1,0 +1,20 @@
+PackageIdentifier: SJMC.SJMCL
+PackageVersion: __VERSION__
+PackageLocale: en-US
+Publisher: SJMC
+PublisherUrl: https://mc.sjtu.cn/
+PublisherSupportUrl: https://github.com/UNIkeEN/SJMCL/issues
+Author: Shanghai Jiao Tong University Minecraft Club
+PackageName: SJMCL
+PackageUrl: https://mc.sjtu.cn/sjmcl/en
+License: GPL-3.0-only with additional terms (see LICENSE.EXTRA)
+LicenseUrl: https://github.com/UNIkeEN/SJMCL/blob/main/LICENSE.EXTRA
+ShortDescription: Next-generation open-source cross-platform Minecraft launcher.
+Description: SJMC Launcher is a modern, cross-platform Minecraft launcher built on the Tauri framework, independently developed by members of the Shanghai Jiao Tong University Minecraft Club.
+Moniker: sjmcl
+Tags:
+  - mc
+  - minecraft
+ReleaseNotesUrl: https://github.com/UNIkeEN/SJMCL/releases/tag/__RELEASE_TAG__
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/.github/winget/SJMC.SJMCL.locale.zh-CN.yaml.template
+++ b/.github/winget/SJMC.SJMCL.locale.zh-CN.yaml.template
@@ -1,0 +1,21 @@
+PackageIdentifier: SJMC.SJMCL
+PackageVersion: __VERSION__
+PackageLocale: zh-CN
+Publisher: SJMC
+PublisherUrl: https://mc.sjtu.cn/
+PublisherSupportUrl: https://github.com/UNIkeEN/SJMCL/issues
+Author: 上海交通大学 Minecraft 社
+PackageName: SJMCL
+PackageUrl: https://mc.sjtu.cn/sjmcl
+License: GPL-3.0-only with additional terms (see LICENSE.EXTRA)
+LicenseUrl: https://github.com/UNIkeEN/SJMCL/blob/main/LICENSE.EXTRA
+ShortDescription: 新一代开源跨平台 Minecraft 启动器
+Description: SJMC Launcher 是一款基于 Tauri 框架打造的现代化、跨平台 Minecraft 启动器，由上海交通大学 Minecraft 社的成员自主开发。
+Moniker: sjmcl
+Tags:
+  - mc
+  - minecraft
+  - 我的世界
+ReleaseNotesUrl: https://github.com/UNIkeEN/SJMCL/releases/tag/__RELEASE_TAG__
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/.github/winget/SJMC.SJMCL.yaml.template
+++ b/.github/winget/SJMC.SJMCL.yaml.template
@@ -1,0 +1,5 @@
+PackageIdentifier: SJMC.SJMCL
+PackageVersion: __VERSION__
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/.github/workflows/post-release-publish.yml
+++ b/.github/workflows/post-release-publish.yml
@@ -97,3 +97,13 @@ jobs:
     secrets:
       HOMEBREW_TAP_APP_ID: ${{ secrets.HOMEBREW_TAP_APP_ID }}
       HOMEBREW_TAP_APP_PRIVATE_KEY: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+
+  Publish-Winget:
+    needs: [Prepare-Release-Assets]
+    if: needs.Prepare-Release-Assets.outputs.is_prerelease == 'false'
+    uses: ./.github/workflows/publish-winget.yml
+    with:
+      version: ${{ needs.Prepare-Release-Assets.outputs.version }}
+      release_tag: ${{ needs.Prepare-Release-Assets.outputs.release_tag }}
+    secrets:
+      WINGET_BOT_GITHUB_TOKEN: ${{ secrets.WINGET_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -208,5 +208,5 @@ jobs:
             --base master \
             --head "SJMC-Dev-Bot:${BRANCH_NAME}" \
             --title "New version: SJMC.SJMCL version ${VERSION}" \
-            --body "## Summary\n- Update SJMC.SJMCL to ${VERSION}\n- Generated from GitHub release assets in UNIkeEN/SJMCL" \
+            --body "## Summary\n- Update SJMC.SJMCL to ${VERSION}\n- Generated from GitHub release assets in ${{ github.repository }}" \
             --label Windows-Package-Manager-Manifest

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -1,0 +1,212 @@
+name: Publish Winget Manifest
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to publish"
+        required: true
+        type: string
+      release_tag:
+        description: "Release tag to read assets from"
+        required: true
+        type: string
+    secrets:
+      WINGET_BOT_GITHUB_TOKEN:
+        description: "GitHub token for pushing to a winget-pkgs fork and creating PRs"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish_winget_manifest:
+    name: Publish Winget manifest
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v4
+
+      - name: Read Windows release asset metadata
+        shell: bash
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          get_asset_digest() {
+            local asset_name="$1"
+            gh api "repos/${GH_REPO}/releases/tags/${RELEASE_TAG}" \
+              --jq ".assets[] | select(.name == \"${asset_name}\") | .digest"
+          }
+
+          X64_ASSET="SJMCL_${VERSION}_windows_x86_64_setup.exe"
+          X86_ASSET="SJMCL_${VERSION}_windows_i686_setup.exe"
+          ARM64_ASSET="SJMCL_${VERSION}_windows_aarch64_setup.exe"
+
+          X64_DIGEST=$(get_asset_digest "$X64_ASSET")
+          X86_DIGEST=$(get_asset_digest "$X86_ASSET")
+          ARM64_DIGEST=$(get_asset_digest "$ARM64_ASSET")
+
+          if [[ -z "$X64_DIGEST" ]]; then
+            echo "Missing release asset digest: ${X64_ASSET}"
+            exit 1
+          fi
+
+          if [[ -z "$X86_DIGEST" ]]; then
+            echo "Missing release asset digest: ${X86_ASSET}"
+            exit 1
+          fi
+
+          if [[ -z "$ARM64_DIGEST" ]]; then
+            echo "Missing release asset digest: ${ARM64_ASSET}"
+            exit 1
+          fi
+
+          if [[ "$X64_DIGEST" != sha256:* || "$X86_DIGEST" != sha256:* || "$ARM64_DIGEST" != sha256:* ]]; then
+            echo "Unexpected Windows asset digest format. Expected sha256:<hex>."
+            exit 1
+          fi
+
+          echo "X64_INSTALLER_URL=https://github.com/${GH_REPO}/releases/download/${RELEASE_TAG}/${X64_ASSET}" >> "$GITHUB_ENV"
+          echo "X86_INSTALLER_URL=https://github.com/${GH_REPO}/releases/download/${RELEASE_TAG}/${X86_ASSET}" >> "$GITHUB_ENV"
+          echo "ARM64_INSTALLER_URL=https://github.com/${GH_REPO}/releases/download/${RELEASE_TAG}/${ARM64_ASSET}" >> "$GITHUB_ENV"
+          echo "X64_INSTALLER_SHA256=${X64_DIGEST#sha256:}" >> "$GITHUB_ENV"
+          echo "X86_INSTALLER_SHA256=${X86_DIGEST#sha256:}" >> "$GITHUB_ENV"
+          echo "ARM64_INSTALLER_SHA256=${ARM64_DIGEST#sha256:}" >> "$GITHUB_ENV"
+
+      - name: Render Winget manifests
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          OUTPUT_DIR="winget-manifests/manifests/s/SJMC/SJMCL/${VERSION}"
+          mkdir -p "$OUTPUT_DIR"
+
+          render_template() {
+            local template_path="$1"
+            local output_path="$2"
+
+            cp "$template_path" "$output_path"
+            sed -i "s|__VERSION__|${VERSION}|g" "$output_path"
+            sed -i "s|__RELEASE_TAG__|${RELEASE_TAG}|g" "$output_path"
+            sed -i "s|__X64_INSTALLER_URL__|${X64_INSTALLER_URL}|g" "$output_path"
+            sed -i "s|__X86_INSTALLER_URL__|${X86_INSTALLER_URL}|g" "$output_path"
+            sed -i "s|__ARM64_INSTALLER_URL__|${ARM64_INSTALLER_URL}|g" "$output_path"
+            sed -i "s|__X64_INSTALLER_SHA256__|${X64_INSTALLER_SHA256}|g" "$output_path"
+            sed -i "s|__X86_INSTALLER_SHA256__|${X86_INSTALLER_SHA256}|g" "$output_path"
+            sed -i "s|__ARM64_INSTALLER_SHA256__|${ARM64_INSTALLER_SHA256}|g" "$output_path"
+          }
+
+          render_template ".github/winget/SJMC.SJMCL.yaml.template" "$OUTPUT_DIR/SJMC.SJMCL.yaml"
+          render_template ".github/winget/SJMC.SJMCL.locale.en-US.yaml.template" "$OUTPUT_DIR/SJMC.SJMCL.locale.en-US.yaml"
+          render_template ".github/winget/SJMC.SJMCL.locale.zh-CN.yaml.template" "$OUTPUT_DIR/SJMC.SJMCL.locale.zh-CN.yaml"
+          render_template ".github/winget/SJMC.SJMCL.installer.yaml.template" "$OUTPUT_DIR/SJMC.SJMCL.installer.yaml"
+
+      - name: Show generated manifests
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          find "winget-manifests/manifests/s/SJMC/SJMCL/${VERSION}" -maxdepth 1 -type f | sort | while read -r manifest; do
+            echo "=== ${manifest} ==="
+            cat "$manifest"
+          done
+
+      - name: Upload Winget manifests
+        uses: actions/upload-artifact@v4
+        with:
+          name: winget-manifests-${{ inputs.version }}
+          path: winget-manifests/manifests/s/SJMC/SJMCL/${{ inputs.version }}
+          if-no-files-found: error
+
+  submit_winget_pr:
+    name: Submit Winget PR
+    needs: [publish_winget_manifest]
+    runs-on: windows-latest
+
+    steps:
+      - name: Download Winget manifests
+        uses: actions/download-artifact@v4
+        with:
+          name: winget-manifests-${{ inputs.version }}
+          path: winget-manifests/manifests/s/SJMC/SJMCL/${{ inputs.version }}
+
+      - name: Validate Winget manifests
+        shell: pwsh
+        run: |
+          $manifestPath = (Resolve-Path "winget-manifests/manifests/s/SJMC/SJMCL/${{ inputs.version }}").Path
+          winget validate --manifest $manifestPath --disable-interactivity
+
+      - name: Checkout Winget fork
+        uses: actions/checkout@v4
+        with:
+          repository: SJMC-Dev-Bot/winget-pkgs
+          token: ${{ secrets.WINGET_BOT_GITHUB_TOKEN }}
+          path: winget-pkgs
+          fetch-depth: 0
+
+      - name: Update fork branch
+        id: update-branch
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          BRANCH_NAME="sjmc-sjmcl-${VERSION}"
+          MANIFEST_DIR="manifests/s/SJMC/SJMCL/${VERSION}"
+
+          git -C winget-pkgs config user.name "SJMC-Dev-Bot"
+          git -C winget-pkgs config user.email "launcher@sjmc.club"
+
+          git -C winget-pkgs remote add upstream https://github.com/microsoft/winget-pkgs.git
+          git -C winget-pkgs fetch upstream master
+          git -C winget-pkgs fetch origin "$BRANCH_NAME" || true
+          git -C winget-pkgs checkout -B "$BRANCH_NAME" upstream/master
+
+          mkdir -p "winget-pkgs/${MANIFEST_DIR}"
+          cp winget-manifests/manifests/s/SJMC/SJMCL/${VERSION}/* "winget-pkgs/${MANIFEST_DIR}/"
+
+          if git -C winget-pkgs diff --quiet -- "$MANIFEST_DIR"; then
+            echo "No Winget manifest changes to submit."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git -C winget-pkgs add "$MANIFEST_DIR"
+          git -C winget-pkgs commit -m "Add SJMC.SJMCL version ${VERSION}"
+          git -C winget-pkgs push --force-with-lease origin "$BRANCH_NAME"
+
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Create or reuse Winget PR
+        if: steps.update-branch.outputs.has_changes == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.WINGET_BOT_GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          BRANCH_NAME="${{ steps.update-branch.outputs.branch_name }}"
+          EXISTING_PR_URL=$(gh pr list \
+            --repo microsoft/winget-pkgs \
+            --state open \
+            --head "SJMC-Dev-Bot:${BRANCH_NAME}" \
+            --json url \
+            --jq '.[0].url')
+
+          if [ -n "$EXISTING_PR_URL" ]; then
+            echo "Winget PR already exists: $EXISTING_PR_URL"
+            exit 0
+          fi
+
+          gh pr create \
+            --repo microsoft/winget-pkgs \
+            --base master \
+            --head "SJMC-Dev-Bot:${BRANCH_NAME}" \
+            --title "New version: SJMC.SJMCL version ${VERSION}" \
+            --body "## Summary\n- Update SJMC.SJMCL to ${VERSION}\n- Generated from GitHub release assets in UNIkeEN/SJMCL" \
+            --label Windows-Package-Manager-Manifest


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

#1606 

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Add automation to generate and submit Winget manifests for stable releases using GitHub release assets.

New Features:
- Automatically publish Winget manifests for new stable releases via a reusable GitHub Actions workflow.

CI:
- Extend the post-release workflow to trigger a Winget publish job for non-prerelease versions using a dedicated reusable workflow that renders, validates, and uploads manifests before opening or reusing a PR against microsoft/winget-pkgs.