### PR TITLE
refactor(frontend): improve UX of download resource / modpack modal by refactor footer operations

### DIFF
--- a/src/components/modals/download-specific-resource-modal.tsx
+++ b/src/components/modals/download-specific-resource-modal.tsx
@@ -1,6 +1,7 @@
 import {
   Avatar,
   Box,
+  Button,
   Card,
   Grid,
   HStack,
@@ -11,14 +12,21 @@ import {
   ModalBody,
   ModalCloseButton,
   ModalContent,
+  ModalFooter,
   ModalHeader,
   ModalOverlay,
   ModalProps,
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
+  Radio,
   Tag,
   Text,
   VStack,
+  useDisclosure,
 } from "@chakra-ui/react";
-import { downloadDir } from "@tauri-apps/api/path";
+import { downloadDir, join } from "@tauri-apps/api/path";
 import { save } from "@tauri-apps/plugin-dialog";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useRouter } from "next/router";
@@ -38,6 +46,7 @@ import { MenuSelector } from "@/components/common/menu-selector";
 import NavMenu from "@/components/common/nav-menu";
 import { OptionItem, OptionItemGroup } from "@/components/common/option-item";
 import { Section } from "@/components/common/section";
+import InstancesView from "@/components/instances-view";
 import MCVersionNumberHelper from "@/components/mc-version-number-helper";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
@@ -46,6 +55,7 @@ import { useToast } from "@/contexts/toast";
 import { InstanceSubdirType, ModLoaderType } from "@/enums/instance";
 import { OtherResourceSource, OtherResourceType } from "@/enums/resource";
 import { GetStateFlag } from "@/hooks/get-state";
+import { InstanceSummary } from "@/models/instance/misc";
 import {
   GameClientResourceInfo,
   OtherResourceFileInfo,
@@ -71,6 +81,9 @@ interface DownloadSpecificResourceModalProps extends Omit<
   curInstanceModLoader?: ModLoaderType;
 }
 
