### PR TITLE
docs(readme): add install warnings for snap and winget

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Install from Snap Store:
 sudo snap install sjmcl
 ```
 
+> [!WARNING]
+> When installing via Snap, game data may be stored in a sandboxed directory by default. Before uninstalling the launcher, please back up important data such as saves, resource packs, and mods in a timely manner.
+
 </details>
 
 <details>
@@ -100,6 +103,9 @@ Install with Winget:
 ```powershell
 winget install SJMC.SJMCL
 ```
+
+> [!WARNING]
+> The Winget index is publicly maintained. Before installing, consider running `winget show SJMC.SJMCL` to inspect the installer URL, and make sure the download source is from `github.com/UNIkeEN/SJMCL` or `sjmcl.club`.
 
 </details>
 

--- a/docs/README.zh-Hans.md
+++ b/docs/README.zh-Hans.md
@@ -79,6 +79,9 @@ makepkg -si
 sudo snap install sjmcl
 ```
 
+> [!WARNING]
+> 使用 Snap 安装时，游戏数据可能会默认存放在沙盒目录内。卸载启动器前，请及时备份存档、资源包、模组等重要数据。
+
 </details>
 
 <details>
@@ -100,6 +103,9 @@ brew install --cask SJMC-Dev/SJMCL/sjmcl
 ```powershell
 winget install SJMC.SJMCL
 ```
+
+> [!WARNING]
+> Winget 的索引仓库是公开协作维护的。安装前建议运行 `winget show SJMC.SJMCL` 查看安装器地址，并确认下载来源来自 `github.com/UNIkeEN/SJMCL` 或 `sjmcl.club`。
 
 </details>
 

--- a/docs/README.zh-Hant.md
+++ b/docs/README.zh-Hant.md
@@ -79,6 +79,9 @@ makepkg -si
 sudo snap install sjmcl
 ```
 
+> [!WARNING]
+> 使用 Snap 安裝時，遊戲資料可能會預設存放在沙盒目錄內。解除安裝啟動器前，請及時備份存檔、資源包、模組等重要資料。
+
 </details>
 
 <details>
@@ -100,6 +103,9 @@ brew install --cask SJMC-Dev/SJMCL/sjmcl
 ```powershell
 winget install SJMC.SJMCL
 ```
+
+> [!WARNING]
+> Winget 的索引倉庫是公開協作維護的。安裝前建議執行 `winget show SJMC.SJMCL` 檢視安裝器位址，並確認下載來源來自 `github.com/UNIkeEN/SJMCL` 或 `sjmcl.club`。
 
 </details>
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [x] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

### Description

增加snap和winget的warning，与官网同步

### Additional Context

## Summary by Sourcery

Document additional installation warnings for Snap and Winget package sources across all localized READMEs.

Documentation:
- Add a warning about Snap installs storing game data in sandboxed directories and the need to back up saves and other data before uninstalling.
- Add a warning about verifying the Winget installer source and URL before installation in English, Simplified Chinese, and Traditional Chinese READMEs.