### PR TITLE
feat(instance): support removal of loaders and OptiFine

### DIFF
--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -18,7 +18,8 @@ use zip::read::ZipArchive;
 
 use crate::instance::constants::TRANSLATION_CACHE_EXPIRY_HOURS;
 use crate::instance::helpers::client_json::{
-  McClientInfo, remove_mod_loader_from_client_info, replace_native_libraries,
+  McClientInfo, remove_mod_loader_from_client_info, remove_optifine_from_client_info,
+  replace_native_libraries,
 };
 use crate::instance::helpers::game_version::{build_game_version_cmp_fn, compare_game_versions};
 use crate::instance::helpers::loader::common::{execute_processors, install_mod_loader};
@@ -1519,6 +1520,53 @@ pub async fn change_mod_loader(
 }
 
 #[tauri::command]
+pub async fn remove_mod_loader(app: AppHandle, instance_id: String) -> SJMCLResult<()> {
+  let mut instance = {
+    let binding = app.state::<Mutex<HashMap<String, Instance>>>();
+    let state = binding.lock()?;
+    state
+      .get(&instance_id)
+      .ok_or(InstanceError::InstanceNotFoundByID)?
+      .clone()
+  };
+  let version_isolation = get_instance_game_config(&app, &instance).version_isolation;
+  let json_path = instance
+    .version_path
+    .join(format!("{}.json", instance.name));
+  let mut version_info: McClientInfo = load_json_async(&json_path).await?;
+
+  let subdirs = get_instance_subdir_paths(&app, &instance, &[&InstanceSubdirType::Mods])
+    .ok_or(InstanceError::InstanceNotFoundByID)?;
+  let [mods_dir] = subdirs.as_slice() else {
+    return Err(InstanceError::InstanceNotFoundByID.into());
+  };
+
+  if matches!(
+    instance.mod_loader.loader_type,
+    ModLoaderType::Fabric | ModLoaderType::Quilt
+  ) && version_isolation
+  {
+    remove_fabric_api_mods(mods_dir).await?;
+  }
+
+  remove_mod_loader_from_client_info(&mut version_info, instance.mod_loader.loader_type);
+  instance.mod_loader = ModLoader {
+    loader_type: ModLoaderType::Unknown,
+    version: String::new(),
+    status: ModLoaderStatus::Installed,
+    branch: None,
+  };
+
+  save_json_async(&version_info, &json_path).await?;
+  instance
+    .save_json_cfg()
+    .await
+    .map_err(|_| InstanceError::FileCreationFailed)?;
+
+  Ok(())
+}
+
+#[tauri::command]
 pub async fn change_optifine(
   app: AppHandle,
   instance_id: String,
@@ -1565,6 +1613,33 @@ pub async fn change_optifine(
     .await?;
   }
 
+  instance
+    .save_json_cfg()
+    .await
+    .map_err(|_| InstanceError::FileCreationFailed)?;
+
+  Ok(())
+}
+
+#[tauri::command]
+pub async fn remove_optifine(app: AppHandle, instance_id: String) -> SJMCLResult<()> {
+  let mut instance = {
+    let binding = app.state::<Mutex<HashMap<String, Instance>>>();
+    let state = binding.lock()?;
+    state
+      .get(&instance_id)
+      .ok_or(InstanceError::InstanceNotFoundByID)?
+      .clone()
+  };
+  let json_path = instance
+    .version_path
+    .join(format!("{}.json", instance.name));
+  let mut version_info: McClientInfo = load_json_async(&json_path).await?;
+
+  remove_optifine_from_client_info(&mut version_info);
+  instance.optifine = None;
+
+  save_json_async(&version_info, &json_path).await?;
   instance
     .save_json_cfg()
     .await

--- a/src-tauri/src/instance/helpers/client_json.rs
+++ b/src-tauri/src/instance/helpers/client_json.rs
@@ -373,11 +373,14 @@ pub fn remove_optifine_from_client_info(client_info: &mut McClientInfo) {
   reset_fields_from_patches(client_info);
 }
 
-fn reset_fields_from_patches(client_info: &mut McClientInfo) {
+pub fn reset_fields_from_patches(client_info: &mut McClientInfo) {
   let patches = client_info.patches.clone();
   let Some(base) = patches.first() else {
     return;
   };
+  let has_forge_patch = patches
+    .iter()
+    .any(|patch| matches!(patch.id.as_str(), "forge" | "legacyforge"));
 
   client_info.libraries.clear();
   let mut library_names = HashSet::new();
@@ -401,7 +404,14 @@ fn reset_fields_from_patches(client_info: &mut McClientInfo) {
       client_info.main_class = Some(main_class.clone());
     }
 
-    if let Some(arguments) = &patch.arguments {
+    let mut patch_arguments = patch.arguments.clone();
+    if patch.id == "optifine" {
+      if let Some(arguments) = &mut patch_arguments {
+        normalize_optifine_tweaker(arguments, has_forge_patch);
+      }
+    }
+
+    if let Some(arguments) = patch_arguments {
       if let Some(base_arguments) = &mut client_info.arguments {
         base_arguments.game.extend(arguments.game.clone());
         base_arguments.jvm.extend(arguments.jvm.clone());
@@ -411,7 +421,14 @@ fn reset_fields_from_patches(client_info: &mut McClientInfo) {
       client_info.minecraft_arguments = None;
     }
 
-    if let Some(minecraft_arguments) = &patch.minecraft_arguments {
+    let mut patch_minecraft_arguments = patch.minecraft_arguments.clone();
+    if patch.id == "optifine"
+      && let Some(minecraft_arguments) = &mut patch_minecraft_arguments
+    {
+      normalize_optifine_tweaker_str(minecraft_arguments, has_forge_patch);
+    }
+
+    if let Some(minecraft_arguments) = &patch_minecraft_arguments {
       if minecraft_arguments.is_empty() {
         continue;
       }
@@ -427,6 +444,37 @@ fn reset_fields_from_patches(client_info: &mut McClientInfo) {
       }
     }
   }
+}
+
+fn normalize_optifine_tweaker(arguments: &mut LaunchArgumentTemplate, has_forge_patch: bool) {
+  let tweaker = if has_forge_patch {
+    "optifine.OptiFineForgeTweaker"
+  } else {
+    "optifine.OptiFineTweaker"
+  };
+
+  for item in &mut arguments.game {
+    for value in &mut item.value {
+      if matches!(
+        value.as_str(),
+        "optifine.OptiFineTweaker" | "optifine.OptiFineForgeTweaker"
+      ) {
+        *value = tweaker.to_string();
+      }
+    }
+  }
+}
+
+fn normalize_optifine_tweaker_str(arguments: &mut String, has_forge_patch: bool) {
+  let tweaker = if has_forge_patch {
+    "optifine.OptiFineForgeTweaker"
+  } else {
+    "optifine.OptiFineTweaker"
+  };
+
+  *arguments = arguments
+    .replace("optifine.OptiFineForgeTweaker", tweaker)
+    .replace("optifine.OptiFineTweaker", tweaker);
 }
 
 pub async fn libraries_to_info(

--- a/src-tauri/src/instance/helpers/client_json.rs
+++ b/src-tauri/src/instance/helpers/client_json.rs
@@ -368,6 +368,11 @@ pub fn remove_mod_loader_from_client_info(
   reset_fields_from_patches(client_info);
 }
 
+pub fn remove_optifine_from_client_info(client_info: &mut McClientInfo) {
+  client_info.patches.retain(|patch| patch.id != "optifine");
+  reset_fields_from_patches(client_info);
+}
+
 fn reset_fields_from_patches(client_info: &mut McClientInfo) {
   let patches = client_info.patches.clone();
   let Some(base) = patches.first() else {

--- a/src-tauri/src/instance/helpers/loader/forge.rs
+++ b/src-tauri/src/instance/helpers/loader/forge.rs
@@ -11,7 +11,9 @@ use tauri_plugin_http::reqwest;
 use url::Url;
 use zip::ZipArchive;
 
-use crate::instance::helpers::client_json::{LaunchArgumentTemplate, LibrariesValue, McClientInfo};
+use crate::instance::helpers::client_json::{
+  LibrariesValue, McClientInfo, reset_fields_from_patches,
+};
 use crate::instance::helpers::loader::common::add_library_entry;
 use crate::instance::helpers::misc::get_instance_subdir_paths;
 use crate::instance::models::misc::{Instance, InstanceError, InstanceSubdirType, ModLoader};
@@ -322,21 +324,13 @@ pub async fn download_forge_libraries(
       }));
     }
 
-    let (arguments, minecraft_arguments) = if let Some(v_args) = &client_info.arguments {
-      let nf_args = forge_info
-        .arguments
-        .ok_or(InstanceError::ModLoaderVersionParseError)?;
-
-      let new_args = LaunchArgumentTemplate {
-        game: [v_args.game.clone(), nf_args.game.clone()].concat(),
-        jvm: [v_args.jvm.clone(), nf_args.jvm.clone()].concat(),
-      };
-      (Some(new_args), None)
+    let arguments = forge_info.arguments.clone();
+    let minecraft_arguments = if arguments.is_some() {
+      None
     } else {
-      (None, forge_info.minecraft_arguments)
+      forge_info.minecraft_arguments.clone()
     };
-    client_info.arguments = arguments.clone();
-    client_info.minecraft_arguments = minecraft_arguments.clone();
+
     client_info.patches.push(McClientInfo {
       id: "forge".to_string(),
       version: Some(forge_info.id.clone()),
@@ -452,6 +446,8 @@ pub async fn download_forge_libraries(
     }
     client_info.patches.push(new_patch);
   }
+
+  reset_fields_from_patches(client_info);
 
   let mut seen = std::collections::HashSet::new();
   task_params.retain(|param| match param {

--- a/src-tauri/src/instance/helpers/loader/neoforge.rs
+++ b/src-tauri/src/instance/helpers/loader/neoforge.rs
@@ -7,7 +7,7 @@ use tauri::AppHandle;
 use url::Url;
 use zip::ZipArchive;
 
-use crate::instance::helpers::client_json::{LaunchArgumentTemplate, McClientInfo};
+use crate::instance::helpers::client_json::{McClientInfo, reset_fields_from_patches};
 use crate::instance::helpers::loader::common::add_library_entry;
 use crate::instance::helpers::loader::forge::InstallProfile;
 use crate::instance::helpers::misc::get_instance_subdir_paths;
@@ -293,23 +293,16 @@ pub async fn download_neoforge_libraries(
 
   let nf_args = neoforge_info
     .arguments
-    .ok_or(InstanceError::ModLoaderVersionParseError)?;
-  let v_args = client_info
-    .arguments
     .clone()
-    .ok_or(InstanceError::ClientJsonParseError)?;
-  let new_args = LaunchArgumentTemplate {
-    game: [v_args.game, nf_args.game].concat(),
-    jvm: [v_args.jvm, nf_args.jvm].concat(),
-  };
-  client_info.arguments = Some(new_args.clone());
+    .ok_or(InstanceError::ModLoaderVersionParseError)?;
+
   client_info.patches.push(McClientInfo {
     id: "neoforge".to_string(),
     version: Some(neoforge_info.id.clone()),
     priority: Some(30000),
     inherits_from: neoforge_info.inherits_from.clone(),
     main_class: neoforge_info.main_class.clone(),
-    arguments: Some(new_args.clone()),
+    arguments: Some(nf_args),
     libraries: loader_libraries,
     ..Default::default()
   });
@@ -339,6 +332,8 @@ pub async fn download_neoforge_libraries(
       sha1: None,
     }));
   }
+
+  reset_fields_from_patches(client_info);
 
   let mut seen = std::collections::HashSet::new();
   task_params.retain(|param| match param {

--- a/src-tauri/src/launch/helpers/command_generator.rs
+++ b/src-tauri/src/launch/helpers/command_generator.rs
@@ -182,11 +182,11 @@ pub async fn generate_launch_command(
     assets_index_name: client_info.asset_index.id.clone(),
     game_directory: root_dir.to_string_lossy().to_string(),
 
-    version_name: custom_info
-      .clone()
-      .unwrap_or_else(|| selected_instance.name.clone()),
+    version_name: selected_instance.name.clone(),
     primary_jar_name: format!("{}.jar", selected_instance.name.clone()),
-    version_type: custom_info.unwrap_or_else(|| client_info.type_.clone()),
+    version_type: custom_info
+      .clone()
+      .unwrap_or_else(|| client_info.type_.clone()),
     natives_directory: natives_dir.to_string_lossy().to_string(),
     launcher_name: "SJMC Launcher".to_string(),
     launcher_version: basic_info.launcher_version,
@@ -372,7 +372,11 @@ pub async fn generate_launch_command(
   // -----------------------------------------
   // Part 3: Replace JVM and game arguments
   // -----------------------------------------
-  let map = arguments_value.into_hashmap()?;
+  let jvm_map = arguments_value.into_hashmap()?;
+  let mut game_map = jvm_map.clone();
+  if let Some(custom_info) = custom_info {
+    game_map.insert("version_name".to_string(), custom_info);
+  }
 
   // some feature rules defined in client json, add to jvm/game arg templates
   let has_quickplay_single = quick_play_singleplayer
@@ -399,7 +403,7 @@ pub async fn generate_launch_command(
       client_jvm_args.remove(classpath_pos);
       client_jvm_args.remove(classpath_pos);
     }
-    cmd.extend(replace_arguments(client_jvm_args, &map));
+    cmd.extend(replace_arguments(client_jvm_args, &jvm_map));
   } else {
     // ref: https://github.com/HMCL-dev/HMCL/blob/e8ff42c4b29d0b0a5a417c9d470390311c6d9a72/HMCLCore/src/main/java/org/jackhuang/hmcl/game/Arguments.java#L112
     let mut client_jvm_args = vec![];
@@ -423,7 +427,7 @@ pub async fn generate_launch_command(
       "-Dminecraft.launcher.brand=${launcher_name}".to_string(),
       "-Dminecraft.launcher.version=${launcher_version}".to_string(),
     ]);
-    cmd.extend(replace_arguments(client_jvm_args, &map));
+    cmd.extend(replace_arguments(client_jvm_args, &jvm_map));
   }
 
   // main class (after replace jvm args)
@@ -436,10 +440,10 @@ pub async fn generate_launch_command(
 
   if let Some(client_args) = &client_info.arguments {
     let client_game_args = client_args.to_game_arguments(&launch_feature)?;
-    cmd.extend(replace_arguments(client_game_args, &map));
+    cmd.extend(replace_arguments(client_game_args, &game_map));
   } else if let Some(client_args_str) = client_info.minecraft_arguments {
     let client_game_args = client_args_str.split(' ').map(|s| s.to_string()).collect();
-    cmd.extend(replace_arguments(client_game_args, &map));
+    cmd.extend(replace_arguments(client_game_args, &game_map));
   } else {
     return Err(InstanceError::ClientJsonParseError.into());
   }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -142,6 +142,8 @@ pub async fn run() {
         instance::commands::check_change_mod_loader_availablity,
         instance::commands::change_mod_loader,
         instance::commands::change_optifine,
+        instance::commands::remove_mod_loader,
+        instance::commands::remove_optifine,
         instance::commands::retrieve_modpack_meta_info,
         instance::commands::add_custom_instance_icon,
         instance::commands::retrieve_exportable_file_list,

--- a/src/components/modals/change-loader-modal.tsx
+++ b/src/components/modals/change-loader-modal.tsx
@@ -23,7 +23,9 @@ import { LuArrowRight } from "react-icons/lu";
 import { OptionItem } from "@/components/common/option-item";
 import { LoaderSelector } from "@/components/loader-selector";
 import { useLauncherConfig } from "@/contexts/config";
+import { useGlobalData } from "@/contexts/global-data";
 import { useInstanceSharedData } from "@/contexts/instance";
+import { useSharedModals } from "@/contexts/shared-modal";
 import { useToast } from "@/contexts/toast";
 import { ModLoaderType } from "@/enums/instance";
 import {
@@ -48,8 +50,10 @@ export const ChangeLoaderModal: React.FC<ChangeLoaderModalProps> = ({
 }) => {
   const { t } = useTranslation();
   const { config } = useLauncherConfig();
+  const { getInstanceList } = useGlobalData();
   const { summary } = useInstanceSharedData();
   const primaryColor = config.appearance.theme.primaryColor;
+  const { openGenericConfirmDialog } = useSharedModals();
   const toast = useToast();
   const router = useRouter();
 
@@ -116,7 +120,6 @@ export const ChangeLoaderModal: React.FC<ChangeLoaderModalProps> = ({
             : null;
 
       if (!res) return;
-
       if (res.status === "error") {
         toast({
           title: res.message,
@@ -132,7 +135,53 @@ export const ChangeLoaderModal: React.FC<ChangeLoaderModalProps> = ({
     }
   };
 
-  const isUnselected =
+  const handleRemoveCurrentInstallation = () => {
+    if (!summary?.id) return;
+
+    const tKey =
+      mode === "modloader" ? "RemoveModLoaderDialog" : "RemoveOptifineDialog";
+
+    const dialogBody =
+      mode === "modloader"
+        ? t(`${tKey}.dialog.content`, {
+            instanceName: summary.name,
+            type: currentModLoader.loaderType,
+            version: parseModLoaderVersion(currentModLoader.version),
+          })
+        : t(`${tKey}.dialog.content`, {
+            instanceName: summary.name,
+            version: summary?.optifine?.version || "",
+          });
+
+    openGenericConfirmDialog({
+      title: t(`${tKey}.dialog.title`),
+      body: dialogBody,
+      btnOK: t("General.delete"),
+      isAlert: true,
+      onOKCallback: async () => {
+        const res =
+          mode === "modloader"
+            ? await InstanceService.removeModLoader(summary.id!)
+            : await InstanceService.removeOptifine(summary.id!);
+        if (res.status === "error") {
+          toast({
+            title: res.message,
+            description: res.details,
+            status: "error",
+          });
+        } else {
+          toast({
+            title: res.message,
+            status: "success",
+          });
+          modalProps.onClose?.();
+          getInstanceList(true); // refresh instance info
+        }
+      },
+    });
+  };
+
+  const isNewLoaderUnselected =
     !selectedModLoader.version ||
     selectedModLoader.loaderType === ModLoaderType.Unknown;
 
@@ -146,7 +195,9 @@ export const ChangeLoaderModal: React.FC<ChangeLoaderModalProps> = ({
         summary.optifine.version ===
           `${selectedOptifine.type}_${selectedOptifine.patch}`;
 
-  const isDisabled = mode === "modloader" ? isUnselected : !selectedOptifine;
+  const isDisabled =
+    mode === "modloader" ? isNewLoaderUnselected : !selectedOptifine;
+
   return (
     <Modal
       scrollBehavior="inside"
@@ -203,7 +254,7 @@ export const ChangeLoaderModal: React.FC<ChangeLoaderModalProps> = ({
               <LuArrowRight size={18} />
             </Box>
             <Flex flex="1" justify="flex-start" pl={8}>
-              {isUnselected ? (
+              {isNewLoaderUnselected ? (
                 <OptionItem
                   prefixElement={<Skeleton boxSize="36px" borderRadius="md" />}
                   title={
@@ -375,6 +426,18 @@ export const ChangeLoaderModal: React.FC<ChangeLoaderModalProps> = ({
             <Button variant="ghost" onClick={modalProps.onClose}>
               {t("General.cancel")}
             </Button>
+
+            {isDisabled &&
+              (mode === "modloader"
+                ? currentModLoader.loaderType !== "Unknown"
+                : !!summary?.optifine) && (
+                <Button
+                  variant="ghost"
+                  onClick={handleRemoveCurrentInstallation}
+                >
+                  {t("ChangeLoaderModal.footer.removeCurrentInstallation")}
+                </Button>
+              )}
 
             <Button
               colorScheme={primaryColor}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -368,7 +368,8 @@
     "footer": {
       "installFabricApi": "Install Fabric API Mod",
       "installQFAPI": "Install QFAPI / QSL Mod (if available)",
-      "reinstall": "Reinstall"
+      "reinstall": "Reinstall",
+      "removeCurrentInstallation": "Remove Installation"
     }
   },
   "CheckModUpdateModal": {
@@ -1877,6 +1878,18 @@
       "login": "Login"
     }
   },
+  "RemoveModLoaderDialog": {
+    "dialog": {
+      "title": "Remove Mod Loader",
+      "content": "Are you sure you want to remove {{type}} {{version}} installed for {{instanceName}}? Your mods may stop working."
+    }
+  },
+  "RemoveOptifineDialog": {
+    "dialog": {
+      "title": "Remove OptiFine",
+      "content": "Are you sure you want to remove OptiFine {{version}} installed for {{instanceName}}? Your shader packs may stop working."
+    }
+  },
   "ResourceDownloader": {
     "label": {
       "source": "Source",
@@ -2925,6 +2938,26 @@
       "changeOptiFine": {
         "error": {
           "title": "Failed to Change OptiFine"
+        }
+      },
+      "removeModLoader": {
+        "success": "Mod loader removed successfully",
+        "error": {
+          "title": "Failed to remove mod loader",
+          "description": {
+            "INSTANCE_NOT_FOUND_BY_ID": "Instance ID does not exist",
+            "FILE_CREATION_FAILED": "Failed to save instance configuration"
+          }
+        }
+      },
+      "removeOptifine": {
+        "success": "OptiFine removed successfully",
+        "error": {
+          "title": "Failed to remove OptiFine",
+          "description": {
+            "INSTANCE_NOT_FOUND_BY_ID": "Instance ID does not exist",
+            "FILE_CREATION_FAILED": "Failed to save instance configuration"
+          }
         }
       },
       "retrieveModpackMetaInfo": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -368,7 +368,8 @@
     "footer": {
       "installFabricApi": "Instalar Mod Fabric API",
       "installQFAPI": "Instalar Mod QFAPI / QSL (si está disponible)",
-      "reinstall": "Reinstalar"
+      "reinstall": "Reinstalar",
+      "removeCurrentInstallation": "Eliminar instalación"
     }
   },
   "CheckModUpdateModal": {
@@ -1877,6 +1878,18 @@
       "login": "Iniciar sesión"
     }
   },
+  "RemoveModLoaderDialog": {
+    "dialog": {
+      "title": "Eliminar cargador de mods",
+      "content": "¿Está seguro de que desea eliminar {{type}} {{version}} instalado para {{instanceName}}? Es posible que sus mods dejen de funcionar."
+    }
+  },
+  "RemoveOptifineDialog": {
+    "dialog": {
+      "title": "Eliminar OptiFine",
+      "content": "¿Está seguro de que desea eliminar OptiFine {{version}} instalado para {{instanceName}}? Es posible que sus shader packs dejen de funcionar."
+    }
+  },
   "ResourceDownloader": {
     "label": {
       "source": "Fuente",
@@ -2919,6 +2932,31 @@
           "title": "Error al cambiar el cargador de mods",
           "description": {
             "NOT_SUPPORT_CHANGE_MOD_LOADER": "Instalado por un proceso externo, no se puede configurar"
+          }
+        }
+      },
+      "changeOptiFine": {
+        "error": {
+          "title": "Error al modificar OptiFine"
+        }
+      },
+      "removeModLoader": {
+        "success": "Cargador de mods eliminado correctamente",
+        "error": {
+          "title": "Error al eliminar el cargador de mods",
+          "description": {
+            "INSTANCE_NOT_FOUND_BY_ID": "El ID de la instancia no existe",
+            "FILE_CREATION_FAILED": "Error al guardar la configuración de la instancia"
+          }
+        }
+      },
+      "removeOptifine": {
+        "success": "OptiFine eliminado correctamente",
+        "error": {
+          "title": "Error al eliminar OptiFine",
+          "description": {
+            "INSTANCE_NOT_FOUND_BY_ID": "El ID de la instancia no existe",
+            "FILE_CREATION_FAILED": "Error al guardar la configuración de la instancia"
           }
         }
       },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -368,7 +368,8 @@
     "footer": {
       "installFabricApi": "Installer également le mod Fabric API",
       "installQFAPI": "Installer aussi le mod QFAPI / QSL (si disponible)",
-      "reinstall": "Réinstaller"
+      "reinstall": "Réinstaller",
+      "removeCurrentInstallation": "Supprimer l'installation"
     }
   },
   "CheckModUpdateModal": {
@@ -1877,6 +1878,18 @@
       "login": "Connexion"
     }
   },
+  "RemoveModLoaderDialog": {
+    "dialog": {
+      "title": "Supprimer le chargeur de mods",
+      "content": "Êtes-vous sûr de vouloir supprimer {{type}} {{version}} installé pour {{instanceName}} ? Vos mods pourraient ne plus fonctionner."
+    }
+  },
+  "RemoveOptifineDialog": {
+    "dialog": {
+      "title": "Supprimer OptiFine",
+      "content": "Êtes-vous sûr de vouloir supprimer OptiFine {{version}} installé pour {{instanceName}} ? Vos shader packs pourraient ne plus fonctionner."
+    }
+  },
   "ResourceDownloader": {
     "label": {
       "source": "Source",
@@ -2925,6 +2938,26 @@
       "changeOptiFine": {
         "error": {
           "title": "Échec de la modification d'OptiFine"
+        }
+      },
+      "removeModLoader": {
+        "success": "Chargeur de mods supprimé avec succès",
+        "error": {
+          "title": "Échec de la suppression du chargeur de mods",
+          "description": {
+            "INSTANCE_NOT_FOUND_BY_ID": "L'ID de l'instance n'existe pas",
+            "FILE_CREATION_FAILED": "Échec de la sauvegarde de la configuration de l'instance"
+          }
+        }
+      },
+      "removeOptifine": {
+        "success": "OptiFine supprimé avec succès",
+        "error": {
+          "title": "Échec de la suppression d'OptiFine",
+          "description": {
+            "INSTANCE_NOT_FOUND_BY_ID": "L'ID de l'instance n'existe pas",
+            "FILE_CREATION_FAILED": "Échec de la sauvegarde de la configuration de l'instance"
+          }
         }
       },
       "retrieveModpackMetaInfo": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -368,7 +368,8 @@
     "footer": {
       "installFabricApi": "同時に Fabric API モッドをインストール",
       "installQFAPI": "QFAPI / QSL モッドもインストール（利用可能な場合）",
-      "reinstall": "再インストール"
+      "reinstall": "再インストール",
+      "removeCurrentInstallation": "インストールを削除"
     }
   },
   "CheckModUpdateModal": {
@@ -1877,6 +1878,18 @@
       "login": "ログイン"
     }
   },
+  "RemoveModLoaderDialog": {
+    "dialog": {
+      "title": "Modローダーを削除",
+      "content": "{{instanceName}} にインストールされた {{type}} {{version}} を削除してもよろしいですか？Modが動作しなくなる可能性があります。"
+    }
+  },
+  "RemoveOptifineDialog": {
+    "dialog": {
+      "title": "OptiFineを削除",
+      "content": "{{instanceName}} にインストールされた OptiFine {{version}} を削除してもよろしいですか？シェーダーパックが動作しなくなる可能性があります。"
+    }
+  },
   "ResourceDownloader": {
     "label": {
       "source": "ダウンロードソース",
@@ -2925,6 +2938,26 @@
       "changeOptiFine": {
         "error": {
           "title": "OptiFine の変更に失敗"
+        }
+      },
+      "removeModLoader": {
+        "success": "Modローダーが正常に削除されました",
+        "error": {
+          "title": "Modローダーの削除に失敗",
+          "description": {
+            "INSTANCE_NOT_FOUND_BY_ID": "インスタンスIDが存在しません",
+            "FILE_CREATION_FAILED": "インスタンス設定の保存に失敗"
+          }
+        }
+      },
+      "removeOptifine": {
+        "success": "OptiFineが正常に削除されました",
+        "error": {
+          "title": "OptiFineの削除に失敗",
+          "description": {
+            "INSTANCE_NOT_FOUND_BY_ID": "インスタンスIDが存在しません",
+            "FILE_CREATION_FAILED": "インスタンス設定の保存に失敗"
+          }
         }
       },
       "retrieveModpackMetaInfo": {

--- a/src/locales/lzh.json
+++ b/src/locales/lzh.json
@@ -368,7 +368,8 @@
     "footer": {
       "installFabricApi": "同時置 Fabric API 改囊",
       "installQFAPI": "同時置 QFAPI / QSL 改囊（若可用）",
-      "reinstall": "復置"
+      "reinstall": "復置",
+      "removeCurrentInstallation": "移除安裝"
     }
   },
   "CheckModUpdateModal": {
@@ -1877,6 +1878,18 @@
       "login": "登入"
     }
   },
+  "RemoveModLoaderDialog": {
+    "dialog": {
+      "title": "移除模組載入器",
+      "content": "確認要移除為 {{instanceName}} 已安裝的模組載入器 {{type}} {{version}} 嗎？您的模組可能將無法使用。"
+    }
+  },
+  "RemoveOptifineDialog": {
+    "dialog": {
+      "title": "移除 OptiFine",
+      "content": "確認要移除為 {{instanceName}} 已安裝的 OptiFine {{version}} 嗎？您的光影可能將無法使用。"
+    }
+  },
   "ResourceDownloader": {
     "label": {
       "source": "引源",
@@ -2925,6 +2938,26 @@
       "changeOptiFine": {
         "error": {
           "title": "改 OptiFine 未成"
+        }
+      },
+      "removeModLoader": {
+        "success": "模組載入器移除成功",
+        "error": {
+          "title": "模組載入器移除失敗",
+          "description": {
+            "INSTANCE_NOT_FOUND_BY_ID": "實例 ID 不存在",
+            "FILE_CREATION_FAILED": "實例配置文件保存失敗"
+          }
+        }
+      },
+      "removeOptifine": {
+        "success": "OptiFine 移除成功",
+        "error": {
+          "title": "OptiFine 移除失敗",
+          "description": {
+            "INSTANCE_NOT_FOUND_BY_ID": "實例 ID 不存在",
+            "FILE_CREATION_FAILED": "實例配置文件保存失敗"
+          }
         }
       },
       "retrieveModpackMetaInfo": {

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -368,7 +368,8 @@
     "footer": {
       "installFabricApi": "同时安装 Fabric API 模组",
       "installQFAPI": "同时安装 QFAPI / QSL 模组（如果可用）",
-      "reinstall": "重新安装"
+      "reinstall": "重新安装",
+      "removeCurrentInstallation": "移除安装"
     }
   },
   "CheckModUpdateModal": {
@@ -1877,6 +1878,18 @@
       "login": "登录"
     }
   },
+  "RemoveModLoaderDialog": {
+    "dialog": {
+      "title": "移除模组加载器",
+      "content": "确认要移除为 {{instanceName}} 已安装的模组加载器 {{type}} {{version}} 吗？您的模组可能将无法使用。"
+    }
+  },
+  "RemoveOptifineDialog": {
+    "dialog": {
+      "title": "移除 OptiFine",
+      "content": "确认要移除为 {{instanceName}} 已安装的 OptiFine {{version}} 吗？您的光影可能将无法使用。"
+    }
+  },
   "ResourceDownloader": {
     "label": {
       "source": "下载源",
@@ -2925,6 +2938,26 @@
       "changeOptiFine": {
         "error": {
           "title": "修改 OptiFine 失败"
+        }
+      },
+      "removeModLoader": {
+        "success": "模组加载器移除成功",
+        "error": {
+          "title": "模组加载器移除失败",
+          "description": {
+            "INSTANCE_NOT_FOUND_BY_ID": "实例 ID 不存在",
+            "FILE_CREATION_FAILED": "实例配置文件保存失败"
+          }
+        }
+      },
+      "removeOptifine": {
+        "success": "OptiFine 移除成功",
+        "error": {
+          "title": "OptiFine 移除失败",
+          "description": {
+            "INSTANCE_NOT_FOUND_BY_ID": "实例 ID 不存在",
+            "FILE_CREATION_FAILED": "实例配置文件保存失败"
+          }
         }
       },
       "retrieveModpackMetaInfo": {

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -368,7 +368,8 @@
     "footer": {
       "installFabricApi": "同時安裝 Fabric API 模組",
       "installQFAPI": "同時安裝 QFAPI / QSL 模組（如果可用）",
-      "reinstall": "重新安裝"
+      "reinstall": "重新安裝",
+      "removeCurrentInstallation": "移除安裝"
     }
   },
   "CheckModUpdateModal": {
@@ -1877,6 +1878,18 @@
       "login": "登入"
     }
   },
+  "RemoveModLoaderDialog": {
+    "dialog": {
+      "title": "移除模組載入器",
+      "content": "確認要移除為 {{instanceName}} 已安裝的模組載入器 {{type}} {{version}} 嗎？您的模組可能將無法使用。"
+    }
+  },
+  "RemoveOptifineDialog": {
+    "dialog": {
+      "title": "移除 OptiFine",
+      "content": "確認要移除為 {{instanceName}} 已安裝的 OptiFine {{version}} 嗎？您的光影可能將無法使用。"
+    }
+  },
   "ResourceDownloader": {
     "label": {
       "source": "下載源",
@@ -2925,6 +2938,26 @@
       "changeOptiFine": {
         "error": {
           "title": "修改 OptiFine 失敗"
+        }
+      },
+      "removeModLoader": {
+        "success": "模組載入器移除成功",
+        "error": {
+          "title": "模組載入器移除失敗",
+          "description": {
+            "INSTANCE_NOT_FOUND_BY_ID": "實例 ID 不存在",
+            "FILE_CREATION_FAILED": "實例配置檔案儲存失敗"
+          }
+        }
+      },
+      "removeOptifine": {
+        "success": "OptiFine 移除成功",
+        "error": {
+          "title": "OptiFine 移除失敗",
+          "description": {
+            "INSTANCE_NOT_FOUND_BY_ID": "實例 ID 不存在",
+            "FILE_CREATION_FAILED": "實例配置檔案儲存失敗"
+          }
         }
       },
       "retrieveModpackMetaInfo": {

--- a/src/services/instance.ts
+++ b/src/services/instance.ts
@@ -513,6 +513,20 @@ export class InstanceService {
   }
 
   /**
+   * REMOVE the mod loader from a given instance.
+   * @param {string} instanceId - The ID of the instance.
+   * @returns {Promise<InvokeResponse<void>>}
+   */
+  @responseHandler("instance")
+  static async removeModLoader(
+    instanceId: string
+  ): Promise<InvokeResponse<void>> {
+    return await invoke("remove_mod_loader", {
+      instanceId,
+    });
+  }
+
+  /**
    * CHANGE the OptiFine version for a given instance.
    * @param {string} instanceId - The ID of the instance to update.
    * @param {OptiFineResourceInfo} newOptifine - The new OptiFine information.
@@ -526,6 +540,20 @@ export class InstanceService {
     return await invoke("change_optifine", {
       instanceId,
       newOptifine,
+    });
+  }
+
+  /**
+   * REMOVE the OptiFine from a given instance.
+   * @param {string} instanceId - The ID of the instance.
+   * @returns {Promise<InvokeResponse<void>>}
+   */
+  @responseHandler("instance")
+  static async removeOptifine(
+    instanceId: string
+  ): Promise<InvokeResponse<void>> {
+    return await invoke("remove_optifine", {
+      instanceId,
     });
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - close #1738

## Summary by Sourcery

Add commands to remove an instance's mod loader and OptiFine configuration and update client JSON handling accordingly.

New Features:
- Expose a Tauri command to remove the mod loader from an instance and clear related configuration.
- Expose a Tauri command to remove OptiFine from an instance and clear related configuration.

Enhancements:
- Extend client JSON helpers to support removing OptiFine patches and recalculating derived fields.
- Register the new remove commands in the Tauri command list so they are available to the frontend.