### PR TITLE
fix(resource): sort NeoForge loader versions by full version

### DIFF
--- a/src-tauri/src/resource/helpers/loader_meta/neoforge.rs
+++ b/src-tauri/src/resource/helpers/loader_meta/neoforge.rs
@@ -113,7 +113,7 @@ async fn get_neoforge_meta_by_game_version_official(
     return Err(ResourceError::ParseError.into());
   };
 
-  let mut results: Vec<(i32, ModLoaderResourceInfo)> = Vec::new();
+  let mut results: Vec<(Vec<i32>, ModLoaderResourceInfo)> = Vec::new();
 
   for version_value in version_list {
     if let Some(version) = version_value.as_str() {
@@ -156,12 +156,20 @@ async fn get_neoforge_meta_by_game_version_official(
         };
 
         if matches_game_version {
-          let sort_key: i32 = if is_april_fools {
-            cap[2].parse()?
-          } else if let Some(m) = cap.get(6) {
-            m.as_str().parse()?
+          let sort_key: Vec<i32> = if is_april_fools {
+            vec![cap[2].parse()?]
           } else {
-            cap[3].parse()?
+            let patch: i32 = cap[3].parse()?;
+            let build: i32 = cap.get(4).map_or(Ok(0), |m| m.as_str().parse::<i32>())?;
+            let release_rank = match cap.get(5).map(|m| m.as_str()) {
+              None => 3,
+              Some("rc") => 2,
+              Some("beta") => 1,
+              Some("alpha") => 0,
+              Some(_) => 0,
+            };
+            let prerelease: i32 = cap.get(6).map_or(Ok(0), |m| m.as_str().parse::<i32>())?;
+            vec![patch, build, release_rank, prerelease]
           };
 
           let stable = if is_april_fools {
@@ -185,7 +193,7 @@ async fn get_neoforge_meta_by_game_version_official(
     }
   }
 
-  results.sort_by_key(|b| std::cmp::Reverse(b.0));
+  results.sort_by(|a, b| b.0.cmp(&a.0));
   Ok(results.into_iter().map(|r| r.1).collect())
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - fix #1696

## Summary by Sourcery

Bug Fixes:
- Correct NeoForge loader version ordering by using a composite sort key that reflects full version details instead of a single numeric field.