### PR TITLE
feat: add build metadata for nightly and test builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: string
         default: '' # leave empty to use the triggering ref
+      build_type:
+        description: 'Build type exposed to the app at compile time'
+        required: false
+        type: string
+        default: 'release'
     secrets:
       SJMCL_CURSEFORGE_API_KEY:
         required: true
@@ -65,6 +70,11 @@ jobs:
         with:
           ref: ${{ inputs.branch || github.ref || 'main' }} 
 
+      - name: Resolve build metadata
+        id: build_metadata
+        shell: bash
+        run: echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -106,6 +116,8 @@ jobs:
         run: npm run tauri build -- --target ${{ matrix.target }}
         env:
           SJMCL_CURSEFORGE_API_KEY: ${{ secrets.SJMCL_CURSEFORGE_API_KEY }}
+          SJMCL_BUILD_TYPE: ${{ inputs.build_type }}
+          SJMCL_COMMIT_SHA: ${{ steps.build_metadata.outputs.commit_sha }}
 
       - name: Patch portable executable
         if: matrix.platform == 'windows' || matrix.platform == 'linux'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -152,6 +152,7 @@ jobs:
       version: "nightly_${{ needs.Check-and-Prepare.outputs.nightly_version }}"
       upload_artifacts: true
       branch: "nightly"
+      build_type: "nightly"
     secrets:
       SJMCL_CURSEFORGE_API_KEY: ${{ secrets.SJMCL_CURSEFORGE_API_KEY }}
 
@@ -282,4 +283,4 @@ jobs:
             fi
           done
           
-          echo "Cleanup completed" 
+          echo "Cleanup completed"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,6 +125,9 @@ jobs:
         run: npm run tauri build -- --features devtools --no-bundle -- --profile test-build
         env:
           SJMCL_CURSEFORGE_API_KEY: ${{ secrets.SJMCL_CURSEFORGE_API_KEY }}
