### PR TITLE
feat(ci): build and upload portable artifacts in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,8 +99,8 @@ jobs:
           #   args: '--target aarch64-apple-darwin'
           - platform: 'ubuntu-latest'
             args: ''
-          # - platform: 'windows-latest'
-          #   args: ''
+          - platform: 'windows-latest'
+            args: ''
 
     steps:
       - uses: actions/checkout@v4
@@ -131,3 +131,28 @@ jobs:
         run: npx tauri build ${{ matrix.args }}
         env:
           SJMCL_CURSEFORGE_API_KEY: ${{ secrets.SJMCL_CURSEFORGE_API_KEY }}
+
+      - name: Build portable artifact
+        id: portable
+        if: matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-latest'
+        shell: bash
+        run: |
+          mkdir -p artifacts
+          if [ "${{ matrix.platform }}" = "windows-latest" ]; then
+            python scripts/release/bundle_portable_assets.py -p "src-tauri/target/release/" -o "SJMCL-patched.exe" "SJMCL.exe"
+            cp "src-tauri/target/release/SJMCL-patched.exe" artifacts/
+            echo "platform_tag=windows" >> "$GITHUB_OUTPUT"
+          else
+            python scripts/release/bundle_portable_assets.py -p "src-tauri/target/release/" -o "SJMCL-patched" "SJMCL"
+            cp "src-tauri/target/release/SJMCL-patched" artifacts/
+            echo "platform_tag=linux" >> "$GITHUB_OUTPUT"
+          fi
+          echo "short_sha=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload portable artifact
+        if: matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: SJMCL_${{ steps.portable.outputs.platform_tag }}_x86_64_portable_test-${{ steps.portable.outputs.short_sha }}
+          path: artifacts/*
+          if-no-files-found: error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,20 +135,20 @@ jobs:
           if [ "${{ matrix.platform }}" = "windows-latest" ]; then
             OUTPUT_NAME="SJMCL-${SHORT_SHA}.exe"
             python scripts/release/bundle_portable_assets.py -p "src-tauri/target/release/" -o "$OUTPUT_NAME" "SJMCL.exe"
-            cp "src-tauri/target/release/$OUTPUT_NAME" artifacts/
             echo "platform_tag=windows" >> "$GITHUB_OUTPUT"
           else
             OUTPUT_NAME="SJMCL-${SHORT_SHA}"
             python scripts/release/bundle_portable_assets.py -p "src-tauri/target/release/" -o "$OUTPUT_NAME" "SJMCL"
-            cp "src-tauri/target/release/$OUTPUT_NAME" artifacts/
             echo "platform_tag=linux" >> "$GITHUB_OUTPUT"
           fi
+          cp "src-tauri/target/release/$OUTPUT_NAME" artifacts/
+          echo "output_name=$OUTPUT_NAME" >> "$GITHUB_OUTPUT"
           echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Upload portable artifact
         if: matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
-          name: SJMCL_${{ steps.portable.outputs.platform_tag }}_x86_64_portable_test-${{ steps.portable.outputs.short_sha }}
-          path: artifacts/*
+          path: artifacts/${{ steps.portable.outputs.output_name }}
+          archive: false
           if-no-files-found: error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,16 +131,19 @@ jobs:
         shell: bash
         run: |
           mkdir -p artifacts
+          SHORT_SHA="${GITHUB_SHA:0:7}"
           if [ "${{ matrix.platform }}" = "windows-latest" ]; then
-            python scripts/release/bundle_portable_assets.py -p "src-tauri/target/release/" -o "SJMCL-patched.exe" "SJMCL.exe"
-            cp "src-tauri/target/release/SJMCL-patched.exe" artifacts/
+            OUTPUT_NAME="SJMCL-${SHORT_SHA}.exe"
+            python scripts/release/bundle_portable_assets.py -p "src-tauri/target/release/" -o "$OUTPUT_NAME" "SJMCL.exe"
+            cp "src-tauri/target/release/$OUTPUT_NAME" artifacts/
             echo "platform_tag=windows" >> "$GITHUB_OUTPUT"
           else
-            python scripts/release/bundle_portable_assets.py -p "src-tauri/target/release/" -o "SJMCL-patched" "SJMCL"
-            cp "src-tauri/target/release/SJMCL-patched" artifacts/
+            OUTPUT_NAME="SJMCL-${SHORT_SHA}"
+            python scripts/release/bundle_portable_assets.py -p "src-tauri/target/release/" -o "$OUTPUT_NAME" "SJMCL"
+            cp "src-tauri/target/release/$OUTPUT_NAME" artifacts/
             echo "platform_tag=linux" >> "$GITHUB_OUTPUT"
           fi
-          echo "short_sha=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Upload portable artifact
         if: matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,11 +76,8 @@ jobs:
       - name: Lint JavaScript/TypeScript Frontend
         run: npx eslint 'src/**/*.{js,jsx,ts,tsx}' --no-fix --max-warnings=0 
       
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
           components: rustfmt
 
       - name: Lint Rust Backend
@@ -116,19 +113,15 @@ jobs:
           node-version: lts/*
       - run: npm install
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          target: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin' || '' }}
+      - uses: dtolnay/rust-toolchain@stable
 
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: "./src-tauri -> target"
-          key: ${{ matrix.platform }}-${{ matrix.args }}
+          key: ${{ matrix.platform }}
 
       - name: Test Build
-        run: npx tauri build ${{ matrix.args }}
+        run: npm run tauri build -- ${{ matrix.args }}
         env:
           SJMCL_CURSEFORGE_API_KEY: ${{ secrets.SJMCL_CURSEFORGE_API_KEY }}
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

#1712 

### Description

test workflow通过后上传编译结果

### Additional Context

## Summary by Sourcery

Update the test workflow to build multiplatform Tauri artifacts and upload portable binaries for Linux and Windows on successful test builds.

New Features:
- Build and package portable Tauri artifacts for Linux and Windows during the test workflow and upload them as GitHub Actions artifacts.

Enhancements:
- Switch Rust setup in CI to use the dtolnay/rust-toolchain action and simplify caching keys and build invocation in the test workflow.

CI:
- Enable Windows in the Tauri test build matrix and extend the test workflow to generate and upload portable artifacts for supported platforms.