### PR TITLE
fix(frontend): set html lang attribute dynamically based on current locale, fix CJK variant issue

### DIFF
--- a/src/contexts/config.tsx
+++ b/src/contexts/config.tsx
@@ -9,6 +9,7 @@ import React, {
 } from "react";
 import { useToast } from "@/contexts/toast";
 import { useGetState } from "@/hooks/get-state";
+import { localeResources } from "@/locales";
 import {
   LauncherConfig,
   VersionMetaInfo,
@@ -117,6 +118,8 @@ export const LauncherConfigContextProvider: React.FC<{
 
   useEffect(() => {
     i18n.changeLanguage(language);
+    document.documentElement.lang =
+      localeResources[language]?.htmlLang || language;
   }, [language]);
 
   useEffect(() => {

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -11,6 +11,7 @@ type LocaleResources = {
   [key: string]: {
     translation: Record<string, any>;
     display_name: string;
+    htmlLang: string;
   };
 };
 
@@ -18,30 +19,37 @@ export const localeResources: LocaleResources = {
   en: {
     translation: en,
     display_name: "English",
+    htmlLang: "en",
   },
   es: {
     translation: es,
     display_name: "Español",
+    htmlLang: "es",
   },
   fr: {
     translation: fr,
     display_name: "Français",
+    htmlLang: "fr",
   },
   ja: {
     translation: ja,
     display_name: "日本語",
+    htmlLang: "ja",
   },
   "zh-Hans": {
     translation: zh_Hans,
     display_name: "简体中文",
+    htmlLang: "zh-Hans",
   },
   "zh-Hant": {
     translation: zh_Hant,
     display_name: "繁體中文",
+    htmlLang: "zh-Hant",
   },
   lzh: {
     translation: lzh,
     display_name: "文言",
+    htmlLang: "zh",
   },
 };
 

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -2,7 +2,7 @@ import { Head, Html, Main, NextScript } from "next/document";
 
 export default function Document() {
   return (
-    <Html lang="en">
+    <Html>
       <Head />
       <body>
         <Main />


### PR DESCRIPTION
### Checklist

- [ ] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🐞 Bug fix
- [x] 🌐 Internationalization

### Related Issues

- fix #1702

### Description

The `<html lang>` attribute was hardcoded to `"en"` in `_document.tsx`. This caused CJK (Chinese/Japanese/Korean) characters to render with incorrect font variants (e.g., Chinese text displayed using Japanese glyph shapes when a Japanese font preceded Chinese fonts in the system font stack).

This PR:

1. Adds an `htmlLang` property to each locale resource entry in `src/locales/index.ts`, mapping each language to the correct BCP 47 language tag.
2. Dynamically sets `document.documentElement.lang` whenever the user switches languages via the LauncherConfig context.
3. Removes the hardcoded `lang="en"` from `_document.tsx` so the initial server-side render doesn't conflict with the client-side dynamic value.

This ensures browsers apply the correct locale-specific font fallback and typographic rules, particularly for `zh-Hans`, `zh-Hant`, `ja`, and `lzh`.

## Summary by Sourcery

Update locale handling so the HTML document language reflects the active locale, fixing incorrect CJK font variant rendering.

Bug Fixes:
- Ensure the HTML lang attribute matches the selected locale to prevent incorrect CJK font glyph variants.

Enhancements:
- Add htmlLang metadata to locale resources and use it to dynamically set document.documentElement.lang on language changes.