### PR TITLE
feat(ci): speed up test builds with a dedicated profile and enable devtools

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,9 +95,7 @@ jobs:
           # - platform: macos-latest
           #   args: '--target aarch64-apple-darwin'
           - platform: 'ubuntu-latest'
-            args: ''
           - platform: 'windows-latest'
-            args: ''
 
     steps:
       - uses: actions/checkout@v4
@@ -121,7 +119,7 @@ jobs:
           key: ${{ matrix.platform }}
 
       - name: Test Build
-        run: npm run tauri build -- --profile test-build --features devtools --no-bundle ${{ matrix.args }}
+        run: npm run tauri build -- --features devtools --no-bundle -- --profile test-build
         env:
           SJMCL_CURSEFORGE_API_KEY: ${{ secrets.SJMCL_CURSEFORGE_API_KEY }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,7 +121,7 @@ jobs:
           key: ${{ matrix.platform }}
 
       - name: Test Build
-        run: npm run tauri build -- --profile ci --features devtools --no-bundle ${{ matrix.args }}
+        run: npm run tauri build -- --profile test-build --features devtools --no-bundle ${{ matrix.args }}
         env:
           SJMCL_CURSEFORGE_API_KEY: ${{ secrets.SJMCL_CURSEFORGE_API_KEY }}
 
@@ -134,12 +134,12 @@ jobs:
           SHORT_SHA="${GITHUB_SHA:0:7}"
           if [ "${{ matrix.platform }}" = "windows-latest" ]; then
             OUTPUT_NAME="SJMCL_${SHORT_SHA}_windows_x86_64_portable.exe"
-            python scripts/release/bundle_portable_assets.py -p "src-tauri/target/ci/" -o "$OUTPUT_NAME" "SJMCL.exe"
+            python scripts/release/bundle_portable_assets.py -p "src-tauri/target/test-build/" -o "$OUTPUT_NAME" "SJMCL.exe"
           else
             OUTPUT_NAME="SJMCL_${SHORT_SHA}_linux_x86_64_portable"
-            python scripts/release/bundle_portable_assets.py -p "src-tauri/target/ci/" -o "$OUTPUT_NAME" "SJMCL"
+            python scripts/release/bundle_portable_assets.py -p "src-tauri/target/test-build/" -o "$OUTPUT_NAME" "SJMCL"
           fi
-          cp "src-tauri/target/ci/$OUTPUT_NAME" artifacts/
+          cp "src-tauri/target/test-build/$OUTPUT_NAME" artifacts/
           echo "output_name=$OUTPUT_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Upload portable artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,7 +121,7 @@ jobs:
           key: ${{ matrix.platform }}
 
       - name: Test Build
-        run: npm run tauri build -- --profile ci --features devtools ${{ matrix.args }}
+        run: npm run tauri build -- --profile ci --features devtools --no-bundle ${{ matrix.args }}
         env:
           SJMCL_CURSEFORGE_API_KEY: ${{ secrets.SJMCL_CURSEFORGE_API_KEY }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,7 +121,7 @@ jobs:
           key: ${{ matrix.platform }}
 
       - name: Test Build
-        run: npm run tauri build -- ${{ matrix.args }}
+        run: npm run tauri build -- --profile ci --features devtools ${{ matrix.args }}
         env:
           SJMCL_CURSEFORGE_API_KEY: ${{ secrets.SJMCL_CURSEFORGE_API_KEY }}
 
@@ -134,14 +134,14 @@ jobs:
           SHORT_SHA="${GITHUB_SHA:0:7}"
           if [ "${{ matrix.platform }}" = "windows-latest" ]; then
             OUTPUT_NAME="SJMCL-${SHORT_SHA}.exe"
-            python scripts/release/bundle_portable_assets.py -p "src-tauri/target/release/" -o "$OUTPUT_NAME" "SJMCL.exe"
+            python scripts/release/bundle_portable_assets.py -p "src-tauri/target/ci/" -o "$OUTPUT_NAME" "SJMCL.exe"
             echo "platform_tag=windows" >> "$GITHUB_OUTPUT"
           else
             OUTPUT_NAME="SJMCL-${SHORT_SHA}"
-            python scripts/release/bundle_portable_assets.py -p "src-tauri/target/release/" -o "$OUTPUT_NAME" "SJMCL"
+            python scripts/release/bundle_portable_assets.py -p "src-tauri/target/ci/" -o "$OUTPUT_NAME" "SJMCL"
             echo "platform_tag=linux" >> "$GITHUB_OUTPUT"
           fi
-          cp "src-tauri/target/release/$OUTPUT_NAME" artifacts/
+          cp "src-tauri/target/ci/$OUTPUT_NAME" artifacts/
           echo "output_name=$OUTPUT_NAME" >> "$GITHUB_OUTPUT"
           echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,6 +118,9 @@ jobs:
           workspaces: "./src-tauri -> target"
           key: ${{ matrix.platform }}
 
+      - name: Bump version for test build
+        run: npm run version bump 0.0.1
+
       - name: Test Build
         run: npm run tauri build -- --features devtools --no-bundle -- --profile test-build
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,17 +133,14 @@ jobs:
           mkdir -p artifacts
           SHORT_SHA="${GITHUB_SHA:0:7}"
           if [ "${{ matrix.platform }}" = "windows-latest" ]; then
-            OUTPUT_NAME="SJMCL-${SHORT_SHA}.exe"
+            OUTPUT_NAME="SJMCL_${SHORT_SHA}_windows_x86_64_portable.exe"
             python scripts/release/bundle_portable_assets.py -p "src-tauri/target/ci/" -o "$OUTPUT_NAME" "SJMCL.exe"
-            echo "platform_tag=windows" >> "$GITHUB_OUTPUT"
           else
-            OUTPUT_NAME="SJMCL-${SHORT_SHA}"
+            OUTPUT_NAME="SJMCL_${SHORT_SHA}_linux_x86_64_portable"
             python scripts/release/bundle_portable_assets.py -p "src-tauri/target/ci/" -o "$OUTPUT_NAME" "SJMCL"
-            echo "platform_tag=linux" >> "$GITHUB_OUTPUT"
           fi
           cp "src-tauri/target/ci/$OUTPUT_NAME" artifacts/
           echo "output_name=$OUTPUT_NAME" >> "$GITHUB_OUTPUT"
-          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Upload portable artifact
         if: matrix.platform == 'windows-latest' || matrix.platform == 'ubuntu-latest'

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,8 +30,8 @@ panic = "abort"
 
 # Faster-to-compile profile for CI test builds. Inherits the release baseline
 # (strip, panic=abort) but drops the costly optimizations (opt-level=3, lto).
-# Used only by the test workflow via `tauri build -- --profile ci`.
-[profile.ci]
+# Used only by the test workflow via `tauri build -- --profile test-build`.
+[profile.test-build]
 inherits = "release"
 opt-level = 1
 lto = false

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,11 +16,25 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 dotenvy = "0.15.7"
 tauri-build = { version = "2.6.1", features = [] }
 
+[features]
+default = []
+# Enables WebView DevTools in optimized builds. Off by default so production
+# releases never ship an inspector; CI portable builds opt in via --features devtools.
+devtools = ["tauri/devtools"]
+
 [profile.release]
 opt-level = 3   # as default
 strip = true
 lto = true
 panic = "abort"
+
+# Faster-to-compile profile for CI test builds. Inherits the release baseline
+# (strip, panic=abort) but drops the costly optimizations (opt-level=3, lto).
+# Used only by the test workflow via `tauri build -- --profile ci`.
+[profile.ci]
+inherits = "release"
+opt-level = 1
+lto = false
 
 [patch.crates-io]
 expat-sys = { git = "https://github.com/SJMC-dev/libexpat.git" }

--- a/src-tauri/src/launcher_config/helpers/misc.rs
+++ b/src-tauri/src/launcher_config/helpers/misc.rs
@@ -19,6 +19,7 @@ impl LauncherConfig {
     let version = match (is_dev, app.package_info().version.to_string().as_str()) {
       (true, _) => "dev".to_string(),
       (false, "0.0.0") => "nightly".to_string(),
+      (false, "0.0.1") => "test-build".to_string(),
       (false, v) => v.to_string(),
     };
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -320,17 +320,6 @@ pub async fn run() {
           }
         }
 
-        // Open DevTools automatically in dev-enabled builds (e.g. CI portable artifacts).
-        // Compiled out of production releases since the `devtools` feature is off by default.
-        #[cfg(feature = "devtools")]
-        {
-          if let Some(main_window) = app.get_webview_window("main") {
-            main_window.open_devtools();
-          } else {
-            log::warn!("Failed to open DevTools: main window not found.");
-          }
-        }
-
         // Registering the deep links at runtime on Linux and Windows
         // ref: https://v2.tauri.app/plugin/deep-linking/#registering-desktop-deep-links-at-runtime
         #[cfg(any(target_os = "linux", target_os = "windows"))]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -320,6 +320,17 @@ pub async fn run() {
           }
         }
 
