### PR TITLE
fix(backend): add missing proxy config in client building process, add frontend need-restart sign

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -235,7 +235,7 @@ pub async fn run() {
         let local_mod_translations = LocalModTranslationsCache::load().unwrap_or_default();
         app.manage(Mutex::new(local_mod_translations));
 
-        let client = build_sjmcl_client(app.handle(), true, false);
+        let client = build_sjmcl_client(app.handle(), true);
         app.manage(client);
 
         let launching_queue = Vec::<LaunchingState>::new();

--- a/src-tauri/src/utils/web.rs
+++ b/src-tauri/src/utils/web.rs
@@ -13,13 +13,12 @@ use tauri_plugin_http::reqwest::header::HeaderMap;
 use tauri_plugin_http::reqwest::{Client, ClientBuilder, Proxy};
 use url::Url;
 
-/// Builds a reqwest client with SJMCL version header and proxy support.
+/// Builds a reqwest client with SJMCL User-Agent and proxy support.
 /// Defaults to 10s timeout.
 ///
 /// # Arguments
 ///
 /// * `app` - The Tauri AppHandle.
-/// * `use_version_header` - Whether to include the SJMCL version header.
 /// * `use_proxy` - Whether to use the proxy settings from the config.
 ///
 /// TODO: support more custom config from reqwest::Config
@@ -32,23 +31,21 @@ use url::Url;
 /// # Example
 ///
 /// ```rust
-/// let client = build_sjmcl_client(&app, true, true);
+/// let client = build_sjmcl_client(&app, true);
 /// ```
-pub fn build_sjmcl_client(app: &AppHandle, use_version_header: bool, use_proxy: bool) -> Client {
+pub fn build_sjmcl_client(app: &AppHandle, use_proxy: bool) -> Client {
   let mut builder = ClientBuilder::new()
     .timeout(Duration::from_secs(10))
     .tcp_keepalive(Duration::from_secs(10));
 
   if let Ok(config) = app.state::<Mutex<LauncherConfig>>().lock() {
-    if use_version_header {
-      // According to the User-Agent requirements of mozilla and BMCLAPI, the User-Agent is set to start with ${NAME}/${VERSION}
-      // https://github.com/MCLF-CN/docs/issues/2
-      // https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Reference/Headers/User-Agent
-      if let Ok(header_value) = format!("SJMCL/{}", &config.basic_info.launcher_version).parse() {
-        let mut headers = HeaderMap::new();
-        headers.insert("User-Agent", header_value);
-        builder = builder.default_headers(headers);
-      }
+    // According to the User-Agent requirements of mozilla and BMCLAPI, the User-Agent is set to start with ${NAME}/${VERSION}
+    // https://github.com/MCLF-CN/docs/issues/2
+    // https://developer.mozilla.org/zh-CN/docs/Web/HTTP/Reference/Headers/User-Agent
+    if let Ok(header_value) = format!("SJMCL/{}", &config.basic_info.launcher_version).parse() {
+      let mut headers = HeaderMap::new();
+      headers.insert("User-Agent", header_value);
+      builder = builder.default_headers(headers);
     }
 
     if use_proxy && config.download.proxy.enabled {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -593,6 +593,7 @@
     },
     "proxy": {
       "title": "Proxy",
+      "headExtra": "Restart Required",
       "settings": {
         "enabled": {
           "title": "Enable Proxy"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -593,6 +593,7 @@
     },
     "proxy": {
       "title": "Proxy",
+      "headExtra": "Redémarrage requis",
       "settings": {
         "enabled": {
           "title": "Activer le proxy"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -593,6 +593,7 @@
     },
     "proxy": {
       "title": "プロキシ",
+      "headExtra": "再起動が必要",
       "settings": {
         "enabled": {
           "title": "プロキシ有効化"

--- a/src/locales/lzh.json
+++ b/src/locales/lzh.json
@@ -593,6 +593,7 @@
     },
     "proxy": {
       "title": "代",
+      "headExtra": "以下置設復啟而效",
       "settings": {
         "enabled": {
           "title": "啟代"

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -593,6 +593,7 @@
     },
     "proxy": {
       "title": "代理",
+      "headExtra": "以下设置重启时生效",
       "settings": {
         "enabled": {
           "title": "启用代理"

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -593,6 +593,7 @@
     },
     "proxy": {
       "title": "Proxy",
+      "headExtra": "需要重新啟動",
       "settings": {
         "enabled": {
           "title": "啟用 Proxy"

--- a/src/pages/settings/download.tsx
+++ b/src/pages/settings/download.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   HStack,
   Icon,
@@ -374,6 +375,13 @@ const DownloadSettingsPage = () => {
     },
     {
       title: t("DownloadSettingPage.proxy.title"),
+      headExtra: (
+        <Box display="flex" alignItems="center">
+          <Text fontSize="xs" className="secondary-text">
+            {t("DownloadSettingPage.proxy.headExtra")}
+          </Text>
+        </Box>
+      ),
       items: [
         {
           title: t("DownloadSettingPage.proxy.settings.enabled.title"),
@@ -455,7 +463,7 @@ const DownloadSettingsPage = () => {
   return (
     <>
       {downloadSettingGroups.map((group, index) => (
-        <OptionItemGroup title={group.title} items={group.items} key={index} />
+        <OptionItemGroup key={index} {...group} />
       ))}
     </>
   );


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

related #1632 

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Ensure HTTP client always sends launcher version in User-Agent and surface a proxy-restart notice in download settings.

New Features:
- Display an informational note above proxy settings in the download settings page to indicate a restart requirement.

Bug Fixes:
- Always attach the launcher version User-Agent header when building the backend HTTP client.
- Respect the configured proxy settings when building the backend HTTP client used at startup.

Enhancements:
- Propagate additional group props to the download settings option group component to support extra header content.