### PR TITLE
fix(backend): prevent duplicate mod downloads when installing modpack (#1653)

### DIFF
--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -1036,8 +1036,8 @@ pub async fn create_instance(
   mod_loader: ModLoaderResourceInfo,
   optifine: Option<OptiFineResourceInfo>,
   modpack_path: Option<String>,
-  is_install_fabric_api: Option<bool>,
-  is_install_qf_api: Option<bool>,
+  mut is_install_fabric_api: Option<bool>,
+  mut is_install_qf_api: Option<bool>,
 ) -> SJMCLResult<()> {
   let client = app.state::<reqwest::Client>();
   let launcher_config_state = app.state::<Mutex<LauncherConfig>>();
@@ -1173,11 +1173,10 @@ pub async fn create_instance(
 
   // When installing a modpack, skip auto-installing Fabric API / QFAPI to avoid
   // duplicates — the modpack manifest already specifies the exact version needed.
-  let (effective_install_fabric_api, effective_install_qf_api) = if modpack_path.is_some() {
-    (Some(false), Some(false))
-  } else {
-    (is_install_fabric_api, is_install_qf_api)
-  };
+  if modpack_path.is_some() {
+    is_install_fabric_api = Some(false);
+    is_install_qf_api = Some(false);
+  }
 
   // download loader (installer)
   if instance.mod_loader.loader_type != ModLoaderType::Unknown {
@@ -1190,8 +1189,8 @@ pub async fn create_instance(
       mods_dir.to_path_buf(),
       &mut version_info,
       &mut task_params,
-      effective_install_fabric_api,
-      effective_install_qf_api,
+      is_install_fabric_api,
+      is_install_qf_api,
     )
     .await?;
   }

--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -1171,6 +1171,14 @@ pub async fn create_instance(
   task_params
     .extend(get_invalid_assets(&app, &version_info, priority_list[0], assets_dir, false).await?);
 
+  // When installing a modpack, skip auto-installing Fabric API / QFAPI to avoid
+  // duplicates — the modpack manifest already specifies the exact version needed.
+  let (effective_install_fabric_api, effective_install_qf_api) = if modpack_path.is_some() {
+    (Some(false), Some(false))
+  } else {
+    (is_install_fabric_api, is_install_qf_api)
+  };
+
   // download loader (installer)
   if instance.mod_loader.loader_type != ModLoaderType::Unknown {
     install_mod_loader(
@@ -1182,8 +1190,8 @@ pub async fn create_instance(
       mods_dir.to_path_buf(),
       &mut version_info,
       &mut task_params,
-      is_install_fabric_api,
-      is_install_qf_api,
+      effective_install_fabric_api,
+      effective_install_qf_api,
     )
     .await?;
   }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

- #1653

### Description

- This PR prevents duplicate mod install (Fabric API / QFAPI) when installing a modpack.
- When installing a modpack, Fabric API / QFAPI won't be installed automatically, the program will only install mods in the modpack.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Bug Fixes:
- Skip auto-installing Fabric API and QFAPI during modpack-based instance creation when the modpack already specifies these dependencies.

## Summary by Sourcery

Bug Fixes:
- Skip auto-installing Fabric API and QFAPI when creating an instance from a modpack so they are only installed if explicitly requested.