### PR TITLE
fix(frontend): prevent returning focus after closing modal

### DIFF
--- a/src/components/modals/add-auth-server-modal.tsx
+++ b/src/components/modals/add-auth-server-modal.tsx
@@ -125,6 +125,7 @@ const AddAuthServerModal: React.FC<AddAuthServerModalProps> = ({
     <Modal
       size={{ base: "md", lg: "lg", xl: "xl" }}
       initialFocusRef={initialRef}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/add-game-server-modal.tsx
+++ b/src/components/modals/add-game-server-modal.tsx
@@ -91,6 +91,7 @@ const AddGameServerModal: React.FC<AddGameServerModalProps> = ({
     <Modal
       size={{ base: "md", lg: "lg", xl: "xl" }}
       initialFocusRef={initialRef}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/add-player-modal.tsx
+++ b/src/components/modals/add-player-modal.tsx
@@ -286,6 +286,7 @@ const AddPlayerModal: React.FC<AddPlayerModalProps> = ({
     <Modal
       size={{ base: "md", lg: "lg", xl: "xl" }}
       initialFocusRef={initialRef}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/add-post-source-modal.tsx
+++ b/src/components/modals/add-post-source-modal.tsx
@@ -39,7 +39,7 @@ const AddDiscoverSourceModal: React.FC<Omit<ModalProps, "children">> = ({
   };
 
   return (
-    <Modal {...props} onClose={handleCloseModal}>
+    <Modal returnFocusOnClose={false} {...props} onClose={handleCloseModal}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("AddDiscoverSourceModal.modal.header")}</ModalHeader>

--- a/src/components/modals/alert-resource-dependency-modal.tsx
+++ b/src/components/modals/alert-resource-dependency-modal.tsx
@@ -203,6 +203,7 @@ const AlertResourceDependencyModal: React.FC<
     <Modal
       scrollBehavior="inside"
       size={{ base: "md", lg: "lg", xl: "xl" }}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/change-mod-loader-modal.tsx
+++ b/src/components/modals/change-mod-loader-modal.tsx
@@ -117,6 +117,7 @@ export const ChangeModLoaderModal: React.FC<ChangeModLoaderModalProps> = ({
     <Modal
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
+      returnFocusOnClose={false}
       onCloseComplete={() => {
         setSelectedModLoader(defaultModLoaderResourceInfo);
       }}

--- a/src/components/modals/check-mod-update-modal.tsx
+++ b/src/components/modals/check-mod-update-modal.tsx
@@ -306,6 +306,7 @@ const CheckModUpdateModal: React.FC<CheckModUpdateModalProps> = ({
     <Modal
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/copy-or-move-modal.tsx
+++ b/src/components/modals/copy-or-move-modal.tsx
@@ -277,6 +277,7 @@ const CopyOrMoveModal: React.FC<CopyOrMoveModalProps> = ({
     <Modal
       size={{ base: "md", lg: "lg", xl: "xl" }}
       scrollBehavior="inside"
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/create-instance-modal.tsx
+++ b/src/components/modals/create-instance-modal.tsx
@@ -351,6 +351,7 @@ export const CreateInstanceModal: React.FC<Omit<ModalProps, "children">> = ({
     <Modal
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/download-game-server-modal.tsx
+++ b/src/components/modals/download-game-server-modal.tsx
@@ -66,6 +66,7 @@ export const DownloadGameServerModal: React.FC<
     <Modal
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/download-java-modal.tsx
+++ b/src/components/modals/download-java-modal.tsx
@@ -156,7 +156,11 @@ export const DownloadJavaModal: React.FC<Omit<ModalProps, "children">> = ({
   };
 
   return (
-    <Modal size={{ base: "sm", lg: "md" }} {...props}>
+    <Modal
+      size={{ base: "sm", lg: "md" }}
+      returnFocusOnClose={false}
+      {...props}
+    >
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("DownloadJavaModal.header.title")}</ModalHeader>

--- a/src/components/modals/download-modpack-modal.tsx
+++ b/src/components/modals/download-modpack-modal.tsx
@@ -30,6 +30,7 @@ export const DownloadModpackModal: React.FC<DownloadModpackModalProps> = ({
     <Modal
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/download-resource-modal.tsx
+++ b/src/components/modals/download-resource-modal.tsx
@@ -74,6 +74,7 @@ const DownloadResourceModal: React.FC<DownloadResourceModalProps> = ({
     <Modal
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/download-specific-resource-modal.tsx
+++ b/src/components/modals/download-specific-resource-modal.tsx
@@ -499,6 +499,7 @@ const DownloadSpecificResourceModal: React.FC<
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
       autoFocus={false}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/edit-game-directory-modal.tsx
+++ b/src/components/modals/edit-game-directory-modal.tsx
@@ -71,6 +71,7 @@ export const ActionSelectDialog: React.FC<ActionSelectDialogProps> = ({
       onClose={modalProps.onClose}
       autoFocus={false}
       isCentered
+      returnFocusOnClose={false}
     >
       <AlertDialogOverlay>
         <AlertDialogContent>
@@ -284,6 +285,7 @@ const EditGameDirectoryModal: React.FC<EditGameDirectoryModalProps> = ({
     <Modal
       size={{ base: "md", lg: "lg", xl: "xl" }}
       initialFocusRef={initialRef}
+      returnFocusOnClose={false}
       {...modalProps}
       onClose={handleCloseModal}
     >

--- a/src/components/modals/generic-confirm-dialog.tsx
+++ b/src/components/modals/generic-confirm-dialog.tsx
@@ -79,6 +79,7 @@ const GenericConfirmDialog: React.FC<GenericConfirmDialogProps> = ({
       onClose={handleCancel}
       autoFocus={false}
       isCentered
+      returnFocusOnClose={false}
       {...props}
     >
       <AlertDialogOverlay>

--- a/src/components/modals/import-account-info-modal.tsx
+++ b/src/components/modals/import-account-info-modal.tsx
@@ -243,6 +243,7 @@ const ImportAccountInfoModal: React.FC<ImportAccountInfoModalProps> = ({
     <Modal
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
+      returnFocusOnClose={false}
       {...props}
     >
       <ModalOverlay />

--- a/src/components/modals/import-modpack-modal.tsx
+++ b/src/components/modals/import-modpack-modal.tsx
@@ -195,6 +195,7 @@ const ImportModpackModal: React.FC<ImportModpackModalProps> = ({
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
       autoFocus={false}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/launch-process-modal.tsx
+++ b/src/components/modals/launch-process-modal.tsx
@@ -343,6 +343,7 @@ const LaunchProcessModal: React.FC<LaunchProcessModalProps> = ({
       size="sm"
       closeOnEsc={false}
       closeOnOverlayClick={false}
+      returnFocusOnClose={false}
       {...props}
       onClose={handleCloseModalWithCancel}
     >

--- a/src/components/modals/manage-skin-modal.tsx
+++ b/src/components/modals/manage-skin-modal.tsx
@@ -209,6 +209,7 @@ const ManageSkinModal: React.FC<ManageSkinModalProps> = ({
     <Modal
       isOpen={isOpen}
       onClose={onClose}
+      returnFocusOnClose={false}
       size={
         selectedSkin === "upload"
           ? { base: "2xl", lg: "3xl", xl: "4xl" }

--- a/src/components/modals/manual-add-java-path-modal.tsx
+++ b/src/components/modals/manual-add-java-path-modal.tsx
@@ -81,7 +81,7 @@ const ManualAddJavaPathModal: React.FC<ManualAddJavaPathModalProps> = ({
   };
 
   return (
-    <Modal {...props} onClose={handleClose}>
+    <Modal returnFocusOnClose={false} {...props} onClose={handleClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("ManualAddJavaPathModal.modal.header")}</ModalHeader>

--- a/src/components/modals/mod-info-modal.tsx
+++ b/src/components/modals/mod-info-modal.tsx
@@ -104,7 +104,11 @@ const ModInfoModal: React.FC<ModInfoModalProps> = ({
   }, [handleCurseForgeInfo, handleModrinthInfo]);
 
   return (
-    <Modal size={{ base: "md", lg: "lg", xl: "xl" }} {...modalProps}>
+    <Modal
+      size={{ base: "md", lg: "lg", xl: "xl" }}
+      returnFocusOnClose={false}
+      {...modalProps}
+    >
       <ModalOverlay />
       <ModalContent>
         <ModalCloseButton />

--- a/src/components/modals/notify-new-version-modal.tsx
+++ b/src/components/modals/notify-new-version-modal.tsx
@@ -69,7 +69,12 @@ const NotifyNewVersionModal: React.FC<NotifyNewVersionModalProps> = ({
   };
 
   return (
-    <Modal scrollBehavior="inside" size="xl" {...props}>
+    <Modal
+      scrollBehavior="inside"
+      size="xl"
+      returnFocusOnClose={false}
+      {...props}
+    >
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{`${t("NotifyNewVersionModal.title")} - ${newVersion.version}`}</ModalHeader>

--- a/src/components/modals/preview-screenshot-modal.tsx
+++ b/src/components/modals/preview-screenshot-modal.tsx
@@ -85,7 +85,11 @@ const PreviewScreenshotModal: React.FC<PreviewScreenshotModalProps> = ({
   ];
 
   return (
-    <Modal size={{ base: "lg", lg: "2xl", xl: "4xl" }} {...props}>
+    <Modal
+      size={{ base: "lg", lg: "2xl", xl: "4xl" }}
+      returnFocusOnClose={false}
+      {...props}
+    >
       <ModalOverlay />
       <ModalContent>
         <Image

--- a/src/components/modals/relogin-player-modal.tsx
+++ b/src/components/modals/relogin-player-modal.tsx
@@ -124,7 +124,7 @@ const ReLoginPlayerModal: React.FC<ReLoginPlayerModalProps> = ({
   };
 
   return (
-    <Modal {...props} onClose={handleCloseModal}>
+    <Modal returnFocusOnClose={false} {...props} onClose={handleCloseModal}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("ReLoginPlayerModal.modal.title")}</ModalHeader>

--- a/src/components/modals/select-instance-modal.tsx
+++ b/src/components/modals/select-instance-modal.tsx
@@ -29,7 +29,7 @@ const SelectInstanceModal: React.FC<SelectInstanceModalProps> = ({
   const { t } = useTranslation();
 
   return (
-    <Modal scrollBehavior="inside" {...modalProps}>
+    <Modal scrollBehavior="inside" returnFocusOnClose={false} {...modalProps}>
       <ModalOverlay />
       <ModalContent maxH="calc(100vh - 7.5rem)">
         <ModalHeader>

--- a/src/components/modals/select-player-modal.tsx
+++ b/src/components/modals/select-player-modal.tsx
@@ -29,7 +29,7 @@ const SelectPlayerModal: React.FC<SelectPlayerModalProps> = ({
   const { t } = useTranslation();
 
   return (
-    <Modal scrollBehavior="inside" {...modalProps}>
+    <Modal scrollBehavior="inside" returnFocusOnClose={false} {...modalProps}>
       <ModalOverlay />
       <ModalContent maxH="calc(100vh - 7.5rem)">
         <ModalHeader>

--- a/src/components/modals/spotlight-search-modal.tsx
+++ b/src/components/modals/spotlight-search-modal.tsx
@@ -470,7 +470,7 @@ const SpotlightSearchModal: React.FC<Omit<ModalProps, "children">> = ({
   };
 
   return (
-    <Modal scrollBehavior="inside" {...props}>
+    <Modal scrollBehavior="inside" returnFocusOnClose={false} {...props}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>

--- a/src/components/modals/star-us-modal.tsx
+++ b/src/components/modals/star-us-modal.tsx
@@ -22,7 +22,12 @@ const StarUsModal: React.FC<Omit<ModalProps, "children">> = ({ ...props }) => {
   };
 
   return (
-    <Modal autoFocus={false} size={{ base: "sm", lg: "md" }} {...props}>
+    <Modal
+      autoFocus={false}
+      size={{ base: "sm", lg: "md" }}
+      returnFocusOnClose={false}
+      {...props}
+    >
       <ModalOverlay />
       <ModalContent borderRadius="md" overflow="hidden">
         <video autoPlay loop muted width="100%" height="auto">

--- a/src/components/modals/sync-config-modals.tsx
+++ b/src/components/modals/sync-config-modals.tsx
@@ -86,6 +86,7 @@ export const SyncConfigExportModal: React.FC<SyncConfigModalProps> = ({
   return (
     <Modal
       size={{ base: "md", lg: "lg", xl: "xl" }}
+      returnFocusOnClose={false}
       {...modalProps}
       onClose={handleCloseModal}
     >
@@ -164,6 +165,7 @@ export const SyncConfigImportModal: React.FC<SyncConfigModalProps> = ({
   return (
     <Modal
       size={{ base: "md", lg: "lg", xl: "xl" }}
+      returnFocusOnClose={false}
       {...modalProps}
       onClose={handleCloseModal}
     >

--- a/src/components/modals/view-schematic-modal.tsx
+++ b/src/components/modals/view-schematic-modal.tsx
@@ -23,7 +23,13 @@ const ViewSchematicModal: React.FC<ViewSchematicModalProps> = ({
   const { t } = useTranslation();
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} size="md" {...modalProps}>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      size="md"
+      returnFocusOnClose={false}
+      {...modalProps}
+    >
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("ViewSchematicModal.header.title")}</ModalHeader>

--- a/src/components/modals/view-skin-modal.tsx
+++ b/src/components/modals/view-skin-modal.tsx
@@ -30,7 +30,13 @@ const ViewSkinModal: React.FC<ViewSkinModalProps> = ({
   const { t } = useTranslation();
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} size="md" {...modalProps}>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      size="md"
+      returnFocusOnClose={false}
+      {...modalProps}
+    >
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("ViewSkinModal.skinView")}</ModalHeader>

--- a/src/components/modals/welcome-and-terms-modal.tsx
+++ b/src/components/modals/welcome-and-terms-modal.tsx
@@ -52,6 +52,7 @@ const WelcomeAndTermsModal: React.FC<Omit<ModalProps, "children">> = ({
       autoFocus={false}
       closeOnEsc={false}
       closeOnOverlayClick={false}
+      returnFocusOnClose={false}
       size={{ base: "sm", lg: "md" }}
       {...props}
     >

--- a/src/components/modals/world-level-data-modal.tsx
+++ b/src/components/modals/world-level-data-modal.tsx
@@ -72,6 +72,7 @@ const WorldLevelDataModal: React.FC<WorldLevelDataModalProps> = ({
       autoFocus={false}
       size={{ base: "md", lg: "lg", xl: "xl" }}
       scrollBehavior="inside"
+      returnFocusOnClose={false}
       {...props}
     >
       <ModalOverlay />

--- a/src/components/special/guided-tour-provider.tsx
+++ b/src/components/special/guided-tour-provider.tsx
@@ -356,6 +356,7 @@ export const GuidedTourProvider: React.FC<TourProviderProps> = ({
         onClose={close}
         isCentered={false}
         closeOnOverlayClick={false}
+        returnFocusOnClose={false}
         blockScrollOnMount
         trapFocus
         // disable default animations in next steps


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - fix #834

### Description

> - Prevent returning focus after closing modal by setting `returnFocusOnClose` to false

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Bug Fixes:
- Disable focus restoration on close for various modals, alert dialogs, and the guided tour overlay to avoid unintended focus jumps after closing them.