### PR TITLE
feat(extension): support extension to register slot in game error window to handle game crashes

### DIFF
--- a/src/contexts/extension/host.tsx
+++ b/src/contexts/extension/host.tsx
@@ -350,10 +350,7 @@ export const ExtensionHostContextProvider: React.FC<{
 }> = ({ children }) => {
   const router = useRouter();
 
-  if (
-    router.pathname === "/standalone/game-log" ||
-    router.pathname === "/standalone/game-error"
-  ) {
+  if (router.pathname === "/standalone/game-log") {
     return <>{children}</>;
   }
 

--- a/src/contexts/extension/host.tsx
+++ b/src/contexts/extension/host.tsx
@@ -1254,6 +1254,12 @@ const ActiveExtensionHostContextProvider: React.FC<{
     [getScriptUrl]
   );
 
+  // Skip home widget and settings page registration in standalone windows,
+  // since neither is rendered outside the main window.
+  const isStandalonePageRef = useRef(
+    router.pathname.startsWith("/standalone/")
+  );
+
   const activateExtension = useCallback(
     async (extension: ExtensionInfo, signature: string) => {
       const { factory, scriptElement } = await loadExtensionFactory(
@@ -1291,7 +1297,7 @@ const ActiveExtensionHostContextProvider: React.FC<{
         ...(registration.homeWidgets || []),
       ];
 
-      if (homeWidgetDefinitions.length > 0) {
+      if (!isStandalonePageRef.current && homeWidgetDefinitions.length > 0) {
         setHomeWidgetMap((prev) => ({
           ...prev,
           [extension.identifier]: homeWidgetDefinitions.map(
@@ -1315,7 +1321,7 @@ const ActiveExtensionHostContextProvider: React.FC<{
       }
 
       // ------- settings-page -------
-      if (registration.settingsPage) {
+      if (!isStandalonePageRef.current && registration.settingsPage) {
         setSettingsPageMap((prev) => ({
           ...prev,
           [extension.identifier]: {

--- a/src/enums/extension.ts
+++ b/src/enums/extension.ts
@@ -6,6 +6,7 @@ export enum ExtensionUISlotKey {
   InstanceServerResPackItemMenuOperations = "ui.instance.server_resourcepack.item_menu_operations",
   InstanceSchematicItemMenuOperations = "ui.instance.schematic.item_menu_operations",
   InstanceShaderPackItemMenuOperations = "ui.instance.shaderpack.item_menu_operations",
+  GameErrorWindowOperations = "ui.game_error.window_operations",
 }
 
 export type ExtensionSlotKey = ExtensionUISlotKey;

--- a/src/models/extension/slot.ts
+++ b/src/models/extension/slot.ts
@@ -1,3 +1,4 @@
+import type { ButtonProps } from "@chakra-ui/react";
 import type { MouseEventHandler } from "react";
 import type { IconType } from "react-icons";
 import { type ExtensionSlotKey, ExtensionUISlotKey } from "@/enums/extension";
@@ -10,6 +11,7 @@ import type {
   ShaderPackInfo,
 } from "@/models/instance/misc";
 import type { WorldInfo } from "@/models/instance/world";
+import type { JavaInfo } from "@/models/system-info";
 import type { ExtensionContributionBase } from "./contribution";
 
 interface ExtensionInstanceSlotContextBase {
@@ -32,6 +34,10 @@ export type ExtensionSlotContextMap = {
   };
   [ExtensionUISlotKey.InstanceShaderPackItemMenuOperations]: ExtensionInstanceSlotContextBase & {
     pack: ShaderPackInfo;
+  };
+  [ExtensionUISlotKey.GameErrorWindowOperations]: ExtensionInstanceSlotContextBase & {
+    launchingId: number;
+    javaInfo: JavaInfo | undefined;
   };
 } & {
   [K in
@@ -57,6 +63,8 @@ export type ExtensionSlotItemMap = {
     | ExtensionUISlotKey.InstanceServerResPackItemMenuOperations
     | ExtensionUISlotKey.InstanceSchematicItemMenuOperations
     | ExtensionUISlotKey.InstanceShaderPackItemMenuOperations]: CommonIconButtonSlotItem;
+} & {
+  [ExtensionUISlotKey.GameErrorWindowOperations]: ButtonProps;
 };
 
 export interface ExtensionSlotDefinition<K extends ExtensionSlotKey> {

--- a/src/pages/standalone/game-error.tsx
+++ b/src/pages/standalone/game-error.tsx
@@ -18,10 +18,12 @@ import {
 import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { save } from "@tauri-apps/plugin-dialog";
 import { openPath, revealItemInDir } from "@tauri-apps/plugin-opener";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LuCircleAlert, LuFolderOpen } from "react-icons/lu";
 import { useLauncherConfig } from "@/contexts/config";
+import { useExtensionHost } from "@/contexts/extension/host";
+import { ExtensionUISlotKey } from "@/enums/extension";
 import { InstanceSummary } from "@/models/instance/misc";
 import { JavaInfo } from "@/models/system-info";
 import { LaunchService } from "@/services/launch";
@@ -37,6 +39,8 @@ const GameErrorPage: React.FC = () => {
   const { config } = useLauncherConfig();
   const primaryColor = config.appearance.theme.primaryColor;
 
+  const { getExtensionSlotItems } = useExtensionHost();
+
   const [basicInfoParams, setBasicInfoParams] = useState(
     new Map<string, string>()
   );
@@ -44,6 +48,11 @@ const GameErrorPage: React.FC = () => {
   const [javaInfo, setJavaInfo] = useState<JavaInfo>();
   const [reason, setReason] = useState<string>();
   const [isLoading, setIsLoading] = useState(false);
+
+  const launchingId = useMemo(() => {
+    if (typeof window === "undefined") return 0;
+    return parseIdFromWindowLabel(getCurrentWebviewWindow().label);
+  }, []);
 
   const platformName = useCallback(() => {
     let name = config.basicInfo.platform
@@ -84,8 +93,6 @@ const GameErrorPage: React.FC = () => {
 
   // retrieve states and logs (for crash analysis)
   useEffect(() => {
-    let launchingId = parseIdFromWindowLabel(getCurrentWebviewWindow().label);
-
     LaunchService.retrieveGameLaunchingState(launchingId).then((response) => {
       if (response.status === "success") {
         setInstanceInfo(response.data.selectedInstance);
@@ -105,7 +112,7 @@ const GameErrorPage: React.FC = () => {
         );
       }
     });
-  }, [t]);
+  }, [t, launchingId]);
 
   const renderStats = ({
     title,
@@ -133,9 +140,6 @@ const GameErrorPage: React.FC = () => {
   };
 
   const handleOpenLogWindow = async () => {
-    let launchingId = parseIdFromWindowLabel(
-      getCurrentWebviewWindow()?.label || ""
-    );
     if (launchingId) {
       await LaunchService.openGameLogWindow(launchingId);
     }
@@ -150,7 +154,6 @@ const GameErrorPage: React.FC = () => {
     const savePath = await save({
       defaultPath: `minecraft-exported-crash-info-${timestamp}.zip`,
     });
-    let launchingId = parseIdFromWindowLabel(getCurrentWebviewWindow().label);
     if (!savePath || !launchingId) return;
     setIsLoading(true);
     const res = await LaunchService.exportGameCrashInfo(launchingId, savePath);
@@ -252,6 +255,20 @@ const GameErrorPage: React.FC = () => {
         <Button colorScheme={primaryColor} variant="solid">
           {t("GameErrorPage.button.help")}
         </Button>
+        {getExtensionSlotItems(ExtensionUISlotKey.GameErrorWindowOperations, {
+          instanceId: instanceInfo?.id,
+          summary: instanceInfo,
+          launchingId,
+          javaInfo,
+        }).map((props, index) => (
+          <Button
+            key={`ext-btn-${index}`}
+            colorScheme={primaryColor}
+            variant="solid"
+            {...props}
+            size="sm" // keep default size
+          />
+        ))}
         <Icon ml={2} as={LuCircleAlert} color="red.500" />
         <Text fontSize="xs-sm" color="red.500">
           {t("GameErrorPage.bottomAlert")}

--- a/src/pages/standalone/game-error.tsx
+++ b/src/pages/standalone/game-error.tsx
@@ -93,6 +93,8 @@ const GameErrorPage: React.FC = () => {
 
   // retrieve states and logs (for crash analysis)
   useEffect(() => {
+    if (!launchingId) return;
+
     LaunchService.retrieveGameLaunchingState(launchingId).then((response) => {
       if (response.status === "success") {
         setInstanceInfo(response.data.selectedInstance);
@@ -262,7 +264,7 @@ const GameErrorPage: React.FC = () => {
           javaInfo,
         }).map((props, index) => (
           <Button
-            key={`ext-btn-${index}`}
+            key={props.id || `ext-btn-${index}`}
             colorScheme={primaryColor}
             variant="solid"
             {...props}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - e.g. close #xxxx, fix #xxxx

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Add extension support for customizing operations in the game error window and reuse a memoized launching ID across crash-related actions.

New Features:
- Expose a new GameErrorWindowOperations extension UI slot for registering buttons in the game error window.
- Provide game error window extensions with contextual data such as instance info, launching ID, and Java runtime info.

Enhancements:
- Refactor game error page to compute and reuse a memoized launching ID instead of parsing the window label multiple times.
- Adjust extension host routing behavior so extensions remain active on the standalone game error page.