### PR TITLE
fix: allow Linux removable drive run paths

### DIFF
--- a/src-tauri/src/launcher_config/helpers/misc.rs
+++ b/src-tauri/src/launcher_config/helpers/misc.rs
@@ -217,7 +217,7 @@ pub fn check_exe_path_availability(app: &AppHandle) -> bool {
       || exe_str.starts_with("/var/tmp/")
       || exe_str.starts_with("/var/cache/")
       || exe_str.starts_with("/dev/shm/")
-      // /run/media is the default udisks mount point for removable drives on Linux.
+      // /run is tmpfs, while /run/media is a common mount point on some Linux distributions.
       || (exe_str.starts_with("/run/") && !exe_str.starts_with("/run/media/"))
       || exe_str.contains("/Trash/"))
   }

--- a/src-tauri/src/launcher_config/helpers/misc.rs
+++ b/src-tauri/src/launcher_config/helpers/misc.rs
@@ -217,7 +217,8 @@ pub fn check_exe_path_availability(app: &AppHandle) -> bool {
       || exe_str.starts_with("/var/tmp/")
       || exe_str.starts_with("/var/cache/")
       || exe_str.starts_with("/dev/shm/")
-      || exe_str.starts_with("/run/")
+      // /run/media is the default udisks mount point for removable drives on Linux.
+      || (exe_str.starts_with("/run/") && !exe_str.starts_with("/run/media/"))
       || exe_str.contains("/Trash/"))
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - fix #1683

## Summary by Sourcery

Bug Fixes:
- Allow applications located on Linux removable drives mounted under /run/media to pass the executable path availability validation.