### PR TITLE
fix(instance): align launcher metadata placeholders

### DIFF
--- a/src-tauri/src/launch/helpers/command_generator.rs
+++ b/src-tauri/src/launch/helpers/command_generator.rs
@@ -183,10 +183,10 @@ pub async fn generate_launch_command(
     version_type: if !game_config.game_window.custom_info.is_empty() {
       game_config.game_window.custom_info.clone()
     } else {
-      format!("SJMCL {}", basic_info.launcher_version)
+      client_info.type_.clone()
     },
     natives_directory: natives_dir.to_string_lossy().to_string(),
-    launcher_name: format!("SJMCL {}", basic_info.launcher_version),
+    launcher_name: "SJMCL".to_string(),
     launcher_version: basic_info.launcher_version,
     library_directory: libraries_dir.to_string_lossy().to_string(),
     classpath_separator: get_separator().to_string(),

--- a/src-tauri/src/launch/helpers/command_generator.rs
+++ b/src-tauri/src/launch/helpers/command_generator.rs
@@ -186,7 +186,7 @@ pub async fn generate_launch_command(
       client_info.type_.clone()
     },
     natives_directory: natives_dir.to_string_lossy().to_string(),
-    launcher_name: "SJMCL".to_string(),
+    launcher_name: "SJMC Launcher".to_string(),
     launcher_version: basic_info.launcher_version,
     library_directory: libraries_dir.to_string_lossy().to_string(),
     classpath_separator: get_separator().to_string(),


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - fix #1681

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Bug Fixes:
- Correct launcher metadata fields in generated launch command to use the client type and a static launcher name instead of embedding the launcher version in multiple places.