### PR TITLE
fix: fix rustfmt linter scope

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,8 +81,7 @@ jobs:
           components: rustfmt
 
       - name: Lint Rust Backend
-        run: |
-          find src-tauri/src -name '*.rs' | xargs rustfmt --check
+        run: cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
 
   Build:
     needs: changes

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "src/**/*.{js,jsx,ts,tsx}": [
       "eslint --no-fix --max-warnings=0"
     ],
-    "src-tauri/src/**/*.rs": [
+    "{src-tauri/src/**/*.rs,src-tauri/crates/**/*.rs,src-tauri/build.rs}": [
       "rustfmt --check"
     ],
     "scripts/**/*.js": [


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist


- [x] Changes have been tested locally and work as expected.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Description

修复linter范围

## Summary by Sourcery

Broaden and standardize Rust formatting linting to cover the full Rust backend using cargo fmt.

Bug Fixes:
- Fix Rust linter file-matching patterns to ensure all backend Rust sources and build scripts are checked.
- Align CI Rust lint step with local lint-staged behavior by using a consistent cargo fmt command.

Build:
- Update lint-staged configuration to run cargo fmt checks across all Rust crates and build scripts instead of invoking rustfmt directly.

CI:
- Simplify the GitHub Actions Rust lint job to use cargo fmt with the workspace manifest for consistent formatting checks.