### PR TITLE
fix(resource): strip OptiFine version file extensions

### DIFF
--- a/src-tauri/src/resource/helpers/loader_meta/optifine.rs
+++ b/src-tauri/src/resource/helpers/loader_meta/optifine.rs
@@ -4,6 +4,8 @@ use tauri_plugin_http::reqwest;
 
 use crate::resource::helpers::misc::get_download_api;
 use crate::resource::models::{OptiFineResourceInfo, ResourceError, ResourceType, SourceType};
+use crate::utils::fs::split_filename;
+use std::ffi::OsStr;
 
 fn get_optifine_sort_key(info: &OptiFineResourceInfo) -> (u32, u32, u32) {
   let Some((_, suffix)) = info.filename.rsplit_once("_HD_U_") else {
@@ -37,6 +39,9 @@ async fn get_optifine_meta_by_game_version_bmcl(
           .json::<Vec<OptiFineResourceInfo>>()
           .await
           .map_err(|_| ResourceError::ParseError)?;
+        for info in &mut manifest {
+          info.filename = split_filename(OsStr::new(&info.filename)).0;
+        }
         manifest.sort_by(|a, b| {
           get_optifine_sort_key(b)
             .cmp(&get_optifine_sort_key(a))

--- a/src-tauri/src/resource/helpers/loader_meta/optifine.rs
+++ b/src-tauri/src/resource/helpers/loader_meta/optifine.rs
@@ -1,17 +1,16 @@
 use sjmcl_types::error::SJMCLResult;
+use std::ffi::OsStr;
 use tauri::Manager;
 use tauri_plugin_http::reqwest;
 
 use crate::resource::helpers::misc::get_download_api;
 use crate::resource::models::{OptiFineResourceInfo, ResourceError, ResourceType, SourceType};
 use crate::utils::fs::split_filename;
-use std::ffi::OsStr;
 
 fn get_optifine_sort_key(info: &OptiFineResourceInfo) -> (u32, u32, u32) {
   let Some((_, suffix)) = info.filename.rsplit_once("_HD_U_") else {
     return (0, 0, 0);
   };
-  let suffix = suffix.trim_end_matches(".jar");
   let (version, pre) = match suffix.split_once("_pre") {
     Some((version, pre)) => (version, pre.parse().unwrap_or(0)),
     None => (suffix, u32::MAX),
@@ -39,14 +38,16 @@ async fn get_optifine_meta_by_game_version_bmcl(
           .json::<Vec<OptiFineResourceInfo>>()
           .await
           .map_err(|_| ResourceError::ParseError)?;
-        for info in &mut manifest {
+
+        manifest.iter_mut().for_each(|info| {
           info.filename = split_filename(OsStr::new(&info.filename)).0;
-        }
+        });
         manifest.sort_by(|a, b| {
           get_optifine_sort_key(b)
             .cmp(&get_optifine_sort_key(a))
             .then_with(|| b.filename.cmp(&a.filename))
         });
+
         Ok(manifest)
       } else {
         Err(ResourceError::NetworkError.into())


### PR DESCRIPTION
### Checklist

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

fix #1807 

### Description

This PR removes the file extension suffix from OptiFine version entries returned by the resource list API.

The BMCL OptiFine metadata returns `filename` values with a `.jar` suffix, while the launcher UI uses that field as the displayed OptiFine version. This caused OptiFine resource list entries to show the file format suffix as part of the version text.

The backend now normalizes each OptiFine `filename` with the shared `split_filename` utility before sorting and returning the version list, so the UI receives version identifiers without the `.jar` suffix.

Validated with:

- `cargo fmt --check`
- `cargo check`

### Additional Context

This PR still needs secondary verification before merge.

## Summary by Sourcery

Bug Fixes:
- Strip the file extension from OptiFine manifest filenames using the shared filename-splitting utility prior to sorting and exposing them via the resource API.