+          # Exposed to Rust as compile-time constants by build.rs (all SJMCL_* env vars).
+          SJMCL_BUILD_TYPE: test-build
+          SJMCL_COMMIT_SHA: ${{ github.sha }}
 
       - name: Build portable artifact
         id: portable

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -18,6 +18,7 @@ fn main() {
   // original naive impl, see: https://github.com/UNIkeEN/SJMCL/pull/412/files
   for (key, value) in env::vars() {
     if key.starts_with("SJMCL_") {
+      println!("cargo:rerun-if-env-changed={}", key);
       println!("cargo:rustc-env={}={}", key, value);
     }
   }

--- a/src-tauri/src/launcher_config/commands.rs
+++ b/src-tauri/src/launcher_config/commands.rs
@@ -333,13 +333,16 @@ pub async fn clear_download_cache(app: AppHandle) -> SJMCLResult<()> {
 #[tauri::command]
 pub async fn check_launcher_update(app: AppHandle) -> SJMCLResult<VersionMetaInfo> {
   let config_binding = app.state::<Mutex<LauncherConfig>>();
-  let current_version = {
+  let (current_version, build_type) = {
     let config_state = config_binding.lock()?;
-    config_state.basic_info.launcher_version.clone()
+    (
+      config_state.basic_info.launcher_version.clone(),
+      config_state.basic_info.build_type.clone(),
+    )
   };
 
-  // skip non-semver versions
-  if semver::Version::parse(&current_version).is_err() {
+  // skip non-release builds, then validate the version is a proper semver
+  if build_type != "release" || semver::Version::parse(&current_version).is_err() {
     return Ok(VersionMetaInfo::default());
   }
 

--- a/src-tauri/src/launcher_config/helpers/misc.rs
+++ b/src-tauri/src/launcher_config/helpers/misc.rs
@@ -110,6 +110,12 @@ impl LauncherConfig {
       // below set to default, will be updated later in first time calling `check_full_login_availability`
       is_china_mainland_ip: false,
       allow_full_login_feature: false,
+      // build metadata: compile-time constants injected by build.rs, falling back
+      // to "dev"/"release" derived from debug_assertions when not explicitly set.
+      build_type: option_env!("SJMCL_BUILD_TYPE")
+        .map(str::to_string)
+        .unwrap_or_else(|| if is_dev { "dev" } else { "release" }.to_string()),
+      build_commit_sha: option_env!("SJMCL_COMMIT_SHA").unwrap_or("").to_string(),
     };
 
     log::info!(

--- a/src-tauri/src/launcher_config/models.rs
+++ b/src-tauri/src/launcher_config/models.rs
@@ -204,6 +204,11 @@ structstruck::strike! {
       pub is_china_mainland_ip: bool,
       #[default = false]
       pub allow_full_login_feature: bool,
+      // Build metadata, sourced from compile-time constants injected by build.rs.
+      // Filled by setup_with_app; not meant to be edited by the user.
+      #[default = "dev"]
+      pub build_type: String,
+      pub build_commit_sha: String,
     },
     // mocked: false when invoked from the backend, true when the frontend placeholder data is used during loading.
     pub mocked: bool,

--- a/src/components/modals/welcome-and-terms-modal.tsx
+++ b/src/components/modals/welcome-and-terms-modal.tsx
@@ -36,12 +36,17 @@ const WelcomeAndTermsModal: React.FC<Omit<ModalProps, "children">> = ({
     startGuidedTour();
   };
 
-  const unstableVersionLabels = ["dev", "nightly", "beta"];
+  // Map build_type to an unstable-version label for the warning alert.
+  // release builds get no warning; the rest reuse General.version.<label>.
+  const buildTypeToLabel: Record<string, string> = {
+    dev: "dev",
+    nightly: "nightly",
+    "test-build": "test-build",
+  };
   const launcherVersion = config.basicInfo.launcherVersion;
-
   const matchedVersionLabel =
-    unstableVersionLabels.find((k) => launcherVersion.includes(k)) ||
-    (launcherVersion.startsWith("0.") ? "beta" : undefined);
+    buildTypeToLabel[config.basicInfo.buildType] ??
+    (launcherVersion.includes("beta") ? "beta" : undefined);
 
   const isWinArm64 =
     config.basicInfo.platform === "windows" &&

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1124,7 +1124,8 @@
     "version": {
       "dev": "development version",
       "nightly": "nightly build",
-      "beta": "beta version"
+      "beta": "beta version",
+      "test-build": "test build"
     },
     "viewOnWiki": "View on Minecraft Wiki"
   },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1124,7 +1124,8 @@
     "version": {
       "dev": "versión de desarrollo",
       "nightly": "compilación nocturna",
-      "beta": "versión beta"
+      "beta": "versión beta",
+      "test-build": "compilación de prueba"
     },
     "viewOnWiki": "Ver en Minecraft Wiki"
   },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1124,7 +1124,8 @@
     "version": {
       "dev": "Version de développement",
       "nightly": "Version de construction nocturne",
-      "beta": "Version de test"
+      "beta": "Version de test",
+      "test-build": "Version de construction de test"
     },
     "viewOnWiki": "Voir sur Minecraft Wiki"
   },

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1124,7 +1124,8 @@
     "version": {
       "dev": "開発版",
       "nightly": "ナイトリービルド版",
-      "beta": "ベータ版"
+      "beta": "ベータ版",
+      "test-build": "テストビルド版"
     },
     "viewOnWiki": "Minecraft Wiki へ"
   },

--- a/src/locales/lzh.json
+++ b/src/locales/lzh.json
@@ -1124,7 +1124,8 @@
     "version": {
       "dev": "開發版",
       "nightly": "夜間構建版",
-      "beta": "測試版"
+      "beta": "測試版",
+      "test-build": "測試構建版"
     },
     "viewOnWiki": "在 礦藝 Wiki 中覽"
   },

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -1124,7 +1124,8 @@
     "version": {
       "dev": "开发版本",
       "nightly": "夜间构建版本",
-      "beta": "测试版本"
+      "beta": "测试版本",
+      "test-build": "测试构建版本"
     },
     "viewOnWiki": "在 Minecraft Wiki 中查看"
   },

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -1124,7 +1124,8 @@
     "version": {
       "dev": "開發版本",
       "nightly": "夜間構建版本",
-      "beta": "測試版本"
+      "beta": "測試版本",
+      "test-build": "測試構建版本"
     },
     "viewOnWiki": "在 Minecraft Wiki 中檢視"
   },

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -75,6 +75,9 @@ export interface LauncherConfig {
     isExePathAvailable: boolean;
     isChinaMainlandIp: boolean;
     allowFullLoginFeature: boolean;
+    // Build metadata, sourced from compile-time constants injected by build.rs.
+    buildType: string;
+    buildCommitSha: string;
   };
   mocked: boolean;
   runCount: number;
@@ -254,6 +257,8 @@ export const defaultConfig: LauncherConfig = {
     isExePathAvailable: true,
     isChinaMainlandIp: false,
     allowFullLoginFeature: false,
+    buildType: "dev",
+    buildCommitSha: "",
   },
   mocked: true,
   runCount: -1,

