### PR TITLE
fix: tolerate non-standard fabric.mod.json metadata when recognizing mods

### DIFF
--- a/src-tauri/src/instance/helpers/mods/common.rs
+++ b/src-tauri/src/instance/helpers/mods/common.rs
@@ -10,6 +10,46 @@ use crate::instance::helpers::mods::{fabric, forge, legacy_forge, liteloader, qu
 use crate::instance::models::misc::{LocalModInfo, ModLoaderType};
 use crate::utils::image::ImageWrapper;
 
+pub fn sanitize_lenient_json(input: &str) -> String {
+  let mut out = String::with_capacity(input.len());
+  let mut in_string = false;
+  let mut escaped = false;
+  for c in input.chars() {
+    if in_string {
+      if escaped {
+        out.push(c);
+        escaped = false;
+        continue;
+      }
+      match c {
+        '\\' => {
+          out.push(c);
+          escaped = true;
+        }
+        '"' => {
+          out.push(c);
+          in_string = false;
+        }
+        '\u{0000}'..='\u{001F}' => match c {
+          '\n' => out.push_str("\\n"),
+          '\r' => out.push_str("\\r"),
+          '\t' => out.push_str("\\t"),
+          '\u{0008}' => out.push_str("\\b"),
+          '\u{000C}' => out.push_str("\\f"),
+          other => out.push_str(&format!("\\u{:04x}", other as u32)),
+        },
+        _ => out.push(c),
+      }
+    } else {
+      if c == '"' {
+        in_string = true;
+      }
+      out.push(c);
+    }
+  }
+  out
+}
+
 pub fn compress_icon(wrapper: ImageWrapper) -> ImageWrapper {
   let resized_image = image::imageops::resize(
     &wrapper.image,

--- a/src-tauri/src/instance/helpers/mods/fabric.rs
+++ b/src-tauri/src/instance/helpers/mods/fabric.rs
@@ -10,7 +10,9 @@ use std::path::Path;
 use tokio;
 use zip::ZipArchive;
 
-use crate::instance::helpers::mods::common::{LocalModMetadataParser, compress_icon};
+use crate::instance::helpers::mods::common::{
+  LocalModMetadataParser, compress_icon, sanitize_lenient_json,
+};
 use crate::instance::models::misc::{LocalModInfo, ModLoaderType};
 use crate::utils::image::{ImageWrapper, load_image_from_dir_async, load_image_from_jar};
 
@@ -48,24 +50,28 @@ impl LocalModMetadataParser for FabricModMetadataParser {
   fn get_mod_metadata_from_jar<R: Read + Seek>(
     jar: &mut ZipArchive<R>,
   ) -> SJMCLResult<Self::Metadata> {
-    let meta: FabricModMetadata = match jar.by_name("fabric.mod.json") {
-      Ok(val) => match serde_json::from_reader(val) {
-        Ok(val) => val,
-        Err(e) => return Err(SJMCLError::from(e)),
-      },
+    use std::io::Read as _;
+
+    let mut content = String::new();
+    match jar.by_name("fabric.mod.json") {
+      Ok(mut val) => {
+        val.read_to_string(&mut content)?;
+      }
       Err(e) => return Err(SJMCLError::from(e)),
+    }
+    let meta: FabricModMetadata = match serde_json::from_str(&content) {
+      Ok(val) => val,
+      Err(_) => serde_json::from_str(&sanitize_lenient_json(&content))?,
     };
     Ok(meta)
   }
 
   async fn get_mod_metadata_from_dir(dir_path: &Path) -> SJMCLResult<Self::Metadata> {
     let fabric_file_path = dir_path.join("fabric.mod.json");
-    let meta: FabricModMetadata = match tokio::fs::read_to_string(fabric_file_path).await {
-      Ok(val) => match serde_json::from_str(val.as_str()) {
-        Ok(val) => val,
-        Err(e) => return Err(SJMCLError::from(e)),
-      },
-      Err(e) => return Err(SJMCLError::from(e)),
+    let content = tokio::fs::read_to_string(fabric_file_path).await?;
+    let meta: FabricModMetadata = match serde_json::from_str(content.as_str()) {
+      Ok(val) => val,
+      Err(_) => serde_json::from_str(&sanitize_lenient_json(&content))?,
     };
     Ok(meta)
   }
@@ -92,5 +98,54 @@ impl LocalModMetadataParser for FabricModMetadataParser {
         .unwrap_or_default();
     }
     ImageWrapper::default()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::instance::helpers::mods::common::sanitize_lenient_json;
+
+  fn parse(raw: &str) -> serde_json::Result<FabricModMetadata> {
+    match serde_json::from_str::<FabricModMetadata>(raw) {
+      Ok(v) => Ok(v),
+      Err(_) => serde_json::from_str::<FabricModMetadata>(&sanitize_lenient_json(raw)),
+    }
+  }
+
+  #[test]
+  fn parses_wellformed_metadata() {
+    let raw = r#"{"id":"foo","version":"1.0.0","name":"Foo","description":"a mod"}"#;
+    let meta = parse(raw).unwrap();
+    assert_eq!(meta.id, "foo");
+    assert_eq!(meta.version, "1.0.0");
+    assert_eq!(meta.name.as_deref(), Some("Foo"));
+  }
+
+  #[test]
+  fn tolerates_raw_newline_in_description() {
+    // BetterGrassify-style metadata: a raw newline inside the description string.
+    let raw = "{\"id\":\"bettergrassify\",\"version\":\"1.2.3\",\"name\":\"BetterGrassify\",\"description\":\"line one\nline two\"}";
+    assert!(serde_json::from_str::<FabricModMetadata>(raw).is_err());
+    let meta = parse(raw).unwrap();
+    assert_eq!(meta.id, "bettergrassify");
+    assert_eq!(meta.version, "1.2.3");
+    assert_eq!(meta.name.as_deref(), Some("BetterGrassify"));
+    assert_eq!(meta.description.as_deref(), Some("line one\nline two"));
+  }
+
+  #[test]
+  fn tolerates_raw_tab_in_string() {
+    let raw = "{\"id\":\"baz\",\"version\":\"0.1\",\"description\":\"col1\tcol2\"}";
+    let meta = parse(raw).unwrap();
+    assert_eq!(meta.id, "baz");
+    assert_eq!(meta.description.as_deref(), Some("col1\tcol2"));
+  }
+
+  #[test]
+  fn genuinely_broken_json_still_fails() {
+    // Missing required `version`, and truncated braces -> must still error.
+    let raw = "{\"id\":\"foo\",\"name\":\"Foo\"";
+    assert!(parse(raw).is_err());
   }
 }


### PR DESCRIPTION
### Checklist

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

- Fixes #1764

### Description

Some mods (for example BetterGrassify from the Fabulously Optimized modpack) were not recognized by SJMCL while HMCL recognized them fine. Their `fabric.mod.json` has a `description` value containing a raw, unescaped newline, which makes the file technically invalid JSON. SJMCL parses with strict `serde_json`, so any raw control character inside a string value aborts parsing and the mod silently falls through to Unknown.

This change keeps the strict parse first and adds a fallback only on the error branch: a `sanitize_lenient_json` helper escapes raw control characters (0x00-0x1F) that appear inside JSON string literals, then the sanitized text is re-parsed. Well-formed metadata is unaffected because it never reaches the fallback, and genuinely broken JSON (missing required fields, truncated braces) still fails as before.

### Additional Context

Both the jar and on-disk (`fabric.mod.json` in a directory) parse paths share the fallback. Added inline tests in `fabric.rs` covering: a well-formed file (no regression), a raw newline in `description` (the BetterGrassify case), a raw tab inside a string value, and genuinely broken JSON that must still fail.

Tested locally:

```
cargo test -p SJMCL fabric
# test result: ok. 4 passed; 0 failed
cargo fmt --check   # clean
cargo clippy -p SJMCL --lib   # no new warnings
```

## Summary by Sourcery

Improve Fabric mod metadata parsing to recognize mods with lenient JSON while preserving strict behavior for genuinely invalid files.

Bug Fixes:
- Ensure Fabric mods with unescaped control characters in fabric.mod.json (e.g., raw newlines in description) are correctly recognized instead of falling back to Unknown.

Enhancements:
- Introduce a shared JSON sanitization helper that escapes raw control characters inside string values and reuse it across jar and directory metadata parsing paths.

Tests:
- Add unit tests verifying well-formed metadata still parses, lenient JSON with raw newlines/tabs is accepted, and structurally broken JSON continues to fail.