### PR TITLE
refactor: enumerate build type, adjust setup logic of launcher basic info

### DIFF
--- a/src-tauri/src/launcher_config/commands.rs
+++ b/src-tauri/src/launcher_config/commands.rs
@@ -20,7 +20,7 @@ use crate::launcher_config::helpers::updater::{
   self, download_target_version, fetch_latest_version,
 };
 use crate::launcher_config::models::{
-  GameDirectory, JavaInfo, LauncherConfig, LauncherConfigError, VersionMetaInfo,
+  BuildType, GameDirectory, JavaInfo, LauncherConfig, LauncherConfigError, VersionMetaInfo,
 };
 use crate::tasks::{commands::schedule_progressive_task_group, monitor::TaskMonitor};
 use crate::utils::fs::{generate_unique_filename, get_subdirectories};
@@ -343,7 +343,7 @@ pub async fn check_launcher_update(app: AppHandle) -> SJMCLResult<VersionMetaInf
   };
 
   // skip non-release builds, then validate the version is a proper semver
-  if build_type != "release" || semver::Version::parse(&current_version).is_err() {
+  if build_type != BuildType::Release || semver::Version::parse(&current_version).is_err() {
     return Ok(VersionMetaInfo::default());
   }
 

--- a/src-tauri/src/launcher_config/helpers/misc.rs
+++ b/src-tauri/src/launcher_config/helpers/misc.rs
@@ -8,20 +8,29 @@ use tauri::path::BaseDirectory;
 use tauri::{AppHandle, Manager};
 
 use crate::launcher_config::commands::retrieve_custom_background_list;
-use crate::launcher_config::models::{BasicInfo, GameConfig, GameDirectory, LauncherConfig};
+use crate::launcher_config::models::{
+  BasicInfo, BuildType, GameConfig, GameDirectory, LauncherConfig,
+};
 use crate::utils::fs::calculate_sha256;
 use crate::utils::portable::extract_assets;
 use crate::{APP_DATA_DIR, EXE_PATH, IS_PORTABLE};
 
 impl LauncherConfig {
   pub fn setup_with_app(&mut self, app: &AppHandle) -> SJMCLResult<()> {
-    // same as lib.rs
+    // Resolve build_type and displayed version string.
     let is_dev = cfg!(debug_assertions);
-    let version = match (is_dev, app.package_info().version.to_string().as_str()) {
-      (true, _) => "dev".to_string(),
-      (false, "0.0.0") => "nightly".to_string(),
-      (false, "0.0.1") => "test-build".to_string(),
-      (false, v) => v.to_string(),
+    let pkg_version = app.package_info().version.to_string();
+    let build_type = option_env!("SJMCL_BUILD_TYPE")
+      .map(|s| s.parse().unwrap_or(BuildType::Dev))
+      .unwrap_or(match (is_dev, pkg_version.as_str()) {
+        (true, _) => BuildType::Dev,
+        (false, "0.0.0") => BuildType::Nightly,
+        (false, "0.0.1") => BuildType::TestBuild,
+        _ => BuildType::Release,
+      });
+    let version = match build_type {
+      BuildType::Release => pkg_version,
+      _ => build_type.to_string(),
     };
 
     // Set the default download cache directory if unset or not writable, and create it
@@ -111,11 +120,8 @@ impl LauncherConfig {
       // below set to default, will be updated later in first time calling `check_full_login_availability`
       is_china_mainland_ip: false,
       allow_full_login_feature: false,
-      // build metadata: compile-time constants injected by build.rs, falling back
-      // to "dev"/"release" derived from debug_assertions when not explicitly set.
-      build_type: option_env!("SJMCL_BUILD_TYPE")
-        .map(str::to_string)
-        .unwrap_or_else(|| if is_dev { "dev" } else { "release" }.to_string()),
+      // build metadata: compile-time constants may be injected by build.rs
+      build_type,
       build_commit_sha: option_env!("SJMCL_COMMIT_SHA").unwrap_or("").to_string(),
     };
 

--- a/src-tauri/src/launcher_config/models.rs
+++ b/src-tauri/src/launcher_config/models.rs
@@ -4,7 +4,7 @@ use sjmcl_types::partial::PartialUpdate;
 use sjmcl_types::storage::Storage;
 use smart_default::SmartDefault;
 use std::path::PathBuf;
-use strum_macros::Display;
+use strum_macros::{Display, EnumString};
 use tauri::{AppHandle, Emitter};
 
 use crate::launcher_config::constants::{CONFIG_PARTIAL_UPDATE_EVENT, LAUNCHER_CFG_FILE_NAME};
@@ -12,6 +12,16 @@ use crate::launcher_config::migrations::{deserialize_background, deserialize_dis
 use crate::utils::string::snake_to_camel_case;
 use crate::utils::sys_info;
 use crate::{APP_DATA_DIR, EXE_DIR, IS_PORTABLE};
+
+// Info about the latest release version fetched from remote, shown to the user to update.
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct VersionMetaInfo {
+  pub version: String,
+  pub file_name: String,
+  pub release_notes: String,
+  pub published_at: String,
+}
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -30,16 +40,6 @@ pub struct JavaInfo {
   pub major_version: i32, // major version + LTS flag
   pub is_lts: bool,
   pub is_user_added: bool,
-}
-
-// Info about the latest release version fetched from remote, shown to the user to update.
-#[derive(Debug, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VersionMetaInfo {
-  pub version: String,
-  pub file_name: String,
-  pub release_notes: String,
-  pub published_at: String,
 }
 
 // https://github.com/HMCL-dev/HMCL/blob/d9e3816b8edf9e7275e4349d4fc67a5ef2e3c6cf/HMCLCore/src/main/java/org/jackhuang/hmcl/game/ProcessPriority.java#L20
@@ -196,6 +196,21 @@ pub struct GameDirectory {
   pub dir: PathBuf,
 }
 
+// Build metadata: compile-time constants injected by build.rs.
+// Values match frontend src/enums/misc.ts BuildType.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Default, EnumString, Display)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "kebab-case")]
+pub enum BuildType {
+  #[default]
+  Dev,
+  #[serde(rename = "test-build")]
+  TestBuild,
+  Nightly,
+  Beta,
+  Release,
+}
+
 structstruck::strike! {
   #[strikethrough[derive(Partial, Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]]
   #[strikethrough[serde(rename_all = "camelCase")]]
@@ -219,8 +234,8 @@ structstruck::strike! {
       pub allow_full_login_feature: bool,
       // Build metadata, sourced from compile-time constants injected by build.rs.
       // Filled by setup_with_app; not meant to be edited by the user.
-      #[default = "dev"]
-      pub build_type: String,
+      #[default(BuildType::Dev)]
+      pub build_type: BuildType,
       pub build_commit_sha: String,
     },
     // mocked: false when invoked from the backend, true when the frontend placeholder data is used during loading.

--- a/src/components/modals/welcome-and-terms-modal.tsx
+++ b/src/components/modals/welcome-and-terms-modal.tsx
@@ -21,6 +21,7 @@ import { LuLanguages } from "react-icons/lu";
 import LanguageMenu from "@/components/language-menu";
 import { useGuidedTour } from "@/components/special/guided-tour-provider";
 import { useLauncherConfig } from "@/contexts/config";
+import { BuildType } from "@/enums/misc";
 
 const WelcomeAndTermsModal: React.FC<Omit<ModalProps, "children">> = ({
   ...props
@@ -36,17 +37,15 @@ const WelcomeAndTermsModal: React.FC<Omit<ModalProps, "children">> = ({
     startGuidedTour();
   };
 
-  // Map build_type to an unstable-version label for the warning alert.
+  // For non-release builds, use the build type as the version label for the warning alert.
   // release builds get no warning; the rest reuse General.version.<label>.
-  const buildTypeToLabel: Record<string, string> = {
-    dev: "dev",
-    nightly: "nightly",
-    "test-build": "test-build",
-  };
-  const launcherVersion = config.basicInfo.launcherVersion;
-  const matchedVersionLabel =
-    buildTypeToLabel[config.basicInfo.buildType] ??
-    (launcherVersion.includes("beta") ? "beta" : undefined);
+  const matchedUnstableVersionLabel =
+    config.basicInfo.buildType !== BuildType.Release
+      ? config.basicInfo.buildType
+      : config.basicInfo.launcherVersion.startsWith("0.") ||
+          config.basicInfo.launcherVersion.includes("beta")
+        ? BuildType.Beta
+        : undefined;
 
   const isWinArm64 =
     config.basicInfo.platform === "windows" &&
@@ -87,11 +86,13 @@ const WelcomeAndTermsModal: React.FC<Omit<ModalProps, "children">> = ({
               }}
             />
           </Text>
-          {matchedVersionLabel && (
+          {matchedUnstableVersionLabel && (
             <Alert status="warning" mt={3} fontSize="xs-sm" borderRadius="md">
               <AlertIcon />
               {t("WelcomeAndTermsModal.warning.unstableVersion", {
-                versionLabel: t(`General.version.${matchedVersionLabel}`),
+                versionLabel: t(
+                  `General.version.${matchedUnstableVersionLabel}`
+                ),
               })}
             </Alert>
           )}

--- a/src/enums/misc.ts
+++ b/src/enums/misc.ts
@@ -1,3 +1,11 @@
+export enum BuildType {
+  Dev = "dev",
+  Nightly = "nightly",
+  TestBuild = "test-build",
+  Beta = "beta",
+  Release = "release",
+}
+
 export const ChakraColorEnums = [
   "red",
   "orange",

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -1,3 +1,4 @@
+import { BuildType } from "@/enums/misc";
 import type { HomeWidgetStateTuple } from "@/models/extension";
 
 export interface GameConfig {
@@ -82,7 +83,7 @@ export interface LauncherConfig {
     isChinaMainlandIp: boolean;
     allowFullLoginFeature: boolean;
     // Build metadata, sourced from compile-time constants injected by build.rs.
-    buildType: string;
+    buildType: BuildType;
     buildCommitSha: string;
   };
   mocked: boolean;
@@ -270,7 +271,7 @@ export const defaultConfig: LauncherConfig = {
     isExePathAvailable: true,
     isChinaMainlandIp: false,
     allowFullLoginFeature: false,
-    buildType: "dev",
+    buildType: BuildType.Dev,
     buildCommitSha: "",
   },
   mocked: true,

--- a/src/pages/settings/about.tsx
+++ b/src/pages/settings/about.tsx
@@ -18,7 +18,8 @@ import { TitleFullWithLogo } from "@/components/logo-title";
 import { useLauncherConfig } from "@/contexts/config";
 import { useSharedModals } from "@/contexts/shared-modal";
 import { useToast } from "@/contexts/toast";
-import { formatLauncherVersion, isValidSemanticVersion } from "@/utils/string";
+import { BuildType } from "@/enums/misc";
+import { displayLauncherVersion, isValidSemanticVersion } from "@/utils/string";
 
 const AboutSettingsPage = () => {
   const { t } = useTranslation();
@@ -77,9 +78,9 @@ const AboutSettingsPage = () => {
           children: (
             <HStack>
               <Text fontSize="xs-sm" className="secondary-text">
-                {formatLauncherVersion(basicInfo)}
+                {displayLauncherVersion(basicInfo)}
               </Text>
-              {basicInfo.buildType === "release" &&
+              {basicInfo.buildType === BuildType.Release &&
                 isValidSemanticVersion(basicInfo.launcherVersion) && (
                   <Button
                     variant="subtle"

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,3 +1,5 @@
+import { BuildType } from "@/enums/misc";
+
 export const base64ImgSrc = (base64: string): string => {
   return `data:image/png;base64,${base64}`;
 };
@@ -125,13 +127,13 @@ export const isPathSanitized = (path: string, maxLength = 255): boolean => {
 export const isValidSemanticVersion = (version: string) =>
   /^\d+\.\d+\.\d+(-[A-Za-z0-9.-]+)?$/.test(version);
 
-export const formatLauncherVersion = (info: {
+export const displayLauncherVersion = (info: {
   launcherVersion: string;
-  buildType: string;
+  buildType: BuildType;
   buildCommitSha: string;
   isPortable: boolean;
 }): string => {
-  if (info.buildType !== "release") {
+  if (info.buildType !== BuildType.Release) {
     // non-release builds: show the commit short hash in parentheses when
     // available; local dev builds have no injected SHA, so no suffix then.
     const shortSha = info.buildCommitSha.slice(0, 7);


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [x] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - e.g. close #xxxx, fix #xxxx

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Refine build metadata handling by introducing a typed build type across backend and frontend and adjusting launcher setup and version display logic accordingly.

Enhancements:
- Introduce a shared BuildType enum in both Rust and TypeScript to represent launcher build variants instead of raw strings.
- Update launcher setup to derive build type from compile-time metadata or package version and use it to determine the user-facing version string.
- Adjust welcome modal and About page to use the typed build type for unstable-build warnings and version display, including gating update checks to release builds only.