--- a/src/pages/settings/about.tsx
+++ b/src/pages/settings/about.tsx
@@ -18,7 +18,7 @@ import { TitleFullWithLogo } from "@/components/logo-title";
 import { useLauncherConfig } from "@/contexts/config";
 import { useSharedModals } from "@/contexts/shared-modal";
 import { useToast } from "@/contexts/toast";
-import { isValidSemanticVersion } from "@/utils/string";
+import { formatLauncherVersion, isValidSemanticVersion } from "@/utils/string";
 
 const AboutSettingsPage = () => {
   const { t } = useTranslation();
@@ -76,7 +76,7 @@ const AboutSettingsPage = () => {
           children: (
             <HStack>
               <Text fontSize="xs-sm" className="secondary-text">
-                {`${basicInfo.launcherVersion}${basicInfo.isPortable ? " (Portable)" : ""}`}
+                {formatLauncherVersion(basicInfo)}
               </Text>
               {basicInfo.buildType === "release" &&
                 isValidSemanticVersion(basicInfo.launcherVersion) && (

--- a/src/pages/settings/about.tsx
+++ b/src/pages/settings/about.tsx
@@ -78,27 +78,30 @@ const AboutSettingsPage = () => {
               <Text fontSize="xs-sm" className="secondary-text">
                 {`${basicInfo.launcherVersion}${basicInfo.isPortable ? " (Portable)" : ""}`}
               </Text>
-              {isValidSemanticVersion(basicInfo.launcherVersion) && (
-                <Button
-                  variant="subtle"
-                  colorScheme={newerVersion.version ? primaryColor : "gray"}
-                  size="xs"
-                  onClick={
-                    newerVersion.version
-                      ? () => {
-                          openSharedModal("notify-new-version", {
-                            newVersion: newerVersion,
-                          });
-                        }
-                      : checkUpdate
-                  }
-                  isLoading={checkingUpdate}
-                >
-                  {newerVersion.version
-                    ? t("AboutSettingsPage.about.settings.version.foundNew")
-                    : t("AboutSettingsPage.about.settings.version.checkUpdate")}
-                </Button>
-              )}
+              {basicInfo.buildType === "release" &&
+                isValidSemanticVersion(basicInfo.launcherVersion) && (
+                  <Button
+                    variant="subtle"
+                    colorScheme={newerVersion.version ? primaryColor : "gray"}
+                    size="xs"
+                    onClick={
+                      newerVersion.version
+                        ? () => {
+                            openSharedModal("notify-new-version", {
+                              newVersion: newerVersion,
+                            });
+                          }
+                        : checkUpdate
+                    }
+                    isLoading={checkingUpdate}
+                  >
+                    {newerVersion.version
+                      ? t("AboutSettingsPage.about.settings.version.foundNew")
+                      : t(
+                          "AboutSettingsPage.about.settings.version.checkUpdate"
+                        )}
+                  </Button>
+                )}
             </HStack>
           ),
         },

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -124,3 +124,21 @@ export const isPathSanitized = (path: string, maxLength = 255): boolean => {
 
 export const isValidSemanticVersion = (version: string) =>
   /^\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?$/.test(version);
+
+export const formatLauncherVersion = (info: {
+  launcherVersion: string;
+  buildType: string;
+  buildCommitSha: string;
+  isPortable: boolean;
+}): string => {
+  if (info.buildType !== "release") {
+    // non-release builds: show the commit short hash in parentheses when
+    // available; local dev builds have no injected SHA, so no suffix then.
+    const shortSha = info.buildCommitSha.slice(0, 7);
+    return shortSha
+      ? `${info.launcherVersion} (${shortSha})`
+      : info.launcherVersion;
+  }
+  // release builds: keep the existing format, distinguishing portable.
+  return `${info.launcherVersion}${info.isPortable ? " (Portable)" : ""}`;
+};


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

#1744 的后续

### Description

对于nightly和test build，在版本号中显示commit hash

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Add build metadata for launcher builds and surface it in the UI while restricting update checks and warnings to release vs non-release builds.

New Features:
- Expose build type and commit SHA as build metadata from the backend to the frontend configuration.
- Display non-release launcher builds with a short commit hash appended to the version string in the About page.

Enhancements:
- Show unstable-build warnings in the welcome modal based on build type instead of parsing version strings.
- Skip online update checks for non-release builds and only show the update button for release builds.
- Ensure Rust build picks up SJMCL_* environment changes via build script and wire build metadata through CI inputs for release, nightly, and test builds.

Build:
- Add configurable build_type input and resolved commit SHA to the main build workflow and pass them as compile-time environment variables.
- Set build metadata environment variables for test and nightly workflows so nightly and test builds carry the correct type and commit SHA.