### PR TITLE
fix(frontend): prevent returning focus after closing modal

### DIFF
--- a/src/components/modals/add-auth-server-modal.tsx
+++ b/src/components/modals/add-auth-server-modal.tsx
@@ -123,9 +123,9 @@ const AddAuthServerModal: React.FC<AddAuthServerModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       size={{ base: "md", lg: "lg", xl: "xl" }}
       initialFocusRef={initialRef}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/add-auth-server-modal.tsx
+++ b/src/components/modals/add-auth-server-modal.tsx
@@ -123,6 +123,7 @@ const AddAuthServerModal: React.FC<AddAuthServerModalProps> = ({
 
   return (
     <Modal
+      returnFocusOnClose={false}
       size={{ base: "md", lg: "lg", xl: "xl" }}
       initialFocusRef={initialRef}
       {...modalProps}

--- a/src/components/modals/add-game-server-modal.tsx
+++ b/src/components/modals/add-game-server-modal.tsx
@@ -89,6 +89,7 @@ const AddGameServerModal: React.FC<AddGameServerModalProps> = ({
 
   return (
     <Modal
+      returnFocusOnClose={false}
       size={{ base: "md", lg: "lg", xl: "xl" }}
       initialFocusRef={initialRef}
       {...modalProps}

--- a/src/components/modals/add-game-server-modal.tsx
+++ b/src/components/modals/add-game-server-modal.tsx
@@ -89,9 +89,9 @@ const AddGameServerModal: React.FC<AddGameServerModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       size={{ base: "md", lg: "lg", xl: "xl" }}
       initialFocusRef={initialRef}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/add-player-modal.tsx
+++ b/src/components/modals/add-player-modal.tsx
@@ -307,9 +307,9 @@ const AddPlayerModal: React.FC<AddPlayerModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       size={{ base: "md", lg: "lg", xl: "xl" }}
       initialFocusRef={initialRef}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/add-player-modal.tsx
+++ b/src/components/modals/add-player-modal.tsx
@@ -307,6 +307,7 @@ const AddPlayerModal: React.FC<AddPlayerModalProps> = ({
 
   return (
     <Modal
+      returnFocusOnClose={false}
       size={{ base: "md", lg: "lg", xl: "xl" }}
       initialFocusRef={initialRef}
       {...modalProps}

--- a/src/components/modals/add-post-source-modal.tsx
+++ b/src/components/modals/add-post-source-modal.tsx
@@ -39,7 +39,7 @@ const AddDiscoverSourceModal: React.FC<Omit<ModalProps, "children">> = ({
   };
 
   return (
-    <Modal {...props} onClose={handleCloseModal}>
+    <Modal returnFocusOnClose={false} {...props} onClose={handleCloseModal}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("AddDiscoverSourceModal.modal.header")}</ModalHeader>

--- a/src/components/modals/alert-resource-dependency-modal.tsx
+++ b/src/components/modals/alert-resource-dependency-modal.tsx
@@ -201,6 +201,7 @@ const AlertResourceDependencyModal: React.FC<
 
   return (
     <Modal
+      returnFocusOnClose={false}
       scrollBehavior="inside"
       size={{ base: "md", lg: "lg", xl: "xl" }}
       {...modalProps}

--- a/src/components/modals/alert-resource-dependency-modal.tsx
+++ b/src/components/modals/alert-resource-dependency-modal.tsx
@@ -201,9 +201,9 @@ const AlertResourceDependencyModal: React.FC<
 
   return (
     <Modal
-      returnFocusOnClose={false}
       scrollBehavior="inside"
       size={{ base: "md", lg: "lg", xl: "xl" }}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/change-loader-modal.tsx
+++ b/src/components/modals/change-loader-modal.tsx
@@ -146,6 +146,7 @@ export const ChangeLoaderModal: React.FC<ChangeLoaderModalProps> = ({
     <Modal
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
+      returnFocusOnClose={false}
       onCloseComplete={() => {
         setSelectedModLoader(defaultModLoaderResourceInfo);
         setSelectedOptifine(undefined);

--- a/src/components/modals/check-mod-update-modal.tsx
+++ b/src/components/modals/check-mod-update-modal.tsx
@@ -306,9 +306,9 @@ const CheckModUpdateModal: React.FC<CheckModUpdateModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/check-mod-update-modal.tsx
+++ b/src/components/modals/check-mod-update-modal.tsx
@@ -306,6 +306,7 @@ const CheckModUpdateModal: React.FC<CheckModUpdateModalProps> = ({
 
   return (
     <Modal
+      returnFocusOnClose={false}
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
       {...modalProps}

--- a/src/components/modals/copy-or-move-modal.tsx
+++ b/src/components/modals/copy-or-move-modal.tsx
@@ -276,9 +276,9 @@ const CopyOrMoveModal: React.FC<CopyOrMoveModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       size={{ base: "md", lg: "lg", xl: "xl" }}
       scrollBehavior="inside"
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/copy-or-move-modal.tsx
+++ b/src/components/modals/copy-or-move-modal.tsx
@@ -276,6 +276,7 @@ const CopyOrMoveModal: React.FC<CopyOrMoveModalProps> = ({
 
   return (
     <Modal
+      returnFocusOnClose={false}
       size={{ base: "md", lg: "lg", xl: "xl" }}
       scrollBehavior="inside"
       {...modalProps}

--- a/src/components/modals/create-instance-modal.tsx
+++ b/src/components/modals/create-instance-modal.tsx
@@ -368,9 +368,9 @@ export const CreateInstanceModal: React.FC<Omit<ModalProps, "children">> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/create-instance-modal.tsx
+++ b/src/components/modals/create-instance-modal.tsx
@@ -368,6 +368,7 @@ export const CreateInstanceModal: React.FC<Omit<ModalProps, "children">> = ({
 
   return (
     <Modal
+      returnFocusOnClose={false}
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
       {...modalProps}

--- a/src/components/modals/download-game-server-modal.tsx
+++ b/src/components/modals/download-game-server-modal.tsx
@@ -64,9 +64,9 @@ export const DownloadGameServerModal: React.FC<
 
   return (
     <Modal
-      returnFocusOnClose={false}
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/download-game-server-modal.tsx
+++ b/src/components/modals/download-game-server-modal.tsx
@@ -64,6 +64,7 @@ export const DownloadGameServerModal: React.FC<
 
   return (
     <Modal
+      returnFocusOnClose={false}
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
       {...modalProps}

--- a/src/components/modals/download-java-modal.tsx
+++ b/src/components/modals/download-java-modal.tsx
@@ -157,8 +157,8 @@ export const DownloadJavaModal: React.FC<Omit<ModalProps, "children">> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       size={{ base: "sm", lg: "md" }}
+      returnFocusOnClose={false}
       {...props}
     >
       <ModalOverlay />

--- a/src/components/modals/download-java-modal.tsx
+++ b/src/components/modals/download-java-modal.tsx
@@ -156,7 +156,11 @@ export const DownloadJavaModal: React.FC<Omit<ModalProps, "children">> = ({
   };
 
   return (
-    <Modal size={{ base: "sm", lg: "md" }} {...props}>
+    <Modal
+      returnFocusOnClose={false}
+      size={{ base: "sm", lg: "md" }}
+      {...props}
+    >
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("DownloadJavaModal.header.title")}</ModalHeader>

--- a/src/components/modals/download-modpack-modal.tsx
+++ b/src/components/modals/download-modpack-modal.tsx
@@ -28,9 +28,9 @@ export const DownloadModpackModal: React.FC<DownloadModpackModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/download-modpack-modal.tsx
+++ b/src/components/modals/download-modpack-modal.tsx
@@ -28,6 +28,7 @@ export const DownloadModpackModal: React.FC<DownloadModpackModalProps> = ({
 
   return (
     <Modal
+      returnFocusOnClose={false}
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
       {...modalProps}

--- a/src/components/modals/download-resource-modal.tsx
+++ b/src/components/modals/download-resource-modal.tsx
@@ -71,6 +71,7 @@ const DownloadResourceModal: React.FC<DownloadResourceModalProps> = ({
 
   return (
     <Modal
+      returnFocusOnClose={false}
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
       {...modalProps}

--- a/src/components/modals/download-resource-modal.tsx
+++ b/src/components/modals/download-resource-modal.tsx
@@ -71,9 +71,9 @@ const DownloadResourceModal: React.FC<DownloadResourceModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/download-specific-resource-modal.tsx
+++ b/src/components/modals/download-specific-resource-modal.tsx
@@ -633,10 +633,10 @@ const DownloadSpecificResourceModal: React.FC<
 
   return (
     <Modal
-      returnFocusOnClose={false}
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
       autoFocus={false}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/download-specific-resource-modal.tsx
+++ b/src/components/modals/download-specific-resource-modal.tsx
@@ -633,6 +633,7 @@ const DownloadSpecificResourceModal: React.FC<
 
   return (
     <Modal
+      returnFocusOnClose={false}
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
       autoFocus={false}

--- a/src/components/modals/edit-game-directory-modal.tsx
+++ b/src/components/modals/edit-game-directory-modal.tsx
@@ -73,6 +73,7 @@ export const ActionSelectDialog: React.FC<ActionSelectDialogProps> = ({
       leastDestructiveRef={cancelRef}
       onClose={modalProps.onClose}
       autoFocus={false}
+      returnFocusOnClose={false}
       isCentered
     >
       <AlertDialogOverlay>
@@ -289,6 +290,7 @@ const EditGameDirectoryModal: React.FC<EditGameDirectoryModalProps> = ({
 
   return (
     <Modal
+      returnFocusOnClose={false}
       size={{ base: "md", lg: "lg", xl: "xl" }}
       initialFocusRef={initialRef}
       {...modalProps}

--- a/src/components/modals/edit-game-directory-modal.tsx
+++ b/src/components/modals/edit-game-directory-modal.tsx
@@ -290,9 +290,9 @@ const EditGameDirectoryModal: React.FC<EditGameDirectoryModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       size={{ base: "md", lg: "lg", xl: "xl" }}
       initialFocusRef={initialRef}
+      returnFocusOnClose={false}
       {...modalProps}
       onClose={handleCloseModal}
     >

--- a/src/components/modals/export-modpack-modal.tsx
+++ b/src/components/modals/export-modpack-modal.tsx
@@ -561,6 +561,7 @@ const ExportModpackModal: React.FC<ExportModpackModalProps> = ({
 
   return (
     <Modal
+      returnFocusOnClose={false}
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
       {...modalProps}

--- a/src/components/modals/export-modpack-modal.tsx
+++ b/src/components/modals/export-modpack-modal.tsx
@@ -561,9 +561,9 @@ const ExportModpackModal: React.FC<ExportModpackModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/extension-info-modal.tsx
+++ b/src/components/modals/extension-info-modal.tsx
@@ -48,8 +48,8 @@ const ExtensionInfoModal: React.FC<ExtensionInfoModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       size={{ base: "md", lg: "lg", xl: "xl" }}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/extension-info-modal.tsx
+++ b/src/components/modals/extension-info-modal.tsx
@@ -47,7 +47,11 @@ const ExtensionInfoModal: React.FC<ExtensionInfoModalProps> = ({
   );
 
   return (
-    <Modal size={{ base: "md", lg: "lg", xl: "xl" }} {...modalProps}>
+    <Modal
+      returnFocusOnClose={false}
+      size={{ base: "md", lg: "lg", xl: "xl" }}
+      {...modalProps}
+    >
       <ModalOverlay />
       <ModalContent>
         <ModalCloseButton />

--- a/src/components/modals/generic-confirm-dialog.tsx
+++ b/src/components/modals/generic-confirm-dialog.tsx
@@ -78,6 +78,7 @@ const GenericConfirmDialog: React.FC<GenericConfirmDialogProps> = ({
       leastDestructiveRef={cancelRef}
       onClose={handleCancel}
       autoFocus={false}
+      returnFocusOnClose={false}
       isCentered
       {...props}
     >

--- a/src/components/modals/import-account-info-modal.tsx
+++ b/src/components/modals/import-account-info-modal.tsx
@@ -241,9 +241,9 @@ const ImportAccountInfoModal: React.FC<ImportAccountInfoModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
+      returnFocusOnClose={false}
       {...props}
     >
       <ModalOverlay />

--- a/src/components/modals/import-account-info-modal.tsx
+++ b/src/components/modals/import-account-info-modal.tsx
@@ -241,6 +241,7 @@ const ImportAccountInfoModal: React.FC<ImportAccountInfoModalProps> = ({
 
   return (
     <Modal
+      returnFocusOnClose={false}
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
       {...props}

--- a/src/components/modals/import-modpack-modal.tsx
+++ b/src/components/modals/import-modpack-modal.tsx
@@ -192,10 +192,10 @@ const ImportModpackModal: React.FC<ImportModpackModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
       autoFocus={false}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/import-modpack-modal.tsx
+++ b/src/components/modals/import-modpack-modal.tsx
@@ -192,6 +192,7 @@ const ImportModpackModal: React.FC<ImportModpackModalProps> = ({
 
   return (
     <Modal
+      returnFocusOnClose={false}
       scrollBehavior="inside"
       size={{ base: "2xl", lg: "3xl", xl: "4xl" }}
       autoFocus={false}

--- a/src/components/modals/launch-process-modal.tsx
+++ b/src/components/modals/launch-process-modal.tsx
@@ -340,10 +340,10 @@ const LaunchProcessModal: React.FC<LaunchProcessModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       size="sm"
       closeOnEsc={false}
       closeOnOverlayClick={false}
+      returnFocusOnClose={false}
       {...props}
       onClose={handleCloseModalWithCancel}
     >

--- a/src/components/modals/launch-process-modal.tsx
+++ b/src/components/modals/launch-process-modal.tsx
@@ -340,6 +340,7 @@ const LaunchProcessModal: React.FC<LaunchProcessModalProps> = ({
 
   return (
     <Modal
+      returnFocusOnClose={false}
       size="sm"
       closeOnEsc={false}
       closeOnOverlayClick={false}

--- a/src/components/modals/manage-skin-modal.tsx
+++ b/src/components/modals/manage-skin-modal.tsx
@@ -207,6 +207,7 @@ const ManageSkinModal: React.FC<ManageSkinModalProps> = ({
 
   return (
     <Modal
+      returnFocusOnClose={false}
       isOpen={isOpen}
       onClose={onClose}
       size={

--- a/src/components/modals/manage-skin-modal.tsx
+++ b/src/components/modals/manage-skin-modal.tsx
@@ -207,7 +207,6 @@ const ManageSkinModal: React.FC<ManageSkinModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       isOpen={isOpen}
       onClose={onClose}
       size={
@@ -215,6 +214,7 @@ const ManageSkinModal: React.FC<ManageSkinModalProps> = ({
           ? { base: "2xl", lg: "3xl", xl: "4xl" }
           : { base: "md", lg: "lg", xl: "xl" }
       }
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/manual-add-java-path-modal.tsx
+++ b/src/components/modals/manual-add-java-path-modal.tsx
@@ -81,7 +81,7 @@ const ManualAddJavaPathModal: React.FC<ManualAddJavaPathModalProps> = ({
   };
 
   return (
-    <Modal {...props} onClose={handleClose}>
+    <Modal returnFocusOnClose={false} {...props} onClose={handleClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("ManualAddJavaPathModal.modal.header")}</ModalHeader>

--- a/src/components/modals/microsoft-friends-modal.tsx
+++ b/src/components/modals/microsoft-friends-modal.tsx
@@ -387,6 +387,7 @@ const MicrosoftFriendsModal: React.FC<MicrosoftFriendsModalProps> = ({
 
   return (
     <Modal
+      returnFocusOnClose={false}
       size={{ base: "lg", xl: "2xl" }}
       scrollBehavior="inside"
       {...modalProps}

--- a/src/components/modals/microsoft-friends-modal.tsx
+++ b/src/components/modals/microsoft-friends-modal.tsx
@@ -387,9 +387,9 @@ const MicrosoftFriendsModal: React.FC<MicrosoftFriendsModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       size={{ base: "lg", xl: "2xl" }}
       scrollBehavior="inside"
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/mod-info-modal.tsx
+++ b/src/components/modals/mod-info-modal.tsx
@@ -105,8 +105,8 @@ const ModInfoModal: React.FC<ModInfoModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       size={{ base: "md", lg: "lg", xl: "xl" }}
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/mod-info-modal.tsx
+++ b/src/components/modals/mod-info-modal.tsx
@@ -104,7 +104,11 @@ const ModInfoModal: React.FC<ModInfoModalProps> = ({
   }, [handleCurseForgeInfo, handleModrinthInfo]);
 
   return (
-    <Modal size={{ base: "md", lg: "lg", xl: "xl" }} {...modalProps}>
+    <Modal
+      returnFocusOnClose={false}
+      size={{ base: "md", lg: "lg", xl: "xl" }}
+      {...modalProps}
+    >
       <ModalOverlay />
       <ModalContent>
         <ModalCloseButton />

--- a/src/components/modals/notify-new-version-modal.tsx
+++ b/src/components/modals/notify-new-version-modal.tsx
@@ -69,9 +69,9 @@ const NotifyNewVersionModal: React.FC<NotifyNewVersionModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       scrollBehavior="inside"
       size="xl"
+      returnFocusOnClose={false}
       {...props}
     >
       <ModalOverlay />

--- a/src/components/modals/notify-new-version-modal.tsx
+++ b/src/components/modals/notify-new-version-modal.tsx
@@ -68,7 +68,12 @@ const NotifyNewVersionModal: React.FC<NotifyNewVersionModalProps> = ({
   };
 
   return (
-    <Modal scrollBehavior="inside" size="xl" {...props}>
+    <Modal
+      returnFocusOnClose={false}
+      scrollBehavior="inside"
+      size="xl"
+      {...props}
+    >
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{`${t("NotifyNewVersionModal.title")} - ${newVersion.version}`}</ModalHeader>

--- a/src/components/modals/preview-screenshot-modal.tsx
+++ b/src/components/modals/preview-screenshot-modal.tsx
@@ -94,8 +94,8 @@ const PreviewScreenshotModal: React.FC<PreviewScreenshotModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       size={{ base: "lg", lg: "2xl", xl: "4xl" }}
+      returnFocusOnClose={false}
       {...props}
     >
       <ModalOverlay />

--- a/src/components/modals/preview-screenshot-modal.tsx
+++ b/src/components/modals/preview-screenshot-modal.tsx
@@ -93,7 +93,11 @@ const PreviewScreenshotModal: React.FC<PreviewScreenshotModalProps> = ({
   ];
 
   return (
-    <Modal size={{ base: "lg", lg: "2xl", xl: "4xl" }} {...props}>
+    <Modal
+      returnFocusOnClose={false}
+      size={{ base: "lg", lg: "2xl", xl: "4xl" }}
+      {...props}
+    >
       <ModalOverlay />
       <ModalContent>
         <Image

--- a/src/components/modals/relogin-player-modal.tsx
+++ b/src/components/modals/relogin-player-modal.tsx
@@ -124,7 +124,7 @@ const ReLoginPlayerModal: React.FC<ReLoginPlayerModalProps> = ({
   };
 
   return (
-    <Modal {...props} onClose={handleCloseModal}>
+    <Modal returnFocusOnClose={false} {...props} onClose={handleCloseModal}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("ReLoginPlayerModal.modal.title")}</ModalHeader>

--- a/src/components/modals/select-instance-modal.tsx
+++ b/src/components/modals/select-instance-modal.tsx
@@ -29,7 +29,7 @@ const SelectInstanceModal: React.FC<SelectInstanceModalProps> = ({
   const { t } = useTranslation();
 
   return (
-    <Modal returnFocusOnClose={false} scrollBehavior="inside" {...modalProps}>
+    <Modal scrollBehavior="inside" returnFocusOnClose={false} {...modalProps}>
       <ModalOverlay />
       <ModalContent maxH="calc(100vh - 7.5rem)">
         <ModalHeader>

--- a/src/components/modals/select-instance-modal.tsx
+++ b/src/components/modals/select-instance-modal.tsx
@@ -29,7 +29,7 @@ const SelectInstanceModal: React.FC<SelectInstanceModalProps> = ({
   const { t } = useTranslation();
 
   return (
-    <Modal scrollBehavior="inside" {...modalProps}>
+    <Modal returnFocusOnClose={false} scrollBehavior="inside" {...modalProps}>
       <ModalOverlay />
       <ModalContent maxH="calc(100vh - 7.5rem)">
         <ModalHeader>

--- a/src/components/modals/select-player-modal.tsx
+++ b/src/components/modals/select-player-modal.tsx
@@ -29,7 +29,7 @@ const SelectPlayerModal: React.FC<SelectPlayerModalProps> = ({
   const { t } = useTranslation();
 
   return (
-    <Modal returnFocusOnClose={false} scrollBehavior="inside" {...modalProps}>
+    <Modal scrollBehavior="inside" returnFocusOnClose={false} {...modalProps}>
       <ModalOverlay />
       <ModalContent maxH="calc(100vh - 7.5rem)">
         <ModalHeader>

--- a/src/components/modals/select-player-modal.tsx
+++ b/src/components/modals/select-player-modal.tsx
@@ -29,7 +29,7 @@ const SelectPlayerModal: React.FC<SelectPlayerModalProps> = ({
   const { t } = useTranslation();
 
   return (
-    <Modal scrollBehavior="inside" {...modalProps}>
+    <Modal returnFocusOnClose={false} scrollBehavior="inside" {...modalProps}>
       <ModalOverlay />
       <ModalContent maxH="calc(100vh - 7.5rem)">
         <ModalHeader>

--- a/src/components/modals/spotlight-search-modal.tsx
+++ b/src/components/modals/spotlight-search-modal.tsx
@@ -494,7 +494,7 @@ const SpotlightSearchModal: React.FC<Omit<ModalProps, "children">> = ({
   };
 
   return (
-    <Modal returnFocusOnClose={false} scrollBehavior="inside" {...props}>
+    <Modal scrollBehavior="inside" returnFocusOnClose={false} {...props}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>

--- a/src/components/modals/spotlight-search-modal.tsx
+++ b/src/components/modals/spotlight-search-modal.tsx
@@ -494,7 +494,7 @@ const SpotlightSearchModal: React.FC<Omit<ModalProps, "children">> = ({
   };
 
   return (
-    <Modal scrollBehavior="inside" {...props}>
+    <Modal returnFocusOnClose={false} scrollBehavior="inside" {...props}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>

--- a/src/components/modals/star-us-modal.tsx
+++ b/src/components/modals/star-us-modal.tsx
@@ -22,7 +22,12 @@ const StarUsModal: React.FC<Omit<ModalProps, "children">> = ({ ...props }) => {
   };
 
   return (
-    <Modal autoFocus={false} size={{ base: "sm", lg: "md" }} {...props}>
+    <Modal
+      returnFocusOnClose={false}
+      autoFocus={false}
+      size={{ base: "sm", lg: "md" }}
+      {...props}
+    >
       <ModalOverlay />
       <ModalContent borderRadius="md" overflow="hidden">
         <video autoPlay loop muted width="100%" height="auto">

--- a/src/components/modals/star-us-modal.tsx
+++ b/src/components/modals/star-us-modal.tsx
@@ -23,9 +23,9 @@ const StarUsModal: React.FC<Omit<ModalProps, "children">> = ({ ...props }) => {
 
   return (
     <Modal
-      returnFocusOnClose={false}
       autoFocus={false}
       size={{ base: "sm", lg: "md" }}
+      returnFocusOnClose={false}
       {...props}
     >
       <ModalOverlay />

--- a/src/components/modals/sync-config-modals.tsx
+++ b/src/components/modals/sync-config-modals.tsx
@@ -85,6 +85,7 @@ export const SyncConfigExportModal: React.FC<SyncConfigModalProps> = ({
 
   return (
     <Modal
+      returnFocusOnClose={false}
       size={{ base: "md", lg: "lg", xl: "xl" }}
       {...modalProps}
       onClose={handleCloseModal}
@@ -163,6 +164,7 @@ export const SyncConfigImportModal: React.FC<SyncConfigModalProps> = ({
 
   return (
     <Modal
+      returnFocusOnClose={false}
       size={{ base: "md", lg: "lg", xl: "xl" }}
       {...modalProps}
       onClose={handleCloseModal}

--- a/src/components/modals/sync-config-modals.tsx
+++ b/src/components/modals/sync-config-modals.tsx
@@ -85,8 +85,8 @@ export const SyncConfigExportModal: React.FC<SyncConfigModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       size={{ base: "md", lg: "lg", xl: "xl" }}
+      returnFocusOnClose={false}
       {...modalProps}
       onClose={handleCloseModal}
     >
@@ -164,8 +164,8 @@ export const SyncConfigImportModal: React.FC<SyncConfigModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       size={{ base: "md", lg: "lg", xl: "xl" }}
+      returnFocusOnClose={false}
       {...modalProps}
       onClose={handleCloseModal}
     >

--- a/src/components/modals/view-skin-modal.tsx
+++ b/src/components/modals/view-skin-modal.tsx
@@ -30,7 +30,13 @@ const ViewSkinModal: React.FC<ViewSkinModalProps> = ({
   const { t } = useTranslation();
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} size="md" {...modalProps}>
+    <Modal
+      returnFocusOnClose={false}
+      isOpen={isOpen}
+      onClose={onClose}
+      size="md"
+      {...modalProps}
+    >
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>{t("ViewSkinModal.skinView")}</ModalHeader>

--- a/src/components/modals/view-skin-modal.tsx
+++ b/src/components/modals/view-skin-modal.tsx
@@ -31,10 +31,10 @@ const ViewSkinModal: React.FC<ViewSkinModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       isOpen={isOpen}
       onClose={onClose}
       size="md"
+      returnFocusOnClose={false}
       {...modalProps}
     >
       <ModalOverlay />

--- a/src/components/modals/welcome-and-terms-modal.tsx
+++ b/src/components/modals/welcome-and-terms-modal.tsx
@@ -49,6 +49,7 @@ const WelcomeAndTermsModal: React.FC<Omit<ModalProps, "children">> = ({
 
   return (
     <Modal
+      returnFocusOnClose={false}
       autoFocus={false}
       closeOnEsc={false}
       closeOnOverlayClick={false}

--- a/src/components/modals/welcome-and-terms-modal.tsx
+++ b/src/components/modals/welcome-and-terms-modal.tsx
@@ -49,11 +49,11 @@ const WelcomeAndTermsModal: React.FC<Omit<ModalProps, "children">> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       autoFocus={false}
       closeOnEsc={false}
       closeOnOverlayClick={false}
       size={{ base: "sm", lg: "md" }}
+      returnFocusOnClose={false}
       {...props}
     >
       <ModalOverlay />

--- a/src/components/modals/world-level-data-modal.tsx
+++ b/src/components/modals/world-level-data-modal.tsx
@@ -80,10 +80,10 @@ const WorldLevelDataModal: React.FC<WorldLevelDataModalProps> = ({
 
   return (
     <Modal
-      returnFocusOnClose={false}
       autoFocus={false}
       size={{ base: "md", lg: "lg", xl: "xl" }}
       scrollBehavior="inside"
+      returnFocusOnClose={false}
       {...props}
     >
       <ModalOverlay />

--- a/src/components/modals/world-level-data-modal.tsx
+++ b/src/components/modals/world-level-data-modal.tsx
@@ -80,6 +80,7 @@ const WorldLevelDataModal: React.FC<WorldLevelDataModalProps> = ({
 
   return (
     <Modal
+      returnFocusOnClose={false}
       autoFocus={false}
       size={{ base: "md", lg: "lg", xl: "xl" }}
       scrollBehavior="inside"

--- a/src/components/special/guided-tour-provider.tsx
+++ b/src/components/special/guided-tour-provider.tsx
@@ -356,6 +356,7 @@ export const GuidedTourProvider: React.FC<TourProviderProps> = ({
         onClose={close}
         isCentered={false}
         closeOnOverlayClick={false}
+        returnFocusOnClose={false}
         blockScrollOnMount
         trapFocus
         // disable default animations in next steps


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - fix #834

### Description

> - Prevent returning focus after closing modal by setting `returnFocusOnClose` to false.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Bug Fixes:
- Prevent multiple frontend modals from restoring focus to the trigger element by setting returnFocusOnClose to false across the modal components.