### PR TITLE
fix(frontend): add default flex shrink params to menu selector, prevent display issue in settings

### DIFF
--- a/src/components/common/menu-selector.tsx
+++ b/src/components/common/menu-selector.tsx
@@ -81,6 +81,7 @@ export const MenuSelector: React.FC<MenuSelectorProps> = ({
         variant="outline"
         textAlign="left"
         w="auto"
+        flexShrink={0}
         {...buttonProps}
       >
         {renderButtonLabel()}

--- a/src/components/language-menu.tsx
+++ b/src/components/language-menu.tsx
@@ -22,9 +22,6 @@ const LanguageMenu: React.FC<Omit<MenuProps, "children">> = ({ ...props }) => {
         label: val.display_name,
       }))}
       size="xs"
-      buttonProps={{
-        flex: "0 0 auto",
-      }}
     />
   );
 };

--- a/src/pages/settings/general.tsx
+++ b/src/pages/settings/general.tsx
@@ -174,9 +174,6 @@ const GeneralSettingsPage = () => {
               placeholder={t(
                 `GeneralSettingsPage.functions.settings.discoverPage.${generalConfigs.functionality.discoverPage}`
               )}
-              buttonProps={{
-                flex: "0 0 auto",
-              }}
             />
           ),
         },


### PR DESCRIPTION
### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

fix #1690 

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Bug Fixes:
- Fix layout issue where language and general settings selectors could shrink or display incorrectly by centralizing flex behavior in the menu selector button.