### PR TITLE
fix(frontend): prevent returning focus after closing modal

### DIFF
--- a/src/components/common/modal.tsx
+++ b/src/components/common/modal.tsx
@@ -1,0 +1,15 @@
+import {
+  Modal as ChakraModal,
+  type ModalProps as ChakraModalProps,
+} from "@chakra-ui/react";
+import React from "react";
+
+/**
+ * Global Modal wrapper that defaults returnFocusOnClose to false.
+ * Use this instead of importing Modal directly from @chakra-ui/react.
+ */
+export const Modal: React.FC<ChakraModalProps> = (props) => (
+  <ChakraModal returnFocusOnClose={false} {...props} />
+);
+
+export type ModalProps = ChakraModalProps;

--- a/src/components/modals/add-auth-server-modal.tsx
+++ b/src/components/modals/add-auth-server-modal.tsx
@@ -9,19 +9,19 @@ import {
   FormLabel,
   HStack,
   Input,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Text,
   VStack,
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
 import { useToast } from "@/contexts/toast";

--- a/src/components/modals/add-game-server-modal.tsx
+++ b/src/components/modals/add-game-server-modal.tsx
@@ -4,18 +4,18 @@ import {
   FormErrorMessage,
   FormLabel,
   Input,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   VStack,
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
 import { InstanceService } from "@/services/instance";

--- a/src/components/modals/add-player-modal.tsx
+++ b/src/components/modals/add-player-modal.tsx
@@ -16,14 +16,12 @@ import {
   MenuButton,
   MenuItem,
   MenuList,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Text,
   VStack,
   useDisclosure,
@@ -41,6 +39,8 @@ import {
   LuServer,
   LuSquareUserRound,
 } from "react-icons/lu";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { Section } from "@/components/common/section";
 import SegmentedControl from "@/components/common/segmented";
 import SelectPlayerModal from "@/components/modals/select-player-modal";

--- a/src/components/modals/add-post-source-modal.tsx
+++ b/src/components/modals/add-post-source-modal.tsx
@@ -3,17 +3,17 @@ import {
   FormControl,
   FormLabel,
   Input,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
 } from "@chakra-ui/react";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { useLauncherConfig } from "@/contexts/config";
 
 const AddDiscoverSourceModal: React.FC<Omit<ModalProps, "children">> = ({

--- a/src/components/modals/alert-resource-dependency-modal.tsx
+++ b/src/components/modals/alert-resource-dependency-modal.tsx
@@ -2,14 +2,12 @@ import {
   Avatar,
   Button,
   HStack,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Tag,
   Text,
   VStack,
@@ -18,6 +16,8 @@ import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuDownload, LuGlobe, LuUpload } from "react-icons/lu";
 import { BeatLoader } from "react-spinners";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { OptionItem } from "@/components/common/option-item";
 import { useLauncherConfig } from "@/contexts/config";
 import { useSharedModals } from "@/contexts/shared-modal";

--- a/src/components/modals/change-loader-modal.tsx
+++ b/src/components/modals/change-loader-modal.tsx
@@ -5,14 +5,12 @@ import {
   Flex,
   HStack,
   Image,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Skeleton,
   Text,
 } from "@chakra-ui/react";
@@ -20,6 +18,8 @@ import { useRouter } from "next/router";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuArrowRight } from "react-icons/lu";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { OptionItem } from "@/components/common/option-item";
 import { LoaderSelector } from "@/components/loader-selector";
 import { useLauncherConfig } from "@/contexts/config";

--- a/src/components/modals/check-mod-update-modal.tsx
+++ b/src/components/modals/check-mod-update-modal.tsx
@@ -3,14 +3,12 @@ import {
   Button,
   Checkbox,
   HStack,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Progress,
   Text,
   VStack,
@@ -18,6 +16,8 @@ import {
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { useLauncherConfig } from "@/contexts/config";
 import { ModLoaderType } from "@/enums/instance";
 import { OtherResourceSource } from "@/enums/resource";

--- a/src/components/modals/copy-or-move-modal.tsx
+++ b/src/components/modals/copy-or-move-modal.tsx
@@ -5,14 +5,12 @@ import {
   HStack,
   Icon,
   Image,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Radio,
   RadioGroup,
   Tag,
@@ -23,6 +21,8 @@ import { useRouter } from "next/router";
 import React, { useCallback, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { LuCopy, LuScissors } from "react-icons/lu";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { OptionItemGroup } from "@/components/common/option-item";
 import SegmentedControl from "@/components/common/segmented";
 import { useLauncherConfig } from "@/contexts/config";

--- a/src/components/modals/create-instance-modal.tsx
+++ b/src/components/modals/create-instance-modal.tsx
@@ -5,14 +5,12 @@ import {
   Checkbox,
   Flex,
   HStack,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Step,
   StepDescription,
   StepIcon,
@@ -28,6 +26,8 @@ import {
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { GameVersionSelector } from "@/components/game-version-selector";
 import { InstanceBasicSettings } from "@/components/instance-basic-settings";
 import { LoaderSelector } from "@/components/loader-selector";

--- a/src/components/modals/download-game-server-modal.tsx
+++ b/src/components/modals/download-game-server-modal.tsx
@@ -1,19 +1,19 @@
 import {
   Button,
   Flex,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
 } from "@chakra-ui/react";
 import { save } from "@tauri-apps/plugin-dialog";
 import { useRouter } from "next/router";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { GameVersionSelector } from "@/components/game-version-selector";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";

--- a/src/components/modals/download-java-modal.tsx
+++ b/src/components/modals/download-java-modal.tsx
@@ -1,14 +1,12 @@
 import {
   Button,
   Grid,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Text,
   VStack,
 } from "@chakra-ui/react";
@@ -18,6 +16,8 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuExternalLink } from "react-icons/lu";
 import { MenuSelector } from "@/components/common/menu-selector";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
 import { ConfigService } from "@/services/config";

--- a/src/components/modals/download-modpack-modal.tsx
+++ b/src/components/modals/download-modpack-modal.tsx
@@ -1,16 +1,16 @@
 import {
   Flex,
   HStack,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Text,
 } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import ResourceDownloader from "@/components/resource-downloader";
 import { OtherResourceSource, OtherResourceType } from "@/enums/resource";
 

--- a/src/components/modals/download-resource-modal.tsx
+++ b/src/components/modals/download-resource-modal.tsx
@@ -2,13 +2,11 @@ import {
   Flex,
   HStack,
   Icon,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Text,
   Tooltip,
 } from "@chakra-ui/react";
@@ -23,6 +21,8 @@ import {
   LuPuzzle,
   LuSquareLibrary,
 } from "react-icons/lu";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import NavMenu from "@/components/common/nav-menu";
 import ResourceDownloader from "@/components/resource-downloader";
 import { useLauncherConfig } from "@/contexts/config";

--- a/src/components/modals/download-specific-resource-modal.tsx
+++ b/src/components/modals/download-specific-resource-modal.tsx
@@ -8,14 +8,12 @@ import {
   IconButton,
   Image,
   Link,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Popover,
   PopoverBody,
   PopoverContent,
@@ -43,6 +41,8 @@ import { BeatLoader } from "react-spinners";
 import CountTag from "@/components/common/count-tag";
 import Empty from "@/components/common/empty";
 import { MenuSelector } from "@/components/common/menu-selector";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import NavMenu from "@/components/common/nav-menu";
 import { OptionItem, OptionItemGroup } from "@/components/common/option-item";
 import { Section } from "@/components/common/section";

--- a/src/components/modals/edit-game-directory-modal.tsx
+++ b/src/components/modals/edit-game-directory-modal.tsx
@@ -14,14 +14,12 @@ import {
   Input,
   InputGroup,
   InputRightElement,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Stack,
   Tag,
   TagLabel,
@@ -30,6 +28,8 @@ import {
 import { open } from "@tauri-apps/plugin-dialog";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
 import { useRoutingHistory } from "@/contexts/routing-history";
@@ -74,6 +74,7 @@ export const ActionSelectDialog: React.FC<ActionSelectDialogProps> = ({
       onClose={modalProps.onClose}
       autoFocus={false}
       isCentered
+      returnFocusOnClose={false}
     >
       <AlertDialogOverlay>
         <AlertDialogContent>

--- a/src/components/modals/export-modpack-modal.tsx
+++ b/src/components/modals/export-modpack-modal.tsx
@@ -5,14 +5,12 @@ import {
   Checkbox,
   HStack,
   Icon,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   NumberInput,
   NumberInputField,
   Switch,
@@ -27,6 +25,8 @@ import { SiModrinth } from "react-icons/si";
 import { BeatLoader } from "react-spinners";
 import Editable from "@/components/common/editable";
 import Empty from "@/components/common/empty";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import {
   OptionItemGroup,
   OptionItemGroupProps,

--- a/src/components/modals/extension-info-modal.tsx
+++ b/src/components/modals/extension-info-modal.tsx
@@ -4,17 +4,17 @@ import {
   Button,
   Divider,
   HStack,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalOverlay,
-  ModalProps,
   Text,
   VStack,
 } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { OptionItem } from "@/components/common/option-item";
 import { useLauncherConfig } from "@/contexts/config";
 import { ExtensionInfo } from "@/models/extension";

--- a/src/components/modals/generic-confirm-dialog.tsx
+++ b/src/components/modals/generic-confirm-dialog.tsx
@@ -79,6 +79,7 @@ const GenericConfirmDialog: React.FC<GenericConfirmDialogProps> = ({
       onClose={handleCancel}
       autoFocus={false}
       isCentered
+      returnFocusOnClose={false}
       {...props}
     >
       <AlertDialogOverlay>

--- a/src/components/modals/import-account-info-modal.tsx
+++ b/src/components/modals/import-account-info-modal.tsx
@@ -5,14 +5,12 @@ import {
   Checkbox,
   Grid,
   HStack,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Text,
   Tooltip,
   VStack,
@@ -22,6 +20,8 @@ import { useTranslation } from "react-i18next";
 import { LuCircleX, LuTriangleAlert } from "react-icons/lu";
 import { BeatLoader } from "react-spinners";
 import Empty from "@/components/common/empty";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { OptionItemGroup } from "@/components/common/option-item";
 import { Section } from "@/components/common/section";
 import SelectableCard from "@/components/common/selectable-card";

--- a/src/components/modals/import-modpack-modal.tsx
+++ b/src/components/modals/import-modpack-modal.tsx
@@ -1,20 +1,20 @@
 import {
   Button,
   Center,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   VStack,
 } from "@chakra-ui/react";
 import { t } from "i18next";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { BeatLoader } from "react-spinners";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import {
   OptionItemGroup,
   OptionItemGroupProps,

--- a/src/components/modals/launch-process-modal.tsx
+++ b/src/components/modals/launch-process-modal.tsx
@@ -3,14 +3,12 @@ import {
   Button,
   HStack,
   Icon,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Step,
   StepDescription,
   StepIcon,
@@ -28,6 +26,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuX } from "react-icons/lu";
 import { BeatLoader } from "react-spinners";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import SelectInstanceModal from "@/components/modals/select-instance-modal";
 import SelectPlayerModal from "@/components/modals/select-player-modal";
 import { useLauncherConfig } from "@/contexts/config";

--- a/src/components/modals/manage-skin-modal.tsx
+++ b/src/components/modals/manage-skin-modal.tsx
@@ -7,14 +7,12 @@ import {
   HStack,
   IconButton,
   Input,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Radio,
   RadioGroup,
   Text,
@@ -26,6 +24,8 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuFolderOpen } from "react-icons/lu";
 import { AutoSizer } from "react-virtualized";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import SegmentedControl from "@/components/common/segmented";
 import SkinPreview from "@/components/skin-preview";
 import { useLauncherConfig } from "@/contexts/config";

--- a/src/components/modals/manual-add-java-path-modal.tsx
+++ b/src/components/modals/manual-add-java-path-modal.tsx
@@ -6,18 +6,18 @@ import {
   Input,
   InputGroup,
   InputRightElement,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
 } from "@chakra-ui/react";
 import { open } from "@tauri-apps/plugin-dialog";
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
 

--- a/src/components/modals/microsoft-friends-modal.tsx
+++ b/src/components/modals/microsoft-friends-modal.tsx
@@ -5,14 +5,12 @@ import {
   HStack,
   Input,
   Link,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Tag,
   TagLabel,
   Text,
@@ -33,6 +31,8 @@ import {
 } from "react-icons/lu";
 import { BeatLoader } from "react-spinners";
 import { CommonIconButton } from "@/components/common/common-icon-button";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { OptionItemGroup } from "@/components/common/option-item";
 import PlayerAvatar from "@/components/player-avatar";
 import { useLauncherConfig } from "@/contexts/config";

--- a/src/components/modals/mod-info-modal.tsx
+++ b/src/components/modals/mod-info-modal.tsx
@@ -2,13 +2,11 @@ import {
   Avatar,
   Button,
   HStack,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalOverlay,
-  ModalProps,
   Tag,
   Text,
 } from "@chakra-ui/react";
@@ -16,6 +14,8 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuExternalLink } from "react-icons/lu";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { OptionItem } from "@/components/common/option-item";
 import { useLauncherConfig } from "@/contexts/config";
 import { ModLoaderType } from "@/enums/instance";

--- a/src/components/modals/notify-new-version-modal.tsx
+++ b/src/components/modals/notify-new-version-modal.tsx
@@ -1,19 +1,19 @@
 import {
   Button,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
 } from "@chakra-ui/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useRouter } from "next/router";
 import { useTranslation } from "react-i18next";
 import { LuExternalLink } from "react-icons/lu";
 import MarkdownContainer from "@/components/common/markdown-container";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
 import { VersionMetaInfo } from "@/models/config";

--- a/src/components/modals/preview-screenshot-modal.tsx
+++ b/src/components/modals/preview-screenshot-modal.tsx
@@ -3,12 +3,10 @@ import {
   HStack,
   Icon,
   Image,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalOverlay,
-  ModalProps,
   Text,
 } from "@chakra-ui/react";
 import { convertFileSrc } from "@tauri-apps/api/core";
@@ -17,6 +15,8 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { LuCalendarDays, LuImagePlay } from "react-icons/lu";
 import { CommonIconButton } from "@/components/common/common-icon-button";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
 import { ScreenshotInfo } from "@/models/instance/misc";

--- a/src/components/modals/relogin-player-modal.tsx
+++ b/src/components/modals/relogin-player-modal.tsx
@@ -3,20 +3,20 @@ import {
   FormControl,
   FormLabel,
   Input,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Text,
   VStack,
 } from "@chakra-ui/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import OAuthLoginPanel from "@/components/oauth-login-panel";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";

--- a/src/components/modals/select-instance-modal.tsx
+++ b/src/components/modals/select-instance-modal.tsx
@@ -1,14 +1,14 @@
 import {
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
 } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import InstancesView from "@/components/instances-view";
 import { InstanceSummary } from "@/models/instance/misc";
 

--- a/src/components/modals/select-player-modal.tsx
+++ b/src/components/modals/select-player-modal.tsx
@@ -1,14 +1,14 @@
 import {
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
 } from "@chakra-ui/react";
 import { useTranslation } from "react-i18next";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import PlayersView from "@/components/players-view";
 import { Player } from "@/models/account";
 

--- a/src/components/modals/spotlight-search-modal.tsx
+++ b/src/components/modals/spotlight-search-modal.tsx
@@ -8,12 +8,10 @@ import {
   InputGroup,
   InputLeftElement,
   Kbd,
-  Modal,
   ModalBody,
   ModalContent,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Spinner,
   Tag,
   Text,
@@ -26,6 +24,8 @@ import { useTranslation } from "react-i18next";
 import { LuSearch } from "react-icons/lu";
 import CountTag from "@/components/common/count-tag";
 import Empty from "@/components/common/empty";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { OptionItem, OptionItemGroup } from "@/components/common/option-item";
 import PlayerAvatar from "@/components/player-avatar";
 import { useLauncherConfig } from "@/contexts/config";

--- a/src/components/modals/star-us-modal.tsx
+++ b/src/components/modals/star-us-modal.tsx
@@ -1,17 +1,17 @@
 import {
   Button,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Text,
 } from "@chakra-ui/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useTranslation } from "react-i18next";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 
 const StarUsModal: React.FC<Omit<ModalProps, "children">> = ({ ...props }) => {
   const { t } = useTranslation();

--- a/src/components/modals/sync-config-modals.tsx
+++ b/src/components/modals/sync-config-modals.tsx
@@ -6,20 +6,20 @@ import {
   FormLabel,
   HStack,
   Heading,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   PinInput,
   PinInputField,
   Text,
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import { useLauncherConfig } from "@/contexts/config";
 import { useToast } from "@/contexts/toast";
 import { ConfigService } from "@/services/config";

--- a/src/components/modals/view-skin-modal.tsx
+++ b/src/components/modals/view-skin-modal.tsx
@@ -1,15 +1,15 @@
 import {
   Flex,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
 } from "@chakra-ui/react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import SkinPreview from "@/components/skin-preview";
 import { Texture } from "@/models/account";
 import { base64ImgSrc } from "@/utils/string";

--- a/src/components/modals/welcome-and-terms-modal.tsx
+++ b/src/components/modals/welcome-and-terms-modal.tsx
@@ -5,19 +5,19 @@ import {
   HStack,
   Image,
   Link,
-  Modal,
   ModalBody,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Text,
 } from "@chakra-ui/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { exit } from "@tauri-apps/plugin-process";
 import { Trans, useTranslation } from "react-i18next";
 import { LuLanguages } from "react-icons/lu";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import LanguageMenu from "@/components/language-menu";
 import { useGuidedTour } from "@/components/special/guided-tour-provider";
 import { useLauncherConfig } from "@/contexts/config";

--- a/src/components/modals/world-level-data-modal.tsx
+++ b/src/components/modals/world-level-data-modal.tsx
@@ -2,20 +2,20 @@ import {
   Badge,
   Center,
   HStack,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  ModalProps,
   Text,
 } from "@chakra-ui/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { BeatLoader } from "react-spinners";
 import Empty from "@/components/common/empty";
+import { Modal } from "@/components/common/modal";
+import type { ModalProps } from "@/components/common/modal";
 import TreeView, {
   StructTreeNodeData,
   buildStructTreeNodes,

--- a/src/components/special/guided-tour-provider.tsx
+++ b/src/components/special/guided-tour-provider.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   HStack,
   Kbd,
-  Modal,
   ModalBody,
   ModalCloseButton,
   ModalContent,
@@ -31,6 +30,7 @@ import React, {
   useState,
 } from "react";
 import { Trans, useTranslation } from "react-i18next";
+import { Modal } from "@/components/common/modal";
 import { useLauncherConfig } from "@/contexts/config";
 import { clamp } from "@/utils/math";
 

--- a/src/contexts/extension/host.tsx
+++ b/src/contexts/extension/host.tsx
@@ -1719,6 +1719,7 @@ const ActiveExtensionHostContextProvider: React.FC<{
               key={modal.resetKey}
               isOpen={modalState.isOpen}
               onClose={close}
+              returnFocusOnClose={false}
             >
               <ChakraUI.ModalOverlay />
               <ChakraUI.ModalContent>


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - fix #834 

### Description

> - Prevent returning focus after closing modal by setting `returnFocusOnClose` to false

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Standardize modal behavior to avoid returning focus to the trigger element when modals and alert dialogs close.

Bug Fixes:
- Ensure all Chakra-based modals use a shared wrapper that disables returning focus on close by default.
- Disable focus return on close for alert dialogs and extension host modals to prevent unwanted focus jumps.