### PR TITLE
feat(game_config): add display resolution preset list with upbound detection

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -186,6 +186,7 @@ pub async fn run() {
         tasks::commands::resume_progressive_task_group,
         tasks::commands::delete_progressive_task_group,
         utils::commands::retrieve_memory_info,
+        utils::commands::retrieve_resolution_upbound,
         utils::commands::retrieve_truetype_font_list,
         utils::commands::check_service_availability,
         utils::commands::extract_filename,

--- a/src-tauri/src/utils/commands.rs
+++ b/src-tauri/src/utils/commands.rs
@@ -22,19 +22,17 @@ pub fn retrieve_resolution_upbound(app: AppHandle) -> SJMCLResult<(u32, u32)> {
     .and_then(|w| w.available_monitors().ok())
     .unwrap_or_default();
 
-  Ok(
-    monitors
-      .iter()
-      .max_by_key(|m| {
-        let s = m.size();
-        s.width * s.height
-      })
-      .map(|m| {
-        let s = m.size();
-        (s.width, s.height)
-      })
-      .unwrap_or((0, 0)),
-  )
+  monitors
+    .iter()
+    .max_by_key(|m| {
+      let s = m.size();
+      s.width * s.height
+    })
+    .map(|m| {
+      let s = m.size();
+      (s.width, s.height)
+    })
+    .ok_or_else(|| SJMCLError("No monitor available".into()))
 }
 
 #[tauri::command]

--- a/src-tauri/src/utils/commands.rs
+++ b/src-tauri/src/utils/commands.rs
@@ -5,6 +5,7 @@ use crate::utils::sys_info::get_memory_info;
 use base64::{Engine, engine::general_purpose};
 use font_loader::system_fonts;
 use std::fs;
+use tauri::{AppHandle, Manager, State};
 use tauri_plugin_http::reqwest;
 use tokio::time::Instant;
 use url::Url;
@@ -15,6 +16,28 @@ pub fn retrieve_memory_info() -> SJMCLResult<MemoryInfo> {
 }
 
 #[tauri::command]
+pub fn retrieve_resolution_upbound(app: AppHandle) -> SJMCLResult<(u32, u32)> {
+  let monitors = app
+    .get_webview_window("main")
+    .and_then(|w| w.available_monitors().ok())
+    .unwrap_or_default();
+
+  Ok(
+    monitors
+      .iter()
+      .max_by_key(|m| {
+        let s = m.size();
+        s.width * s.height
+      })
+      .map(|m| {
+        let s = m.size();
+        (s.width, s.height)
+      })
+      .unwrap_or((0, 0)),
+  )
+}
+
+#[tauri::command]
 pub fn retrieve_truetype_font_list() -> SJMCLResult<Vec<String>> {
   let sysfonts = system_fonts::query_all();
   Ok(sysfonts)
@@ -22,7 +45,7 @@ pub fn retrieve_truetype_font_list() -> SJMCLResult<Vec<String>> {
 
 #[tauri::command]
 pub async fn check_service_availability(
-  client: tauri::State<'_, reqwest::Client>,
+  client: State<'_, reqwest::Client>,
   url: String,
 ) -> SJMCLResult<u128> {
   let parsed_url = Url::parse(&url)

--- a/src/components/common/menu-selector.tsx
+++ b/src/components/common/menu-selector.tsx
@@ -20,7 +20,7 @@ type OptionLabel = React.ReactNode | { title: string; desc: string };
 
 type MenuSelectorOption =
   | OptionValue
-  | { value: OptionValue; label: OptionLabel };
+  | { value: OptionValue; label: OptionLabel; disabled?: boolean };
 
 export interface MenuSelectorProps extends Omit<MenuProps, "children"> {
   options: MenuSelectorOption[];
@@ -126,9 +126,14 @@ export const MenuSelector: React.FC<MenuSelectorProps> = ({
           }}
         >
           {options.map((opt, i) => {
-            const { value: v, label } = buildOptions(opt);
+            const { value: v, label, disabled } = buildOptions(opt);
             return (
-              <MenuItemOption key={i} value={v} fontSize={fontSize}>
+              <MenuItemOption
+                key={i}
+                value={v}
+                fontSize={fontSize}
+                isDisabled={disabled}
+              >
                 {renderLabel(label)}
               </MenuItemOption>
             );

--- a/src/components/game-settings-groups.tsx
+++ b/src/components/game-settings-groups.tsx
@@ -104,6 +104,33 @@ const GameSettingsGroups: React.FC<GameSettingsGroupsProps> = ({
     return () => clearInterval(interval);
   }, []);
 
+  const [resolutionUpbound, setResolutionUpbound] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
+
+  const handleRetrieveResolutionUpbound = async () => {
+    const res = await UtilsService.retrieveResolutionUpbound();
+    if (res.status === "success") {
+      setResolutionUpbound({
+        width: res.data[0],
+        height: res.data[1],
+      });
+    }
+  };
+
+  useEffect(() => {
+    handleRetrieveResolutionUpbound();
+  }, []);
+
+  const resolutionPresets = [
+    { width: 854, height: 480 },
+    { width: 1280, height: 720 },
+    { width: 1920, height: 1080 },
+    { width: 2560, height: 1440 },
+    { width: 3840, height: 2160 },
+  ];
+
   const settingGroups: OptionItemGroupProps[] = [
     {
       title: t("GlobalGameSettingsPage.gameJava.title"),
@@ -151,12 +178,48 @@ const GameSettingsGroups: React.FC<GameSettingsGroupsProps> = ({
           title: t(
             "GlobalGameSettingsPage.gameWindow.settings.resolution.title"
           ),
+          description:
+            resolutionUpbound &&
+            (gameWindowWidth > resolutionUpbound.width ||
+              gameWindowHeight > resolutionUpbound.height) ? (
+              <Text fontSize="xs" className="warning-text">
+                {t(
+                  "GlobalGameSettingsPage.gameWindow.settings.resolution.warning"
+                )}
+              </Text>
+            ) : undefined,
           children: (
-            <HStack>
+            <HStack flexShrink={0}>
+              <MenuSelector
+                value=""
+                onSelect={(val) => {
+                  if (val == null) return;
+                  const preset = resolutionPresets[Number(val)];
+                  setGameWindowWidth(preset.width);
+                  setGameWindowHeight(preset.height);
+                  updateGameConfig("gameWindow.resolution.width", preset.width);
+                  updateGameConfig(
+                    "gameWindow.resolution.height",
+                    preset.height
+                  );
+                }}
+                options={resolutionPresets.map((p, i) => ({
+                  value: String(i),
+                  label: `${p.width} x ${p.height}`,
+                  disabled:
+                    resolutionUpbound != null &&
+                    (p.width > resolutionUpbound.width ||
+                      p.height > resolutionUpbound.height),
+                }))}
+                placeholder={t(
+                  "GlobalGameSettingsPage.gameWindow.settings.resolution.preset"
+                )}
+                buttonProps={{ variant: "subtle", rightIcon: undefined }}
+              />
               <NumberInput
                 min={400}
                 size="xs"
-                maxW={16}
+                maxW={12}
                 focusBorderColor={`${primaryColor}.500`}
                 value={gameWindowWidth}
                 onChange={(value) => {
@@ -179,7 +242,7 @@ const GameSettingsGroups: React.FC<GameSettingsGroupsProps> = ({
               <NumberInput
                 min={300}
                 size="xs"
-                maxW={16}
+                maxW={12}
                 focusBorderColor={`${primaryColor}.500`}
                 value={gameWindowHeight}
                 onChange={(value) => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1250,7 +1250,9 @@
       "settings": {
         "resolution": {
           "title": "Game Resolution",
-          "switch": "Fullscreen"
+          "preset": "Preset",
+          "switch": "Fullscreen",
+          "warning": "Resolution may exceed monitor limit"
         },
         "customTitle": {
           "title": "Custom Window Title"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1250,7 +1250,9 @@
       "settings": {
         "resolution": {
           "title": "Resolución del Juego",
-          "switch": "Pantalla Completa"
+          "preset": "Predefinido",
+          "switch": "Pantalla Completa",
+          "warning": "La resolución puede exceder el límite del monitor"
         },
         "customTitle": {
           "title": "Título de Ventana Personalizado"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1250,7 +1250,9 @@
       "settings": {
         "resolution": {
           "title": "Résolution du jeu",
-          "switch": "Plein écran"
+          "preset": "Préréglage",
+          "switch": "Plein écran",
+          "warning": "La résolution peut dépasser la limite du moniteur"
         },
         "customTitle": {
           "title": "Titre de la fenêtre personnalisée"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1250,7 +1250,9 @@
       "settings": {
         "resolution": {
           "title": "ゲーム解像度",
-          "switch": "フルスクリーン"
+          "preset": "プリセット",
+          "switch": "フルスクリーン",
+          "warning": "モニター上限を超える可能性あり"
         },
         "customTitle": {
           "title": "カスタムウィンドウタイトル"

--- a/src/locales/lzh.json
+++ b/src/locales/lzh.json
@@ -1250,7 +1250,9 @@
       "settings": {
         "resolution": {
           "title": "戲解析度",
-          "switch": "全幕"
+          "preset": "預定之度",
+          "switch": "全幕",
+          "warning": "此度或逾示器之極"
         },
         "customTitle": {
           "title": "自定匡標題"

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -1250,7 +1250,9 @@
       "settings": {
         "resolution": {
           "title": "游戏分辨率",
-          "switch": "全屏"
+          "preset": "预设",
+          "switch": "全屏",
+          "warning": "分辨率可能超出显示器上限"
         },
         "customTitle": {
           "title": "自定义窗口标题"

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -1250,7 +1250,9 @@
       "settings": {
         "resolution": {
           "title": "遊戲解析度",
-          "switch": "全螢幕"
+          "preset": "預設",
+          "switch": "全螢幕",
+          "warning": "解析度可能超出顯示器上限"
         },
         "customTitle": {
           "title": "自訂視窗標題"

--- a/src/services/utils.ts
+++ b/src/services/utils.ts
@@ -17,6 +17,17 @@ export class UtilsService {
   }
 
   /**
+   * RETRIEVE the maximum monitor resolution (upbound).
+   * @returns {Promise<InvokeResponse<[number, number]>>}
+   */
+  @responseHandler("utils")
+  static async retrieveResolutionUpbound(): Promise<
+    InvokeResponse<[number, number]>
+  > {
+    return await invoke("retrieve_resolution_upbound");
+  }
+
+  /**
    * RETRIEVE the list of installed TrueType fonts.
    * @returns {Promise<InvokeResponse<string[]>>}
    */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -66,6 +66,11 @@ body img {
   line-height: var(--chakra-lineHeights-4);
 }
 
+.warning-text {
+  color: var(--chakra-colors-yellow-500);
+  line-height: var(--chakra-lineHeights-4);
+}
+
 .allow-select {
   user-select: initial !important;
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

close #1735 

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Add display resolution presets to game window settings with automatic detection of the maximum available monitor resolution and UI feedback when selected values exceed it.

New Features:
- Introduce a resolution preset dropdown for game window settings with common resolution options.
- Add backend and frontend utilities to detect the maximum available monitor resolution and use it to constrain resolution choices and show warnings when exceeded.

Enhancements:
- Extend the generic menu selector component to support disabled options based on external constraints.
- Add a reusable warning text style for highlighted notices in the UI.