+// Resource version list with single-select; action buttons vary by type.
+// regular: [Cancel] [Download] [Install to Instance (popover picker)] [Install to Current Instance (only on instance details pages)]
+// modpack: [Cancel] [Download] [Install (download to cache dir then auto-install)]
 const DownloadSpecificResourceModal: React.FC<
   DownloadSpecificResourceModalProps
 > = ({
@@ -103,9 +116,37 @@ const DownloadSpecificResourceModal: React.FC<
   const [versionPacks, setVersionPacks] = useState<OtherResourceVersionPack[]>(
     []
   );
+  const [selectedItem, setSelectedItem] =
+    useState<OtherResourceFileInfo | null>(null);
 
-  const { getGameVersionList, isGameVersionListLoading } = useGlobalData();
+  const { getGameVersionList, isGameVersionListLoading, getInstanceList } =
+    useGlobalData();
   const { openSharedModal, closeSharedModal } = useSharedModals();
+  const {
+    isOpen: isInstanceSelectorPopoverOpen,
+    onOpen: onInstanceSelectorPopoverOpen,
+    onClose: onInstanceSelectorPopoverClose,
+  } = useDisclosure();
+
+  const routeInstanceId = useMemo(() => {
+    const id = router.query.id;
+    return Array.isArray(id) ? id[0] : id;
+  }, [router.query.id]);
+
+  const isModpack = resource.type === OtherResourceType.ModPack;
+
+  const resourceTypeToDirType = useMemo<Record<string, InstanceSubdirType>>(
+    () => ({
+      mod: InstanceSubdirType.Mods,
+      world: InstanceSubdirType.Saves,
+      resourcepack: InstanceSubdirType.ResourcePacks,
+      shader: InstanceSubdirType.ShaderPacks,
+      datapack: InstanceSubdirType.Saves,
+    }),
+    []
+  );
+  const dirType =
+    resourceTypeToDirType[resource.type] ?? InstanceSubdirType.Root;
 
   const modLoaderLabels = [
     "All",
@@ -163,71 +204,167 @@ const DownloadSpecificResourceModal: React.FC<
       : t("DownloadSpecificResourceModal.label.all");
   };
 
-  const getDefaultFilePath = useCallback(async (): Promise<string | null> => {
-    const resourceTypeToDirType: Record<string, InstanceSubdirType> = {
-      mod: InstanceSubdirType.Mods,
-      world: InstanceSubdirType.Saves,
-      resourcepack: InstanceSubdirType.ResourcePacks,
-      shader: InstanceSubdirType.ShaderPacks,
-      datapack: InstanceSubdirType.Saves,
-    };
-    const dirType =
-      resourceTypeToDirType[resource.type] ?? InstanceSubdirType.Root;
+  // add prefix and sanitize
+  const getSelectedFileName = useCallback(
+    (item: OtherResourceFileInfo) =>
+      sanitizeFileName(
+        addPrefix && resource.translatedName
+          ? `[${resource.translatedName}] ${item.fileName}`
+          : item.fileName
+      ),
+    [addPrefix, resource.translatedName]
+  );
 
-    let id = router.query.id;
-    const instanceId = Array.isArray(id) ? id[0] : id;
+  // resource dependencies alert
+  const withDependencyCheck = useCallback(
+    (action: () => void) => {
+      if (!selectedItem) return;
+      if (selectedItem.dependencies.length > 0 && !isModpack) {
+        openSharedModal("alert-resource-dependency", {
+          dependencies: selectedItem.dependencies,
+          downloadSource: resource.source as OtherResourceSource,
+          curInstanceMajorVersion,
+          curInstanceVersion,
+          curInstanceModLoader,
+          downloadOriginalResource: action,
+        });
+      } else {
+        action();
+      }
+    },
+    [
+      selectedItem,
+      isModpack,
+      resource.source,
+      openSharedModal,
+      curInstanceMajorVersion,
+      curInstanceVersion,
+      curInstanceModLoader,
+    ]
+  );
 
-    if (instanceId !== undefined) {
-      return InstanceService.retrieveInstanceSubdirPath(
-        instanceId,
+  // for the "download" button (save dialog), get default download path:
+  // on instance page use the instance's subdir
+  // modpacks always use system download dir
+  const getDefaultDownloadPath = useCallback(async (): Promise<string> => {
+    if (!isModpack && routeInstanceId !== undefined) {
+      const response = await InstanceService.retrieveInstanceSubdirPath(
+        routeInstanceId,
         dirType
-      ).then((response) => {
-        if (response.status === "success") {
-          return response.data;
-        } else {
-          toast({
-            title: response.message,
-            description: response.details,
-            status: "error",
-          });
-          return null;
-        }
+      );
+      if (response.status === "success") return response.data;
+      toast({
+        title: response.message,
+        description: response.details,
+        status: "error",
       });
     }
+    return downloadDir();
+  }, [isModpack, routeInstanceId, dirType, toast]);
 
-    const defaultDownloadPath = await downloadDir();
-    return defaultDownloadPath;
-  }, [resource.type, router.query.id, toast]);
-
-  const startDownload = async (
-    item: OtherResourceFileInfo,
-    translatedName?: string
-  ) => {
-    const dir = await getDefaultFilePath();
-    const fileName = sanitizeFileName(
-      addPrefix && translatedName
-        ? `[${translatedName}] ${item.fileName}`
-        : item.fileName
-    );
-    const savepath = await save({
-      defaultPath: dir + "/" + fileName,
+  const handleDownload = useCallback(() => {
+    if (!selectedItem) return;
+    withDependencyCheck(async () => {
+      const dir = await getDefaultDownloadPath();
+      const fileName = getSelectedFileName(selectedItem);
+      const savepath = await save({ defaultPath: dir + "/" + fileName });
+      if (!savepath) return;
+      // use "modpack-wo-install" group , prevent auto-trigger install
+      const taskGroup = isModpack ? "modpack-wo-install" : resource.type;
+      handleScheduleProgressiveTaskGroup(taskGroup, [
+        {
+          src: selectedItem.downloadUrl,
+          dest: savepath,
+          sha1: selectedItem.sha1,
+          taskType: TaskTypeEnums.Download,
+        },
+      ]);
+      closeSharedModal("download-specific-resource");
+      if (isModpack) closeSharedModal("download-modpack");
+      router.push("/downloads");
     });
-    if (!savepath) return;
-    handleScheduleProgressiveTaskGroup(resource.type, [
+  }, [
+    selectedItem,
+    withDependencyCheck,
+    getDefaultDownloadPath,
+    getSelectedFileName,
+    isModpack,
+    resource.type,
+    handleScheduleProgressiveTaskGroup,
+    closeSharedModal,
+    router,
+  ]);
+
+  const handleInstallToInstance = useCallback(
+    async (instance: InstanceSummary) => {
+      if (!selectedItem) return;
+      const response = await InstanceService.retrieveInstanceSubdirPath(
+        instance.id,
+        dirType
+      );
+      if (response.status === "success") {
+        const destPath = await join(
+          response.data,
+          getSelectedFileName(selectedItem)
+        );
+        handleScheduleProgressiveTaskGroup(resource.type, [
+          {
+            src: selectedItem.downloadUrl,
+            dest: destPath,
+            sha1: selectedItem.sha1,
+            taskType: TaskTypeEnums.Download,
+          },
+        ]);
+        modalProps.onClose();
+      } else {
+        toast({
+          title: response.message,
+          description: response.details,
+          status: "error",
+        });
+      }
+    },
+    [
+      selectedItem,
+      dirType,
+      getSelectedFileName,
+      resource.type,
+      handleScheduleProgressiveTaskGroup,
+      modalProps,
+      toast,
+    ]
+  );
+
+  const handleInstallToCurrentInstance = useCallback(() => {
+    if (!routeInstanceId) return;
+    const instance = getInstanceList()?.find((i) => i.id === routeInstanceId);
+    if (instance) handleInstallToInstance(instance);
+  }, [routeInstanceId, getInstanceList, handleInstallToInstance]);
+
+  const handleInstanceModpack = useCallback(async () => {
+    if (!selectedItem) return;
+    const cacheDir = config.download.cache.directory.trim();
+    if (!cacheDir) return;
+    const fileName = sanitizeFileName(selectedItem.fileName);
+    const destPath = await join(cacheDir, fileName);
+    handleScheduleProgressiveTaskGroup("modpack", [
       {
-        src: item.downloadUrl,
-        dest: savepath,
-        sha1: item.sha1,
+        src: selectedItem.downloadUrl,
+        dest: destPath,
+        sha1: selectedItem.sha1,
         taskType: TaskTypeEnums.Download,
       },
     ]);
-
-    if (resource.type === OtherResourceType.ModPack) {
-      closeSharedModal("download-specific-resource");
-      closeSharedModal("download-modpack");
-      router.push("/downloads");
-    }
-  };
+    closeSharedModal("download-specific-resource");
+    closeSharedModal("download-modpack");
+    router.push("/downloads");
+  }, [
+    selectedItem,
+    config.download.cache.directory,
+    handleScheduleProgressiveTaskGroup,
+    closeSharedModal,
+    router,
+  ]);
 
   const getRecommendedFiles = useMemo((): OtherResourceFileInfo[] => {
     if (!curInstanceVersion || !versionPacks.length) return [];
@@ -428,13 +565,21 @@ const DownloadSpecificResourceModal: React.FC<
                   </Grid>
                 }
                 prefixElement={
-                  <Avatar
-                    src={""}
-                    name={item.releaseType}
-                    boxSize="32px"
-                    borderRadius="4px"
-                    backgroundColor={iconBackgroundColor[item.releaseType]}
-                  />
+                  <HStack spacing={2.5}>
+                    <Radio
+                      isChecked={selectedItem === item}
+                      onChange={() => setSelectedItem(item)}
+                      colorScheme={primaryColor}
+                      pointerEvents="none"
+                    />
+                    <Avatar
+                      src={""}
+                      name={item.releaseType}
+                      boxSize="32px"
+                      borderRadius="4px"
+                      backgroundColor={iconBackgroundColor[item.releaseType]}
+                    />
+                  </HStack>
                 }
                 titleExtra={
                   item.loader && (
@@ -448,22 +593,7 @@ const DownloadSpecificResourceModal: React.FC<
                   )
                 }
                 isFullClickZone
-                onClick={() => {
-                  if (
-                    item.dependencies.length > 0 &&
-                    resource.type !== OtherResourceType.ModPack
-                  ) {
-                    openSharedModal("alert-resource-dependency", {
-                      dependencies: item.dependencies,
-                      downloadSource: resource.source as OtherResourceSource,
-                      curInstanceMajorVersion,
-                      curInstanceVersion,
-                      curInstanceModLoader,
-                      downloadOriginalResource: () =>
-                        startDownload(item, resource.translatedName),
-                    });
-                  } else startDownload(item, resource.translatedName);
-                }}
+                onClick={() => setSelectedItem(item)}
               />
             ))}
           />
@@ -495,6 +625,12 @@ const DownloadSpecificResourceModal: React.FC<
     reFetchVersionPacks();
   }, [reFetchVersionPacks]);
 
+  useEffect(() => {
+    setSelectedItem(
+      modalProps.isOpen ? (getRecommendedFiles[0] ?? null) : null
+    );
+  }, [modalProps.isOpen, getRecommendedFiles]);
+
   return (
     <Modal
       scrollBehavior="inside"
@@ -503,7 +639,7 @@ const DownloadSpecificResourceModal: React.FC<
       {...modalProps}
     >
       <ModalOverlay />
-      <ModalContent h="100%" pb={4}>
+      <ModalContent h="100%">
         <ModalHeader>
           {t("DownloadSpecificResourceModal.title", {
             name:
@@ -685,6 +821,74 @@ const DownloadSpecificResourceModal: React.FC<
             })()
           )}
         </ModalBody>
+        <ModalFooter gap={2}>
+          <Button variant="ghost" onClick={modalProps.onClose}>
+            {t("DownloadSpecificResourceModal.button.cancel")}
+          </Button>
+          <Button
+            variant="ghost"
+            isDisabled={!selectedItem}
+            onClick={handleDownload}
+          >
+            {t("DownloadSpecificResourceModal.button.download")}
+          </Button>
+          {!isModpack && (
+            <Popover
+              isOpen={isInstanceSelectorPopoverOpen}
+              onClose={onInstanceSelectorPopoverClose}
+              placement="top-start"
+              gutter={8}
+            >
+              <PopoverTrigger>
+                <Button
+                  variant={routeInstanceId ? "ghost" : undefined}
+                  colorScheme={routeInstanceId ? undefined : primaryColor}
+                  isDisabled={!selectedItem}
+                  onClick={() =>
+                    withDependencyCheck(onInstanceSelectorPopoverOpen)
+                  }
+                >
+                  {t("DownloadSpecificResourceModal.button.installToInstance")}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent maxH="xs" overflow="auto">
+                <PopoverBody p={0}>
+                  <InstancesView
+                    instances={getInstanceList() || []}
+                    selectedInstance={undefined}
+                    viewType="list"
+                    withMenu={false}
+                    onSelectInstance={(instance) => {
+                      onInstanceSelectorPopoverClose();
+                      handleInstallToInstance(instance);
+                    }}
+                  />
+                </PopoverBody>
+              </PopoverContent>
+            </Popover>
+          )}
+          {isModpack ? (
+            <Button
+              colorScheme={primaryColor}
+              isDisabled={!selectedItem}
+              onClick={handleInstanceModpack}
+            >
+              {t("DownloadSpecificResourceModal.button.install")}
+            </Button>
+          ) : routeInstanceId ? (
+            <Button
+              colorScheme={primaryColor}
+              isDisabled={!selectedItem}
+              onClick={() =>
+                withDependencyCheck(handleInstallToCurrentInstance)
+              }
+            >
+              {t(
+                "DownloadSpecificResourceModal.button.installToCurrentInstance"
+              )}
+            </Button>
+          ) : null}
+        </ModalFooter>
       </ModalContent>
     </Modal>
   );

--- a/src/components/modals/download-specific-resource-modal.tsx
+++ b/src/components/modals/download-specific-resource-modal.tsx
@@ -267,9 +267,9 @@ const DownloadSpecificResourceModal: React.FC<
     withDependencyCheck(async () => {
       const dir = await getDefaultDownloadPath();
       const fileName = getSelectedFileName(selectedItem);
-      const savepath = await save({ defaultPath: dir + "/" + fileName });
+      const savepath = await save({ defaultPath: await join(dir, fileName) });
       if (!savepath) return;
-      // use "modpack-wo-install" group , prevent auto-trigger install
+      // use "modpack-wo-install" group to prevent auto-triggering install
       const taskGroup = isModpack ? "modpack-wo-install" : resource.type;
       handleScheduleProgressiveTaskGroup(taskGroup, [
         {

--- a/src/components/modals/download-specific-resource-modal.tsx
+++ b/src/components/modals/download-specific-resource-modal.tsx
@@ -341,7 +341,7 @@ const DownloadSpecificResourceModal: React.FC<
     if (instance) handleInstallToInstance(instance);
   }, [routeInstanceId, getInstanceList, handleInstallToInstance]);
 
-  const handleInstanceModpack = useCallback(async () => {
+  const handleInstallModpack = useCallback(async () => {
     if (!selectedItem) return;
     const cacheDir = config.download.cache.directory.trim();
     if (!cacheDir) return;
@@ -871,7 +871,7 @@ const DownloadSpecificResourceModal: React.FC<
             <Button
               colorScheme={primaryColor}
               isDisabled={!selectedItem}
-              onClick={handleInstanceModpack}
+              onClick={handleInstallModpack}
             >
               {t("DownloadSpecificResourceModal.button.install")}
             </Button>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -621,6 +621,13 @@
       "alpha": "Alpha",
       "beta": "Beta",
       "release": "Release"
+    },
+    "button": {
+      "cancel": "Cancel",
+      "download": "Download",
+      "installToInstance": "Install to Instance",
+      "installToCurrentInstance": "Install to Current Instance",
+      "install": "Install"
     }
   },
   "DownloadTasksPage": {
@@ -649,6 +656,7 @@
       "resourcepack": "Resourcepack",
       "shader": "Shaderpack",
       "modpack": "Modpack",
+      "modpack-download": "Modpack",
       "datapack": "Datapack",
       "patch-files": "Patch Game Files {{param}}",
       "mod-update": "Update Mod",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -656,7 +656,7 @@
       "resourcepack": "Resourcepack",
       "shader": "Shaderpack",
       "modpack": "Modpack",
-      "modpack-download": "Modpack",
+      "modpack-wo-install": "Modpack",
       "datapack": "Datapack",
       "patch-files": "Patch Game Files {{param}}",
       "mod-update": "Update Mod",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -621,6 +621,13 @@
       "alpha": "Alpha",
       "beta": "Bêta",
       "release": "Version stable"
+    },
+    "button": {
+      "cancel": "Annuler",
+      "download": "Télécharger",
+      "installToInstance": "Installer dans une instance",
+      "installToCurrentInstance": "Installer dans l'instance actuelle",
+      "install": "Installer"
     }
   },
   "DownloadTasksPage": {
@@ -649,6 +656,7 @@
       "resourcepack": "Pack de ressources",
       "shader": "Shaders",
       "modpack": "Pack modifié",
+      "modpack-download": "Pack modifié",
       "datapack": "Paquet de données",
       "patch-files": "Réparer les fichiers du jeu {{param}}",
       "mod-update": "Mettre à jour les mods.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -656,7 +656,7 @@
       "resourcepack": "Pack de ressources",
       "shader": "Shaders",
       "modpack": "Pack modifié",
-      "modpack-download": "Pack modifié",
+      "modpack-wo-install": "Pack modifié",
       "datapack": "Paquet de données",
       "patch-files": "Réparer les fichiers du jeu {{param}}",
       "mod-update": "Mettre à jour les mods.",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -656,7 +656,7 @@
       "resourcepack": "リソースパック",
       "shader": "シェーダーパック",
       "modpack": "モッドパック",
-      "modpack-download": "モッドパック",
+      "modpack-wo-install": "モッドパック",
       "datapack": "データパック",
       "patch-files": "ゲームファイルを修復 {{param}}",
       "mod-update": "モッドを更新",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -621,6 +621,13 @@
       "alpha": "アルファ版",
       "beta": "ベータ版",
       "release": "正式版"
+    },
+    "button": {
+      "cancel": "キャンセル",
+      "download": "ダウンロード",
+      "installToInstance": "インスタンスにインストール",
+      "installToCurrentInstance": "現在のインスタンスにインストール",
+      "install": "インストール"
     }
   },
   "DownloadTasksPage": {
@@ -649,6 +656,7 @@
       "resourcepack": "リソースパック",
       "shader": "シェーダーパック",
       "modpack": "モッドパック",
+      "modpack-download": "モッドパック",
       "datapack": "データパック",
       "patch-files": "ゲームファイルを修復 {{param}}",
       "mod-update": "モッドを更新",

--- a/src/locales/lzh.json
+++ b/src/locales/lzh.json
@@ -656,7 +656,7 @@
       "resourcepack": "資囊",
       "shader": "光影",
       "modpack": "改囊集",
-      "modpack-download": "改囊集",
+      "modpack-wo-install": "改囊集",
       "datapack": "錄囊",
       "patch-files": "修補戲案 {{param}}",
       "mod-update": "迭更改囊",

--- a/src/locales/lzh.json
+++ b/src/locales/lzh.json
@@ -621,6 +621,13 @@
       "alpha": "內試版",
       "beta": "公試版",
       "release": "當版"
+    },
+    "button": {
+      "cancel": "消",
+      "download": "引",
+      "installToInstance": "裝入例",
+      "installToCurrentInstance": "裝入今例",
+      "install": "裝"
     }
   },
   "DownloadTasksPage": {
@@ -649,6 +656,7 @@
       "resourcepack": "資囊",
       "shader": "光影",
       "modpack": "改囊集",
+      "modpack-download": "改囊集",
       "datapack": "錄囊",
       "patch-files": "修補戲案 {{param}}",
       "mod-update": "迭更改囊",

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -656,7 +656,7 @@
       "resourcepack": "资源包",
       "shader": "光影",
       "modpack": "整合包",
-      "modpack-download": "整合包",
+      "modpack-wo-install": "整合包",
       "datapack": "数据包",
       "patch-files": "修补游戏文件 {{param}}",
       "mod-update": "更新模组",

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -621,6 +621,13 @@
       "alpha": "内测版",
       "beta": "公测版",
       "release": "正式版"
+    },
+    "button": {
+      "cancel": "取消",
+      "download": "下载",
+      "installToInstance": "安装到实例",
+      "installToCurrentInstance": "安装到当前实例",
+      "install": "安装"
     }
   },
   "DownloadTasksPage": {
@@ -649,6 +656,7 @@
       "resourcepack": "资源包",
       "shader": "光影",
       "modpack": "整合包",
+      "modpack-download": "整合包",
       "datapack": "数据包",
       "patch-files": "修补游戏文件 {{param}}",
       "mod-update": "更新模组",

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -621,6 +621,13 @@
       "alpha": "Alpha",
       "beta": "Beta",
       "release": "Release"
+    },
+    "button": {
+      "cancel": "取消",
+      "download": "下載",
+      "installToInstance": "安裝到實例",
+      "installToCurrentInstance": "安裝到當前實例",
+      "install": "安裝"
     }
   },
   "DownloadTasksPage": {
@@ -649,6 +656,7 @@
       "resourcepack": "資源包",
       "shader": "光影",
       "modpack": "模組包",
+      "modpack-wo-install": "模組包",
       "datapack": "資料包",
       "patch-files": "修補遊戲檔案 {{param}}",
       "mod-update": "更新模組",


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

close #1024

### Description

<img width="1600" height="1100" alt="6e7da68bb752c224ad30e21ad22ed635" src="https://github.com/user-attachments/assets/a27b3e9c-de9a-4c90-86a6-d26595ee3ed2" />

<img width="1600" height="1100" alt="fca462dcf05ece3e221517aef909d872" src="https://github.com/user-attachments/assets/c2934de3-0511-43d8-b2da-943fa45764bd" />

<img width="1600" height="1100" alt="07e49b5d24c966a75ff9c884a41176e1" src="https://github.com/user-attachments/assets/c2433506-17b4-424d-8b90-383bd4a4215b" />

资源下载从原来的列表点击弹 system save dialog 改成列表选择+不同操作了

## Summary by Sourcery

Refine the download-specific resource modal to use single selection with dedicated footer actions for downloading or installing resources and modpacks.

New Features:
- Allow installing a selected resource directly into a chosen instance via an instance selector popover from the download modal.
- Allow installing a selected resource directly into the current instance when invoked from an instance details page.
- Support installing modpacks by downloading them to the cache directory and then triggering the modpack workflow.

Enhancements:
- Change the resource version list to single-select with a radio indicator and move actions into explicit footer buttons for clearer UX.
- Preselect the recommended resource file when the modal opens to streamline the download or install flow.
- Refine dependency checking so it wraps download and install actions and is skipped for modpacks where appropriate.
- Improve default download and install paths by using instance subdirectories when on an instance page and falling back to the system download directory otherwise.