### PR TITLE
fix(frontend): use IEC units for binary sizes

### DIFF
--- a/src/components/game-settings-groups.tsx
+++ b/src/components/game-settings-groups.tsx
@@ -405,7 +405,7 @@ const GameSettingsGroups: React.FC<GameSettingsGroupsProps> = ({
                     >
                       <NumberInputField pr={0} />
                     </NumberInput>
-                    <Text fontSize="xs">MB</Text>
+                    <Text fontSize="xs">MiB</Text>
                   </HStack>
                 ),
               },

--- a/src/components/memory-status-progress.tsx
+++ b/src/components/memory-status-progress.tsx
@@ -7,7 +7,7 @@ import { MemoryInfo } from "@/models/system-info";
 
 interface MemoryStatusProgressProps {
   memoryInfo: MemoryInfo;
-  allocatedMemory?: number; // in MB
+  allocatedMemory?: number; // in MiB
 }
 
 const MemoryStatusProgress: React.FC<MemoryStatusProgressProps> = ({
@@ -23,9 +23,9 @@ const MemoryStatusProgress: React.FC<MemoryStatusProgressProps> = ({
   const allocatedPercentage =
     total > 0 ? ((allocatedMemory * 1024 * 1024) / total) * 100 : 0;
 
-  const totalInGB = (total / 1024 / 1024 / 1024).toFixed(2);
-  const usedInGB = (used / 1024 / 1024 / 1024).toFixed(2);
-  const allocatedInGB = (allocatedMemory / 1024).toFixed(2);
+  const totalInGiB = (total / 1024 / 1024 / 1024).toFixed(2);
+  const usedInGiB = (used / 1024 / 1024 / 1024).toFixed(2);
+  const allocatedInGiB = (allocatedMemory / 1024).toFixed(2);
 
   return (
     <VStack align="stretch" spacing={2}>
@@ -33,9 +33,9 @@ const MemoryStatusProgress: React.FC<MemoryStatusProgressProps> = ({
         <Text fontSize="xs-sm">{t("MemoryStatusProgress.title")}</Text>
         <Text fontSize="xs-sm" ml="auto" className="secondary-text">
           {t("MemoryStatusProgress.info", {
-            total: totalInGB,
-            used: usedInGB,
-            allocated: allocatedInGB,
+            total: totalInGiB,
+            used: usedInGiB,
+            allocated: allocatedInGiB,
           })}
         </Text>
       </Flex>

--- a/src/components/modals/export-modpack-modal.tsx
+++ b/src/components/modals/export-modpack-modal.tsx
@@ -522,7 +522,7 @@ const ExportModpackModal: React.FC<ExportModpackModalProps> = ({
                       />
                     </NumberInput>
                     <Text fontSize="xs" className="secondary-text">
-                      MB
+                      MiB
                     </Text>
                   </HStack>
                 ),

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -790,7 +790,7 @@
       "includedFiles": "Included Files",
       "exportOptions": "Export Options",
       "packWithLauncher": "Pack With Launcher",
-      "minMemory": "Minimum Memory (MB)",
+      "minMemory": "Minimum Memory (MiB)",
       "noCreateRemoteFiles": "Disable Remote Files",
       "skipCurseForgeRemoteFiles": "Skip CurseForge Remote Files"
     },
@@ -920,7 +920,7 @@
         },
         "javaPermanentGenerationSpace": {
           "title": "PermGen Space",
-          "placeholder": "in MB"
+          "placeholder": "in MiB"
         },
         "environmentVariable": {
           "title": "Environment Variables"
@@ -1277,7 +1277,7 @@
         },
         "memoryUsage": {
           "title": "Memory Usage",
-          "description": "Used memory {{usedMemory}}GB; Game allocated {{allocatedMemory}}GB; Total memory {{totalMemory}}GB"
+          "description": "Used memory {{usedMemory}}GiB; Game allocated {{allocatedMemory}}GiB; Total memory {{totalMemory}}GiB"
         },
         "processPriority": {
           "title": "Process Priority",
@@ -1762,7 +1762,7 @@
   },
   "MemoryStatusProgress": {
     "title": "Memory Status",
-    "info": "{{used}} / {{total}} GB used",
+    "info": "{{used}} / {{total}} GiB used",
     "label": {
       "now": "In use",
       "maxAllocation": "Maximum allocated for Minecraft"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -790,7 +790,7 @@
       "includedFiles": "Archivos Incluidos",
       "exportOptions": "Opciones de Exportación",
       "packWithLauncher": "Empaquetar con el Lanzador",
-      "minMemory": "Memoria Mínima (MB)",
+      "minMemory": "Memoria Mínima (MiB)",
       "noCreateRemoteFiles": "Deshabilitar Archivos Remotos",
       "skipCurseForgeRemoteFiles": "Omitir Archivos Remotos de CurseForge"
     },
@@ -920,7 +920,7 @@
         },
         "javaPermanentGenerationSpace": {
           "title": "Espacio PermGen",
-          "placeholder": "en MB"
+          "placeholder": "en MiB"
         },
         "environmentVariable": {
           "title": "Variables de Entorno"
@@ -1277,7 +1277,7 @@
         },
         "memoryUsage": {
           "title": "Uso de Memoria",
-          "description": "Memoria utilizada {{usedMemory}}GB; Juego asignado {{allocatedMemory}}GB; Memoria total {{totalMemory}}GB"
+          "description": "Memoria utilizada {{usedMemory}}GiB; Juego asignado {{allocatedMemory}}GiB; Memoria total {{totalMemory}}GiB"
         },
         "processPriority": {
           "title": "Prioridad del Proceso",
@@ -1762,7 +1762,7 @@
   },
   "MemoryStatusProgress": {
     "title": "Estado de la memoria",
-    "info": "{{used}} / {{total}} GB en uso",
+    "info": "{{used}} / {{total}} GiB en uso",
     "label": {
       "now": "En uso",
       "maxAllocation": "Máximo asignado para Minecraft"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -790,7 +790,7 @@
       "includedFiles": "Fichiers inclus",
       "exportOptions": "Options d'exportation",
       "packWithLauncher": "Inclure le lanceur",
-      "minMemory": "Mémoire minimale (MB)",
+      "minMemory": "Mémoire minimale (Mio)",
       "noCreateRemoteFiles": "Désactiver les fichiers distants",
       "skipCurseForgeRemoteFiles": "Ignorer les fichiers distants CurseForge"
     },
@@ -920,7 +920,7 @@
         },
         "javaPermanentGenerationSpace": {
           "title": "Espace de génération permanente",
-          "placeholder": "Unités en MB"
+          "placeholder": "Unités en Mio"
         },
         "environmentVariable": {
           "title": "Variable d'environnement"
@@ -1277,7 +1277,7 @@
         },
         "memoryUsage": {
           "title": "Utilisation de la mémoire",
-          "description": "Mémoire utilisée {{usedMemory}}GB ; allouée au jeu {{allocatedMemory}}GB ; totale {{totalMemory}}GB"
+          "description": "Mémoire utilisée {{usedMemory}}Gio ; allouée au jeu {{allocatedMemory}}Gio ; totale {{totalMemory}}Gio"
         },
         "processPriority": {
           "title": "Priorité du processus",
@@ -1762,7 +1762,7 @@
   },
   "MemoryStatusProgress": {
     "title": "État de la mémoire",
-    "info": "{{used}} / {{total}} Go utilisés",
+    "info": "{{used}} / {{total}} Gio utilisés",
     "label": {
       "now": "En cours d'utilisation",
       "maxAllocation": "Maximum alloué à Minecraft"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -790,7 +790,7 @@
       "includedFiles": "含めるファイル",
       "exportOptions": "エクスポートオプション",
       "packWithLauncher": "ランチャーを同梱",
-      "minMemory": "最小メモリ (MB)",
+      "minMemory": "最小メモリ (MiB)",
       "noCreateRemoteFiles": "リモートファイルを無効化",
       "skipCurseForgeRemoteFiles": "CurseForge のリモートファイルをスキップ"
     },
@@ -919,8 +919,8 @@
           }
         },
         "javaPermanentGenerationSpace": {
-          "title": "メモリ永続保存領域(MB)",
-          "placeholder": "MB"
+          "title": "メモリ永続保存領域(MiB)",
+          "placeholder": "MiB"
         },
         "environmentVariable": {
           "title": "環境変数"
@@ -1277,7 +1277,7 @@
         },
         "memoryUsage": {
           "title": "メモリ使用状況",
-          "description": "使用済メモリ{{usedMemory}}GB・ゲーム割当メモリ{{allocatedMemory}}GB・総メモリ{{totalMemory}}GB"
+          "description": "使用済メモリ{{usedMemory}}GiB・ゲーム割当メモリ{{allocatedMemory}}GiB・総メモリ{{totalMemory}}GiB"
         },
         "processPriority": {
           "title": "プロセス優先度",
@@ -1762,7 +1762,7 @@
   },
   "MemoryStatusProgress": {
     "title": "メモリ状況",
-    "info": "使用済メモリ {{used}} / {{total}} GB",
+    "info": "使用済メモリ {{used}} / {{total}} GiB",
     "label": {
       "now": "使用済",
       "maxAllocation": "Minecraft の最大割当量"

--- a/src/locales/lzh.json
+++ b/src/locales/lzh.json
@@ -790,7 +790,7 @@
       "includedFiles": "所納之案",
       "exportOptions": "錄出之選",
       "packWithLauncher": "納啟者於包",
-      "minMemory": "至低憶（MB）",
+      "minMemory": "至低憶（MiB）",
       "noCreateRemoteFiles": "弗用遠案",
       "skipCurseForgeRemoteFiles": "略 CurseForge 遠案"
     },
@@ -920,7 +920,7 @@
         },
         "javaPermanentGenerationSpace": {
           "title": "記憶體永久儲存區域",
-          "placeholder": "單位 MB"
+          "placeholder": "單位 MiB"
         },
         "environmentVariable": {
           "title": "環境易量"
@@ -1277,7 +1277,7 @@
         },
         "memoryUsage": {
           "title": "記憶體佔用情況",
-          "description": "已用記憶體{{usedMemory}}GB；戲分配{{allocatedMemory}}GB；總記憶體{{totalMemory}}GB"
+          "description": "已用記憶體{{usedMemory}}GiB；戲分配{{allocatedMemory}}GiB；總記憶體{{totalMemory}}GiB"
         },
         "processPriority": {
           "title": "程序優先順序",
@@ -1762,7 +1762,7 @@
   },
   "MemoryStatusProgress": {
     "title": "記憶體狀態",
-    "info": "{{used}} / {{total}} GB 已使用",
+    "info": "{{used}} / {{total}} GiB 已使用",
     "label": {
       "now": "方使用",
       "maxAllocation": "為 礦藝 分配的最大值"

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -790,7 +790,7 @@
       "includedFiles": "包含文件",
       "exportOptions": "导出选项",
       "packWithLauncher": "打包启动器",
-      "minMemory": "最低内存 (MB)",
+      "minMemory": "最低内存 (MiB)",
       "noCreateRemoteFiles": "禁用远程文件",
       "skipCurseForgeRemoteFiles": "跳过 CurseForge 远程文件"
     },
@@ -920,7 +920,7 @@
         },
         "javaPermanentGenerationSpace": {
           "title": "内存永久保存区域",
-          "placeholder": "单位 MB"
+          "placeholder": "单位 MiB"
         },
         "environmentVariable": {
           "title": "环境变量"
@@ -1277,7 +1277,7 @@
         },
         "memoryUsage": {
           "title": "内存占用情况",
-          "description": "已用内存{{usedMemory}}GB；游戏分配{{allocatedMemory}}GB；总内存{{totalMemory}}GB"
+          "description": "已用内存{{usedMemory}}GiB；游戏分配{{allocatedMemory}}GiB；总内存{{totalMemory}}GiB"
         },
         "processPriority": {
           "title": "进程优先级",
@@ -1762,7 +1762,7 @@
   },
   "MemoryStatusProgress": {
     "title": "内存状态",
-    "info": "{{used}} / {{total}} GB 已使用",
+    "info": "{{used}} / {{total}} GiB 已使用",
     "label": {
       "now": "正在使用",
       "maxAllocation": "为 Minecraft 分配的最大值"

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -790,7 +790,7 @@
       "includedFiles": "包含檔案",
       "exportOptions": "匯出選項",
       "packWithLauncher": "打包啟動器",
-      "minMemory": "最低記憶體 (MB)",
+      "minMemory": "最低記憶體 (MiB)",
       "noCreateRemoteFiles": "停用遠端檔案",
       "skipCurseForgeRemoteFiles": "略過 CurseForge 遠端檔案"
     },
@@ -920,7 +920,7 @@
         },
         "javaPermanentGenerationSpace": {
           "title": "記憶體永久儲存區域",
-          "placeholder": "單位 MB"
+          "placeholder": "單位 MiB"
         },
         "environmentVariable": {
           "title": "環境變數"
@@ -1277,7 +1277,7 @@
         },
         "memoryUsage": {
           "title": "記憶體佔用情況",
-          "description": "已用記憶體 {{usedMemory}} GB；遊戲分配 {{allocatedMemory}} GB；總記憶體 {{totalMemory}} GB"
+          "description": "已用記憶體 {{usedMemory}} GiB；遊戲分配 {{allocatedMemory}} GiB；總記憶體 {{totalMemory}} GiB"
         },
         "processPriority": {
           "title": "處理程式優先度",
@@ -1762,7 +1762,7 @@
   },
   "MemoryStatusProgress": {
     "title": "記憶體狀態",
-    "info": "{{used}} / {{total}} GB 已使用",
+    "info": "{{used}} / {{total}} GiB 已使用",
     "label": {
       "now": "正在使用",
       "maxAllocation": "為 Minecraft 分配的最大值"

--- a/src/pages/settings/download.tsx
+++ b/src/pages/settings/download.tsx
@@ -296,7 +296,7 @@ const DownloadSettingsPage = () => {
                       {/* no stepper NumberInput, use pr={0} */}
                       <NumberInputField pr={0} />
                     </NumberInput>
-                    <Text fontSize="xs">KB/s</Text>
+                    <Text fontSize="xs">KiB/s</Text>
                   </HStack>
                 ),
               },

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -22,7 +22,7 @@ export const removeFileExt = (filename: string): string => {
 
 export const formatByteSize = (bytes: number) => {
   bytes = Math.max(0, bytes);
-  const sizes = ["B", "KB", "MB", "GB"];
+  const sizes = ["B", "KiB", "MiB", "GiB"];
 
   if (bytes >= 1024) {
     let i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), 3);


### PR DESCRIPTION
### Checklist

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [x] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

resolve #1803

### Description

This PR updates binary size and memory unit labels from SI-style names to IEC names across the app.

It changes download progress formatting, download speed limits, memory allocation controls, modpack export memory labels, and memory status text to use `KiB`, `MiB`, and `GiB` where values are already calculated with 1024-based units. It also updates all enabled locale files, including Spanish and French, with French using `Mio` / `Gio`.

### Additional Context

Validated with:

- `jq empty src/locales/*.json`
- `git diff --check`
- targeted search for remaining SI unit labels

Full lint and locale scripts could not be run because local `node_modules` dependencies are missing (`lint-staged`, `chalk`, `eslint`).

## Summary by Sourcery

Align binary size displays with IEC unit conventions across the UI and locale files.

Enhancements:
- Update memory status, game settings, modpack export, and download speed labels to use KiB, MiB, and GiB where values are 1024-based.
- Adjust byte size formatting utility to emit IEC unit labels instead of SI-style KB/MB/GB.

Documentation:
- Refresh all enabled locale files to reflect the new IEC unit labels, including language-specific forms such as French Mio/Gio.