### PR TITLE
chore(nsis): replace nsis v3.11 text with sjmcl copyright text

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,6 +31,7 @@
       "app"
     ],
     "category": "Game",
+    "copyright": "Copyright © 2024-2026 SJMCL Team",
     "icon": [
       "assets/icons/32x32.png",
       "assets/icons/64x64.png",


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [x] ❓ Other (Please specify below)

### Related Issues

N/A

### Description

Replace the ugly `Nullsoft Install System v3.11` with the SJMCL Team’s copyright notice 🌠 😎

### Additional Context

| Before | After |
|--------|--------|
| <img width="499" height="388" alt="Image1" src="https://github.com/user-attachments/assets/c8a7853b-4aa6-4f0f-9282-ac5cfece2791" /> | <img width="499" height="388" alt="Image2" src="https://github.com/user-attachments/assets/a0b09697-b0e7-4dd6-a672-8957aa9b15a7" /> |

## Summary by Sourcery

Chores:
- Adjust NSIS-related text in tauri.conf.json so the installer displays the SJMCL Team copyright notice.