### PR TITLE
fix(resource): deduplicate Modrinth modpack versions

### DIFF
--- a/src-tauri/src/resource/helpers/curseforge/mod.rs
+++ b/src-tauri/src/resource/helpers/curseforge/mod.rs
@@ -165,6 +165,7 @@ pub async fn fetch_resource_version_packs_curseforge(
     resource_id,
     mod_loader,
     game_versions,
+    ..
   } = query;
 
   loop {

--- a/src-tauri/src/resource/helpers/modrinth/misc.rs
+++ b/src-tauri/src/resource/helpers/modrinth/misc.rs
@@ -102,6 +102,8 @@ structstruck::strike! {
   pub struct ModrinthFileInfo {
     pub url: String,
     pub filename: String,
+    #[serde(default)]
+    pub primary: bool,
     pub hashes: pub struct {
       pub sha1: String,
     },
@@ -151,8 +153,10 @@ fn normalize_modrinth_loader(loader: &str) -> Option<String> {
 
 pub fn map_modrinth_file_to_version_pack(
   res: Vec<ModrinthVersionPack>,
+  resource_type: &str,
 ) -> Vec<OtherResourceVersionPack> {
   let mut version_packs = std::collections::HashMap::new();
+  let is_modpack = resource_type == "modpack";
 
   for version in res {
     let game_versions = if version.game_versions.is_empty() {
@@ -185,21 +189,40 @@ pub fn map_modrinth_file_to_version_pack(
     };
 
     for game_version in &game_versions {
-      for loader in &loaders {
-        let file_infos = version
+      if is_modpack {
+        let file = version
           .files
           .iter()
-          .map(|file| (&version, file, normalize_modrinth_loader(loader)).into())
-          .collect::<Vec<_>>();
+          .find(|file| file.primary)
+          .or_else(|| version.files.first());
 
-        version_packs
-          .entry(game_version.clone())
-          .or_insert_with(|| OtherResourceVersionPack {
-            name: game_version.clone(),
-            items: Vec::new(),
-          })
-          .items
-          .extend(file_infos);
+        if let Some(file) = file {
+          version_packs
+            .entry(game_version.clone())
+            .or_insert_with(|| OtherResourceVersionPack {
+              name: game_version.clone(),
+              items: Vec::new(),
+            })
+            .items
+            .push((&version, file, None).into());
+        }
+      } else {
+        for loader in &loaders {
+          let file_infos = version
+            .files
+            .iter()
+            .map(|file| (&version, file, normalize_modrinth_loader(loader)).into())
+            .collect::<Vec<_>>();
+
+          version_packs
+            .entry(game_version.clone())
+            .or_insert_with(|| OtherResourceVersionPack {
+              name: game_version.clone(),
+              items: Vec::new(),
+            })
+            .items
+            .extend(file_infos);
+        }
       }
     }
   }

--- a/src-tauri/src/resource/helpers/modrinth/mod.rs
+++ b/src-tauri/src/resource/helpers/modrinth/mod.rs
@@ -87,6 +87,7 @@ pub async fn fetch_resource_version_packs_modrinth(
     resource_id,
     mod_loader,
     game_versions,
+    resource_type,
   } = query;
 
   let url = get_modrinth_api(OtherResourceApiEndpoint::VersionPack, Some(resource_id))?;
@@ -122,7 +123,7 @@ pub async fn fetch_resource_version_packs_modrinth(
   )
   .await?;
 
-  Ok(map_modrinth_file_to_version_pack(results))
+  Ok(map_modrinth_file_to_version_pack(results, resource_type))
 }
 
 pub async fn fetch_remote_resource_by_local_modrinth(
@@ -208,6 +209,7 @@ pub async fn fetch_latest_mod_download_param_modrinth(
     resource_id: mod_id.to_string(),
     mod_loader: mod_loader.to_string(),
     game_versions: vec![game_version.to_string()],
+    resource_type: String::new(),
   };
 
   let version_packs = fetch_resource_version_packs_modrinth(app, &query).await?;

--- a/src-tauri/src/resource/models.rs
+++ b/src-tauri/src/resource/models.rs
@@ -124,6 +124,8 @@ pub struct OtherResourceVersionPackQuery {
   pub resource_id: String,
   pub mod_loader: String,
   pub game_versions: Vec<String>,
+  #[serde(default)]
+  pub resource_type: String,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize, Default)]

--- a/src/components/modals/download-specific-resource-modal.tsx
+++ b/src/components/modals/download-specific-resource-modal.tsx
@@ -459,7 +459,8 @@ const DownloadSpecificResourceModal: React.FC<
         resourceId,
         modLoader,
         gameVersions,
-        downloadSource
+        downloadSource,
+        resource.type
       )
         .then((response) => {
           if (response.status === "success") {
@@ -478,7 +479,7 @@ const DownloadSpecificResourceModal: React.FC<
           setIsLoadingVersionPacks(false);
         });
     },
-    [toast]
+    [resource.type, toast]
   );
 
   const reFetchVersionPacks = useCallback(() => {

--- a/src/services/resource.ts
+++ b/src/services/resource.ts
@@ -111,7 +111,8 @@ export class ResourceService {
     resourceId: string,
     modLoader: ModLoaderType | "All",
     gameVersions: string[],
-    downloadSource: OtherResourceSource
+    downloadSource: OtherResourceSource,
+    resourceType?: OtherResourceType
   ): Promise<InvokeResponse<OtherResourceVersionPack[]>> {
     return await invoke("fetch_resource_version_packs", {
       downloadSource,
@@ -119,6 +120,7 @@ export class ResourceService {
         resourceId,
         modLoader,
         gameVersions,
+        resourceType,
       },
     });
   }


### PR DESCRIPTION
### Checklist

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

fix #1761 

### Description

This PR prevents duplicate Modrinth modpack versions from appearing in the modpack download dialog.

Modrinth version responses can contain multiple files and multiple loaders for a single release. The previous mapping expanded every file/loader combination into selectable items, which made some modpack releases appear multiple times with the same version name.

The version-pack query now includes the resource type, allowing the backend to keep the existing file-level expansion for normal resources while mapping Modrinth modpacks as one selectable item per version. For modpacks, the backend selects the primary file and falls back to the first file when no primary file is marked.

Validated with:

- `cargo fmt --check`
- `cargo check`
- `./node_modules/.bin/eslint src/components/modals/download-specific-resource-modal.tsx src/services/resource.ts`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`

### Additional Context

N/A

## Summary by Sourcery

Deduplicate Modrinth modpack versions in the resource download flow by making version-pack fetching aware of resource type and using primary file metadata to represent each modpack release as a single selectable version.

Bug Fixes:
- Prevent duplicate Modrinth modpack versions from appearing in the download-specific-resource dialog by mapping each modpack release to a single selectable version entry.

Enhancements:
- Extend version-pack queries to include resource type so the backend can distinguish modpacks from other resources when building version packs.
- Add support for Modrinth primary file metadata and fall back to the first file when no primary is defined to select the canonical file for modpack versions.

Chores:
- Plumb the optional resource type field through the frontend service, Tauri models, and Modrinth/CurseForge helpers for version-pack fetching.