### PR TITLE
fix(launch): apply custom info to launched version

### DIFF
--- a/src-tauri/src/launch/helpers/command_generator.rs
+++ b/src-tauri/src/launch/helpers/command_generator.rs
@@ -170,6 +170,9 @@ pub async fn generate_launch_command(
     _ => String::new(),
   };
 
+  let custom_info = game_config.game_window.custom_info.trim();
+  let custom_info = (!custom_info.is_empty()).then(|| custom_info.to_string());
+
   let arguments_value = LaunchArguments {
     game_assets: assets_dir
       .join("virtual/legacy")
@@ -179,13 +182,11 @@ pub async fn generate_launch_command(
     assets_index_name: client_info.asset_index.id.clone(),
     game_directory: root_dir.to_string_lossy().to_string(),
 
-    version_name: selected_instance.name.clone(),
+    version_name: custom_info
+      .clone()
+      .unwrap_or_else(|| selected_instance.name.clone()),
     primary_jar_name: format!("{}.jar", selected_instance.name.clone()),
-    version_type: if !game_config.game_window.custom_info.is_empty() {
-      game_config.game_window.custom_info.clone()
-    } else {
-      client_info.type_.clone()
-    },
+    version_type: custom_info.unwrap_or_else(|| client_info.type_.clone()),
     natives_directory: natives_dir.to_string_lossy().to_string(),
     launcher_name: "SJMC Launcher".to_string(),
     launcher_version: basic_info.launcher_version,


### PR DESCRIPTION
### Checklist

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

close #1769

### Description

This PR makes custom launch info apply to the launched version value used by newer Minecraft game arguments.

Previously, custom info only replaced `${version_type}`. Newer Minecraft versions display the launched version from `${version_name}` in more places, so the custom info could appear ineffective. This change normalizes the configured custom info once and applies it to both `${version_name}` and `${version_type}` when present, while preserving the original instance name and client type fallback behavior when it is empty.

Validated with:

- `cargo fmt --check`
- `cargo check`
- `git diff --check`

### Additional Context

Minecraft 26.1+ has changed parts of the version display behavior, and this keeps SJMCL aligned with the launch argument fields that are still available.

## Summary by Sourcery

Bug Fixes:
- Ensure custom launch info overrides both version name and version type fields while preserving existing fallbacks when custom info is empty.