### PR TITLE
fix(backend): clean up dir when failing to create instance, improve retry UX

### DIFF
--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -57,8 +57,8 @@ use crate::tasks::PTaskParam;
 use crate::tasks::commands::schedule_progressive_task_group;
 use crate::tasks::download::DownloadParam;
 use crate::utils::fs::{
-  copy_whole_dir, create_url_shortcut, generate_unique_filename, get_files_with_regex,
-  get_subdirectories, normalize_relative_path,
+  RemoveDirGuard, copy_whole_dir, create_url_shortcut, generate_unique_filename,
+  get_files_with_regex, get_subdirectories, normalize_relative_path,
 };
 use crate::utils::image::ImageWrapper;
 use futures::{StreamExt, TryStreamExt};
@@ -1055,6 +1055,10 @@ pub async fn create_instance(
   if version_path.exists() {
     return Err(InstanceError::ConflictNameError.into());
   }
+
+  // Guard removes version_path on any early return (errors), fix #1105 #1310
+  let dir_guard = RemoveDirGuard::new(version_path.clone());
+
   let optifine_info = optifine.as_ref().map(|info| OptiFine {
     filename: info.filename.clone(),
     version: format!("{}_{}", info.r#type, info.patch),
@@ -1249,6 +1253,7 @@ pub async fn create_instance(
     .await
     .map_err(|_| InstanceError::FileCreationFailed)?;
 
+  dir_guard.commit();
   Ok(())
 }
 

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -594,24 +594,26 @@ where
 /// free, do fallible work, and call `commit()` only on success. Any early `?` return
 /// automatically triggers cleanup.
 pub struct RemoveDirGuard {
-  path: PathBuf,
+  path: Option<PathBuf>,
 }
 
 impl RemoveDirGuard {
   pub fn new(path: PathBuf) -> Self {
-    Self { path }
+    Self { path: Some(path) }
   }
 
   /// Disarms the guard so the directory is kept on drop.
-  pub fn commit(self) {
-    std::mem::forget(self);
+  pub fn commit(mut self) {
+    self.path = None;
   }
 }
 
 impl Drop for RemoveDirGuard {
   fn drop(&mut self) {
-    if self.path.exists() {
-      let _ = fs::remove_dir_all(&self.path);
+    if let Some(path) = &self.path
+      && path.exists()
+    {
+      let _ = fs::remove_dir_all(path);
     }
   }
 }

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -587,3 +587,31 @@ where
 
   Ok(())
 }
+
+/// RAII guard that removes a directory on drop unless [`commit`](RemoveDirGuard::commit) is called.
+///
+/// Useful for transactional directory creation: create the guard after verifying the path is
+/// free, do fallible work, and call `commit()` only on success. Any early `?` return
+/// automatically triggers cleanup.
+pub struct RemoveDirGuard {
+  path: PathBuf,
+}
+
+impl RemoveDirGuard {
+  pub fn new(path: PathBuf) -> Self {
+    Self { path }
+  }
+
+  /// Disarms the guard so the directory is kept on drop.
+  pub fn commit(self) {
+    std::mem::forget(self);
+  }
+}
+
+impl Drop for RemoveDirGuard {
+  fn drop(&mut self) {
+    if self.path.exists() {
+      let _ = fs::remove_dir_all(&self.path);
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

close #1105 #1310

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Ensure instance directories are cleaned up when instance creation fails to prevent conflicts on subsequent retries.

Bug Fixes:
- Automatically remove partially created instance directories when instance creation errors to avoid name conflicts and improve retry behaviour.

Enhancements:
- Introduce an RAII-style directory guard utility to manage temporary instance directories and clean them up on early returns.