### PR TITLE
refactor(mod-loader): remove stable flag display of forge, fabric and quilt

### DIFF
--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/instance.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/instance.rs
@@ -35,7 +35,7 @@ async fn resolve_mod_loader(
       loader_type: ModLoaderType::Unknown,
       version: String::new(),
       description: String::new(),
-      stable: true,
+      stable: None,
       branch: None,
     });
   }
@@ -50,7 +50,7 @@ async fn resolve_mod_loader(
 
   versions
     .iter()
-    .find(|item| item.stable)
+    .find(|item| item.stable.unwrap_or(true))
     .cloned()
     .or_else(|| versions.into_iter().next())
     .ok_or_else(|| ResourceError::ParseError.into())

--- a/src-tauri/src/resource/helpers/loader_meta/fabric.rs
+++ b/src-tauri/src/resource/helpers/loader_meta/fabric.rs
@@ -46,7 +46,8 @@ pub async fn get_fabric_meta_by_game_version(
                   loader_type: ModLoaderType::Fabric,
                   version: info.loader.version,
                   description: String::new(),
-                  stable: info.loader.stable,
+                  // stable: info.loader.stable,
+                  stable: None,
                   branch: None,
                 })
                 .collect(),

--- a/src-tauri/src/resource/helpers/loader_meta/forge.rs
+++ b/src-tauri/src/resource/helpers/loader_meta/forge.rs
@@ -38,7 +38,8 @@ async fn get_forge_meta_by_game_version_bmcl(
                 loader_type: ModLoaderType::Forge,
                 version: info.version,
                 description: info.modified,
-                stable: true,
+                // stable: true,
+                stable: None,
                 branch: info.branch.and_then(|v| v.as_str().map(String::from)),
               })
               .collect(),

--- a/src-tauri/src/resource/helpers/loader_meta/neoforge.rs
+++ b/src-tauri/src/resource/helpers/loader_meta/neoforge.rs
@@ -83,9 +83,11 @@ async fn get_neoforge_meta_by_game_version_official(
             loader_type: ModLoaderType::NeoForge,
             version: version.to_string(),
             description: String::new(),
-            stable: versions
-              .get("is_snapshot")
-              .is_none_or(|v| !v.as_bool().unwrap_or(false)),
+            stable: Some(
+              versions
+                .get("is_snapshot")
+                .is_none_or(|v| !v.as_bool().unwrap_or(false)),
+            ),
             branch: None,
           },
         ));
@@ -185,7 +187,7 @@ async fn get_neoforge_meta_by_game_version_official(
               loader_type: ModLoaderType::NeoForge,
               version: version.to_string(),
               description: String::new(),
-              stable,
+              stable: Some(stable),
               branch: None,
             },
           ));
@@ -239,7 +241,7 @@ async fn get_neoforge_meta_by_game_version_bmcl(
                   loader_type: ModLoaderType::NeoForge,
                   version,
                   description: String::new(),
-                  stable,
+                  stable: Some(stable),
                   branch: None,
                 }
               })

