### PR TITLE
fix(settings): stabilize memory allocation slider

### DIFF
--- a/src/components/game-settings-groups.tsx
+++ b/src/components/game-settings-groups.tsx
@@ -13,7 +13,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { MenuSelector } from "@/components/common/menu-selector";
 import {
@@ -43,17 +43,30 @@ const GameSettingsGroups: React.FC<GameSettingsGroupsProps> = ({
 
   const [javaInfos, setJavaInfos] = useState<JavaInfo[]>([]);
 
-  // use state and useEffect to track and render
-  const [gameWindowWidth, setGameWindowWidth] = useState<number>(400);
-  const [gameWindowHeight, setGameWindowHeight] = useState<number>(300);
-  const [maxMemAllocation, setMaxMemAllocation] = useState<number>(0);
-  const [sliderMaxMemAllocation, setSliderMaxMemAllocation] =
-    useState<number>(0);
-  const [customTitle, setCustomTitle] = useState<string>("");
-  const [customInfo, setCustomInfo] = useState<string>("");
-  const [serverUrl, setServerUrl] = useState<string>("");
+  // Stage editable values locally before committing them to config.
+  const [gameWindowWidth, setGameWindowWidth] = useState<number>(
+    gameConfig.gameWindow.resolution.width
+  );
+  const [gameWindowHeight, setGameWindowHeight] = useState<number>(
+    gameConfig.gameWindow.resolution.height
+  );
+  const [maxMemAllocation, setMaxMemAllocation] = useState<number>(
+    gameConfig.performance.maxMemAllocation
+  );
+  const [sliderMaxMemAllocation, setSliderMaxMemAllocation] = useState<number>(
+    gameConfig.performance.maxMemAllocation
+  );
+  const [customTitle, setCustomTitle] = useState<string>(
+    gameConfig.gameWindow.customTitle
+  );
+  const [customInfo, setCustomInfo] = useState<string>(
+    gameConfig.gameWindow.customInfo
+  );
+  const [serverUrl, setServerUrl] = useState<string>(
+    gameConfig.gameServer.serverUrl
+  );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setGameWindowWidth(gameConfig.gameWindow.resolution.width);
     setGameWindowHeight(gameConfig.gameWindow.resolution.height);
     setMaxMemAllocation(gameConfig.performance.maxMemAllocation);
@@ -361,16 +374,14 @@ const GameSettingsGroups: React.FC<GameSettingsGroupsProps> = ({
                       step={16}
                       w={32}
                       colorScheme={primaryColor}
+                      focusThumbOnChange={false}
                       value={sliderMaxMemAllocation}
                       onChange={(value) => {
                         setSliderMaxMemAllocation(value);
                         setMaxMemAllocation(value);
                       }}
-                      onBlur={() => {
-                        updateGameConfig(
-                          "performance.maxMemAllocation",
-                          maxMemAllocation
-                        );
+                      onChangeEnd={(value) => {
+                        updateGameConfig("performance.maxMemAllocation", value);
                       }}
                     >
                       <SliderTrack>

--- a/src/pages/settings/download.tsx
+++ b/src/pages/settings/download.tsx
@@ -206,11 +206,8 @@ const DownloadSettingsPage = () => {
                         setSliderConcurrentCount(value);
                         setConcurrentCount(value);
                       }}
-                      onBlur={() => {
-                        update(
-                          "download.transmission.concurrentCount",
-                          concurrentCount
-                        );
+                      onChangeEnd={(value) => {
+                        update("download.transmission.concurrentCount", value);
                       }}
                     >
                       <SliderTrack>


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
close #1784 

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Stabilize settings sliders by syncing their local state with the current configuration and committing changes only once sliding ends.

Bug Fixes:
- Initialize game window, memory allocation, and related settings state from the existing game configuration to avoid transient default values.
- Update performance memory allocation and download concurrency settings when the user finishes adjusting the sliders instead of on input blur to prevent lost or inconsistent changes.