### PR TITLE
fix: improve log text contrast in dark mode (#1741)

### DIFF
--- a/src/pages/standalone/game-log.tsx
+++ b/src/pages/standalone/game-log.tsx
@@ -7,6 +7,7 @@ import {
   Input,
   Spacer,
   Tooltip,
+  useColorModeValue,
 } from "@chakra-ui/react";
 import { appLogDir, join } from "@tauri-apps/api/path";
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
@@ -116,8 +117,14 @@ const GameLogPage: React.FC = () => {
     FATAL: { colorScheme: "red", textColor: "red.500" },
     ERROR: { colorScheme: "orange", textColor: "orange.500" },
     WARN: { colorScheme: "yellow", textColor: "yellow.500" },
-    INFO: { colorScheme: "gray", textColor: "gray.600" },
-    DEBUG: { colorScheme: "blue", textColor: "blue.600" },
+    INFO: {
+      colorScheme: "gray",
+      textColor: useColorModeValue("gray.600", "gray.300"),
+    },
+    DEBUG: {
+      colorScheme: "blue",
+      textColor: useColorModeValue("blue.600", "blue.300"),
+    },
   };
 
   const logLevels = useMemo<LogLevel[]>(() => {


### PR DESCRIPTION
Use useColorModeValue to switch INFO text from gray.600 to gray.300 and DEBUG text from blue.600 to blue.300 when in dark mode, fixing low contrast readability issues with the game log window.

<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.


### This PR is a ..


- [x] 🐞 Bug fix

### Related Issues


>  close #1741 

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

>
<img width="782" height="514" alt="image" src="https://github.com/user-attachments/assets/331129cd-8065-4e49-b4cb-4293324898b7" />

## Summary by Sourcery

Bug Fixes:
- Fix low contrast INFO and DEBUG log text in the game log when using dark mode by using theme-aware colors.