+        // Open DevTools automatically in dev-enabled builds (e.g. CI portable artifacts).
+        // Compiled out of production releases since the `devtools` feature is off by default.
+        #[cfg(feature = "devtools")]
+        {
+          if let Some(main_window) = app.get_webview_window("main") {
+            main_window.open_devtools();
+          } else {
+            log::warn!("Failed to open DevTools: main window not found.");
+          }
+        }
+
         // Registering the deep links at runtime on Linux and Windows
         // ref: https://v2.tauri.app/plugin/deep-linking/#registering-desktop-deep-links-at-runtime
         #[cfg(any(target_os = "linux", target_os = "windows"))]


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues


### Description

* 降低编译/链接优化等级以加速test workflow中构建速度
* 为test build启用devtools

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Introduce a dedicated, faster Rust profile and devtools feature for CI test builds and adjust the test workflow to use them for portable artifacts.

New Features:
- Add a `devtools` Cargo feature to enable Tauri WebView DevTools in non-production builds and open them automatically when enabled.

Enhancements:
- Define a `test-build` Cargo profile with reduced optimization and disabled LTO for quicker CI builds.
- Retarget CI portable artifact bundling to use the new `test-build` output directory and adopt clearer platform-specific artifact names in the test workflow.

CI:
- Update the test GitHub Actions workflow to use the new `test-build` profile with devtools enabled and skip bundling during test builds.