--- a/src-tauri/src/resource/helpers/loader_meta/quilt.rs
+++ b/src-tauri/src/resource/helpers/loader_meta/quilt.rs
@@ -55,14 +55,14 @@ pub async fn get_quilt_meta_by_game_version(
                 .into_iter()
                 .map(|info| {
                   let version = info.loader.version;
-                  // let stable = !version.contains("beta")
-                  //   && !version.contains("alpha")
-                  //   && !version.contains("rc");
+                  let stable = !version.contains("beta")
+                    && !version.contains("alpha")
+                    && !version.contains("rc");
                   ModLoaderResourceInfo {
                     loader_type: ModLoaderType::Quilt,
                     version,
                     description: String::new(),
-                    stable: None,
+                    stable: Some(stable),
                     branch: None,
                   }
                 })

--- a/src-tauri/src/resource/helpers/loader_meta/quilt.rs
+++ b/src-tauri/src/resource/helpers/loader_meta/quilt.rs
@@ -55,14 +55,14 @@ pub async fn get_quilt_meta_by_game_version(
                 .into_iter()
                 .map(|info| {
                   let version = info.loader.version;
-                  let stable = !version.contains("beta")
-                    && !version.contains("alpha")
-                    && !version.contains("rc");
+                  // let stable = !version.contains("beta")
+                  //   && !version.contains("alpha")
+                  //   && !version.contains("rc");
                   ModLoaderResourceInfo {
                     loader_type: ModLoaderType::Quilt,
                     version,
                     description: String::new(),
-                    stable,
+                    stable: None,
                     branch: None,
                   }
                 })

--- a/src-tauri/src/resource/models.rs
+++ b/src-tauri/src/resource/models.rs
@@ -180,7 +180,7 @@ pub struct ModLoaderResourceInfo {
   pub loader_type: ModLoaderType,
   pub version: String,
   pub description: String,
-  pub stable: bool,
+  pub stable: Option<bool>,
   pub branch: Option<String>,
 }
 

--- a/src/components/loader-selector.tsx
+++ b/src/components/loader-selector.tsx
@@ -107,34 +107,37 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
     (
       version: ModLoaderResourceInfo | OptiFineResourceInfo
     ): OptionItemProps => {
-      let title = isModLoaderResourceInfo(version)
-        ? version.version
-        : version?.filename;
+      const isModLoader = isModLoaderResourceInfo(version);
+      let title = isModLoader ? version.version : version?.filename;
       return {
         title,
-        description: isModLoaderResourceInfo(version) && version.description,
+        description: isModLoader && version.description,
         prefixElement: (
           <HStack spacing={2.5}>
             <Radio value={title} colorScheme={primaryColor} />
             <Image
-              src={`/images/icons/${isModLoaderResourceInfo(version) ? modLoaderTypesToIcon[version.loaderType] : "OptiFine.png"}`}
+              src={`/images/icons/${isModLoader ? modLoaderTypesToIcon[version.loaderType] : "OptiFine.png"}`}
               alt={title}
               boxSize="28px"
               borderRadius="4px"
             />
           </HStack>
         ),
-        titleExtra: (
-          <Tag colorScheme={primaryColor} className="tag-xs">
-            {t(
-              `LoaderSelector.${(isModLoaderResourceInfo(version) ? version.stable : !version.patch.startsWith("pre")) ? "stable" : "beta"}`
-            )}
-          </Tag>
-        ),
+        titleExtra: (() => {
+          const stableFlag = isModLoader
+            ? version.stable
+            : !version.patch.startsWith("pre");
+          if (stableFlag == null) return;
+          return (
+            <Tag colorScheme={primaryColor} className="tag-xs">
+              {t(`LoaderSelector.${stableFlag ? "stable" : "beta"}`)}
+            </Tag>
+          );
+        })(),
         children: <></>,
         isFullClickZone: true,
         onClick: () => {
-          if (isModLoaderResourceInfo(version)) {
+          if (isModLoader) {
             onSelectModLoader(version);
           } else {
             onSelectOptiFine?.(version);
@@ -219,7 +222,6 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
             loaderType: type,
             version: "",
             description: "",
-            stable: false,
           });
           setSelectedId("");
         } else {

--- a/src/components/modals/change-loader-modal.tsx
+++ b/src/components/modals/change-loader-modal.tsx
@@ -95,7 +95,6 @@ export const ChangeLoaderModal: React.FC<ChangeLoaderModalProps> = ({
       loaderType: summary.modLoader.loaderType,
       version: summary.modLoader.version || "",
       description: "",
-      stable: true,
     };
   }, [summary]);
 

--- a/src/components/modals/import-modpack-modal.tsx
+++ b/src/components/modals/import-modpack-modal.tsx
@@ -127,7 +127,6 @@ const ImportModpackModal: React.FC<ImportModpackModalProps> = ({
               version: modpack.modLoader.version,
               branch: modpack.modLoader.branch,
               description: "",
-              stable: true,
             } as ModLoaderResourceInfo)
           : defaultModLoaderResourceInfo,
         undefined,

--- a/src/models/resource.ts
+++ b/src/models/resource.ts
@@ -64,7 +64,7 @@ export interface ModLoaderResourceInfo {
   loaderType: ModLoaderType;
   version: string;
   description: string;
-  stable: boolean;
+  stable?: boolean;
   branch?: string;
 }
 
@@ -72,7 +72,6 @@ export const defaultModLoaderResourceInfo: ModLoaderResourceInfo = {
   loaderType: ModLoaderType.Unknown,
   version: "",
   description: "",
-  stable: true,
 };
 
 export interface OptiFineResourceInfo {


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

resolve #1767

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Make mod loader stability metadata optional and stop displaying stability tags for Forge, Fabric, and Quilt loaders.

Enhancements:
- Refactor loader selector UI to conditionally render stability tags only when stability metadata is present.
- Change TypeScript and Rust models for mod loader resources to treat stability as an optional field instead of always required.
- Adjust NeoForge and Quilt metadata helpers to wrap stability flags in optional types while leaving Fabric and Forge loaders without stability metadata.
- Update instance resolution logic to treat missing stability as stable by default and to stop assigning default stability in various React components.