### PR TITLE
ci: add manual publish triggers

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -9,9 +9,11 @@ on:
       version:
         description: "Version to publish"
         required: true
+        type: string
       release_tag:
-        description: "Release tag to download assets from"
-        required: true
+        description: "Release tag to download assets from. Defaults to v<version>."
+        required: false
+        type: string
   workflow_call:
     inputs:
       version:
@@ -42,10 +44,11 @@ jobs:
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.release_tag || format('v{0}', inputs.version) }}
         run: |
           get_asset_digest() {
             local asset_name="$1"
-            gh api "repos/${GH_REPO}/releases/tags/${{ inputs.release_tag }}" \
+            gh api "repos/${GH_REPO}/releases/tags/${RELEASE_TAG}" \
               --jq ".assets[] | select(.name == \"${asset_name}\") | .digest"
           }
 

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -1,6 +1,16 @@
 name: Publish Homebrew Cask
 
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish"
+        required: true
+        type: string
+      release_tag:
+        description: "Release tag to read assets from. Defaults to v<version>."
+        required: false
+        type: string
   workflow_call:
     inputs:
       version:
@@ -36,7 +46,7 @@ jobs:
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_TAG: ${{ inputs.release_tag || format('v{0}', inputs.version) }}
           VERSION: ${{ inputs.version }}
         run: |
           get_asset_digest() {

--- a/.github/workflows/publish-snap.yml
+++ b/.github/workflows/publish-snap.yml
@@ -1,6 +1,29 @@
 name: Publish Snap Package
 
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish"
+        required: true
+        type: string
+      release_tag:
+        description: "Release tag to download assets from. Defaults to v<version>."
+        required: false
+        type: string
+      arch:
+        description: "Target architecture"
+        required: true
+        type: choice
+        default: x86_64
+        options:
+          - x86_64
+          - aarch64
+      channel:
+        description: "Snap Store channel"
+        required: true
+        type: string
+        default: stable
   workflow_call:
     inputs:
       version:
@@ -37,9 +60,10 @@ jobs:
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.release_tag || format('v{0}', inputs.version) }}
         run: |
           mkdir -p artifacts
-          gh release download "${{ inputs.release_tag }}" \
+          gh release download "$RELEASE_TAG" \
             --repo "$GH_REPO" \
             --pattern "SJMCL_${{ inputs.version }}_linux_${{ inputs.arch }}.deb" \
             --dir artifacts

--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -1,6 +1,16 @@
 name: Publish Winget Manifest
 
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish"
+        required: true
+        type: string
+      release_tag:
+        description: "Release tag to read assets from. Defaults to v<version>."
+        required: false
+        type: string
   workflow_call:
     inputs:
       version:
@@ -33,7 +43,7 @@ jobs:
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_TAG: ${{ inputs.release_tag || format('v{0}', inputs.version) }}
           VERSION: ${{ inputs.version }}
         run: |
           get_asset_digest() {
@@ -81,7 +91,7 @@ jobs:
         shell: bash
         env:
           VERSION: ${{ inputs.version }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_TAG: ${{ inputs.release_tag || format('v{0}', inputs.version) }}
         run: |
           OUTPUT_DIR="winget-manifests/manifests/s/SJMC/SJMCL/${VERSION}"
           mkdir -p "$OUTPUT_DIR"


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - e.g. close #xxxx, fix #xxxx

### Description

给每个发布渠道workflow添加手动触发

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Add manual dispatch triggers and default release tag handling for all publish workflows.

Build:
- Enable workflow_dispatch with version/release_tag inputs for Snap, Winget, Homebrew, and AUR publish workflows.
- Default release_tag to v<version> when not provided and reuse it in artifact download and manifest generation steps.