### PR TITLE
feat(game_config): add more game display resolution preset

### DIFF
--- a/src/components/game-settings-groups.tsx
+++ b/src/components/game-settings-groups.tsx
@@ -125,9 +125,15 @@ const GameSettingsGroups: React.FC<GameSettingsGroupsProps> = ({
 
   const resolutionPresets = [
     { width: 854, height: 480 },
+    { width: 960, height: 540 },
+    { width: 1024, height: 576 },
     { width: 1280, height: 720 },
+    { width: 1366, height: 768 },
+    { width: 1600, height: 900 },
     { width: 1920, height: 1080 },
+    { width: 2048, height: 1152 },
     { width: 2560, height: 1440 },
+    { width: 3200, height: 1800 },
     { width: 3840, height: 2160 },
   ];
 

--- a/src/components/game-settings-groups.tsx
+++ b/src/components/game-settings-groups.tsx
@@ -221,6 +221,7 @@ const GameSettingsGroups: React.FC<GameSettingsGroupsProps> = ({
                   "GlobalGameSettingsPage.gameWindow.settings.resolution.preset"
                 )}
                 buttonProps={{ variant: "subtle", rightIcon: undefined }}
+                menuListProps={{ maxH: "40vh", overflowY: "auto" }}
               />
               <NumberInput
                 min={400}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

N/A

### Description

The five presets alone weren’t quite enough to meet everyone’s needs. In this PR, I hope to add more resolution combinations based on the relevant Windows options and the related Wikipedia article.

ref: https://en.wikipedia.org/wiki/16:9_aspect_ratio

### Additional Context

N/A

## Summary by Sourcery

New Features:
- Add multiple intermediate display resolution presets between 480p and 4K for game configuration.