### PR TITLE
style(backend): annotate dead code with expect and allow attributes

### DIFF
--- a/src-tauri/src/account/helpers/import/hmcl.rs
+++ b/src-tauri/src/account/helpers/import/hmcl.rs
@@ -66,10 +66,12 @@ pub struct HmclMicrosoftAccount {
   #[serde(rename = "profileID")]
   pub profile_id: String,
   pub profile_name: String,
+  #[expect(dead_code, reason = "kept to match HMCL account JSON schema")]
   pub token_type: String,
   pub access_token: String,
   pub refresh_token: String,
   pub not_after: Option<i64>,
+  #[expect(dead_code, reason = "kept to match HMCL account JSON schema")]
   pub userid: String,
 }
 
@@ -83,6 +85,7 @@ pub struct HmclProfileProperties {
 pub struct HmclThirdPartyAccount {
   #[serde(rename = "serverBaseURL")]
   pub server_base_url: String,
+  #[expect(dead_code, reason = "kept to match HMCL account JSON schema")]
   pub client_token: String,
   pub login_name: Option<String>,
   pub profile_name: Option<String>,

--- a/src-tauri/src/account/helpers/import/legacy_hmcl.rs
+++ b/src-tauri/src/account/helpers/import/legacy_hmcl.rs
@@ -33,10 +33,12 @@ struct HmclOfflineAccount {
 struct HmclMicrosoftAccount {
   uuid: String,
   display_name: String,
+  #[expect(dead_code, reason = "kept to match HMCL account JSON schema")]
   token_type: String,
   access_token: String,
   refresh_token: String,
   not_after: i64,
+  #[expect(dead_code, reason = "kept to match HMCL account JSON schema")]
   userid: String,
 }
 
@@ -50,6 +52,7 @@ struct HmclProfileProperties {
 struct HmclThirdPartyAccount {
   #[serde(rename = "serverBaseURL")]
   server_base_url: String,
+  #[expect(dead_code, reason = "kept to match HMCL account JSON schema")]
   client_token: String,
   display_name: String,
   access_token: String,

--- a/src-tauri/src/account/helpers/import/multimc.rs
+++ b/src-tauri/src/account/helpers/import/multimc.rs
@@ -35,7 +35,9 @@ pub struct MultiMCYgg {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct MultiMCOfficialAccount {
+  #[expect(dead_code, reason = "kept to match MultiMC account JSON schema")]
   pub active: bool,
+  #[expect(dead_code, reason = "kept to match MultiMC account JSON schema")]
   pub r#type: String,
   pub msa: MultiMCMsa,
   pub profile: MultiMCProfile,
@@ -46,6 +48,7 @@ pub struct MultiMCOfficialAccount {
 #[serde(rename_all = "camelCase")]
 pub struct MultiMCAccountEntry {
   pub accounts: Vec<MultiMCOfficialAccount>,
+  #[expect(dead_code, reason = "kept to match MultiMC account JSON schema")]
   pub format_version: u32,
 }
 

--- a/src-tauri/src/instance/helpers/mods/quilt.rs
+++ b/src-tauri/src/instance/helpers/mods/quilt.rs
@@ -13,6 +13,7 @@ use crate::instance::helpers::mods::common::{LocalModMetadataParser, compress_ic
 use crate::instance::models::misc::{LocalModInfo, ModLoaderType};
 use crate::utils::image::{ImageWrapper, load_image_from_dir_async, load_image_from_jar};
 
+#[expect(dead_code, reason = "reserved for future use")]
 #[derive(Debug, Serialize, Deserialize, Default, Clone)]
 #[serde(default)]
 pub struct QuiltModMetadata {

--- a/src-tauri/src/instance/models/world/level.rs
+++ b/src-tauri/src/instance/models/world/level.rs
@@ -76,11 +76,13 @@ pub struct Version {
   pub snapshot: bool,
 }
 
+#[expect(dead_code, reason = "reserved for future use")]
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct EnderItemsEntry {
   pub id: String,
 }
 
+#[expect(dead_code, reason = "reserved for future use")]
 #[derive(Debug, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct GameRules {

--- a/src-tauri/src/launch/helpers/file_validator.rs
+++ b/src-tauri/src/launch/helpers/file_validator.rs
@@ -260,8 +260,8 @@ pub fn get_nonnative_library_paths(
 pub fn get_native_library_paths(
   client_info: &McClientInfo,
   library_path: &Path,
-  use_native_glfw: bool,
-  use_native_openal: bool,
+  #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] use_native_glfw: bool,
+  #[cfg_attr(not(target_os = "linux"), allow(unused_variables))] use_native_openal: bool,
 ) -> SJMCLResult<Vec<PathBuf>> {
   let mut result = Vec::new();
   let feature = FeaturesInfo::default();

--- a/src-tauri/src/resource/helpers/loader_meta/forge.rs
+++ b/src-tauri/src/resource/helpers/loader_meta/forge.rs
@@ -59,6 +59,7 @@ async fn get_forge_meta_by_game_version_official(
   app: &AppHandle,
   game_version: &str,
 ) -> SJMCLResult<Vec<ModLoaderResourceInfo>> {
+  let _ = (app, game_version);
   Err(ResourceError::NoDownloadApi.into()) // TODO
 }
 

--- a/src-tauri/src/resource/helpers/loader_meta/neoforge.rs
+++ b/src-tauri/src/resource/helpers/loader_meta/neoforge.rs
@@ -17,6 +17,7 @@ struct NeoforgeMetaItem {
   pub mcversion: String,
 }
 
+#[expect(dead_code, reason = "reserved for future use")]
 #[derive(Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct NeoforgeVersions {

--- a/src-tauri/src/resource/helpers/misc.rs
+++ b/src-tauri/src/resource/helpers/misc.rs
@@ -111,6 +111,7 @@ pub fn get_download_api(source: SourceType, resource_type: ResourceType) -> SJMC
   }
 }
 
+#[expect(dead_code, reason = "reserved for future use")]
 pub fn convert_url_source_type(
   url: &Url,
   resource_type: &ResourceType,

--- a/src-tauri/src/resource/helpers/mod_db.rs
+++ b/src-tauri/src/resource/helpers/mod_db.rs
@@ -139,6 +139,7 @@ pub struct MCModRecord {
   pub abbr: Option<String>,
 }
 
+#[expect(dead_code, reason = "reserved for future use")]
 impl MCModRecord {
   pub fn get_display_name(&self) -> String {
     let mut builder = String::new();


### PR DESCRIPTION
### Checklist

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [x] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> None.

### Description

为后端多处 dead code 添加 `#[expect(dead_code)]` 注解，抑制编译器 warning，提升代码整洁度。

- 账户导入（HMCL / MultiMC）的 JSON schema 匹配字段：添加 `kept to match ... JSON schema` 理由
- 预留待用的结构体/函数：添加 `reserved for future use` 理由
- `get_native_library_paths` 参数在非 Linux 平台未被使用：改为 `#[cfg_attr(not(target_os = "linux"), allow(unused_variables))]`
- `get_forge_meta_by_game_version_official` 未使用参数：使用 `let _ = (...)` 显式标记

涉及 10 个文件，均为纯注解变更，无逻辑修改。

### Additional Context

> 无。

## Summary by Sourcery

Annotate backend dead code and unused parameters to suppress compiler warnings while keeping JSON schema and future-use structures intact.

Enhancements:
- Add #[expect(dead_code)] annotations with reasons to unused schema-matching fields and reserved structs/functions.
- Relax unused parameter warnings for non-Linux native library options and explicitly mark unused arguments in loader metadata helpers.