### PR TITLE
fix(backend): tolerate invalid Fabric metadata

### DIFF
--- a/src-tauri/src/instance/helpers/mods/fabric.rs
+++ b/src-tauri/src/instance/helpers/mods/fabric.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sjmcl_types::error::{SJMCLError, SJMCLResult};
+use sjmcl_types::error::SJMCLResult;
 use std::collections::HashMap;
 use std::io::{Read, Seek};
 use std::path::Path;
@@ -41,6 +41,23 @@ impl From<FabricModMetadata> for LocalModInfo {
 #[derive(Clone, Copy)]
 pub struct FabricModMetadataParser;
 
+fn parse_fabric_mod_metadata(content: &str) -> SJMCLResult<FabricModMetadata> {
+  Ok(match serde_json::from_str(content) {
+    Ok(meta) => meta,
+    Err(_) => serde_json::from_str(&strip_json_control_chars(content))?,
+  })
+}
+
+// Removes C0 control characters before a fallback parse of invalid Fabric metadata.
+// Some mods ship non-standard metadata with raw control characters, so after
+// strict JSON parsing fails, strips them and tries parsing again.
+fn strip_json_control_chars(input: &str) -> String {
+  input
+    .chars()
+    .filter(|c| !matches!(c, '\u{0000}'..='\u{001F}'))
+    .collect()
+}
+
 #[async_trait]
 impl LocalModMetadataParser for FabricModMetadataParser {
   type Metadata = FabricModMetadata;
@@ -48,26 +65,17 @@ impl LocalModMetadataParser for FabricModMetadataParser {
   fn get_mod_metadata_from_jar<R: Read + Seek>(
     jar: &mut ZipArchive<R>,
   ) -> SJMCLResult<Self::Metadata> {
-    let meta: FabricModMetadata = match jar.by_name("fabric.mod.json") {
-      Ok(val) => match serde_json::from_reader(val) {
-        Ok(val) => val,
-        Err(e) => return Err(SJMCLError::from(e)),
-      },
-      Err(e) => return Err(SJMCLError::from(e)),
-    };
-    Ok(meta)
+    let mut content = String::new();
+    jar
+      .by_name("fabric.mod.json")?
+      .read_to_string(&mut content)?;
+    parse_fabric_mod_metadata(&content)
   }
 
   async fn get_mod_metadata_from_dir(dir_path: &Path) -> SJMCLResult<Self::Metadata> {
     let fabric_file_path = dir_path.join("fabric.mod.json");
-    let meta: FabricModMetadata = match tokio::fs::read_to_string(fabric_file_path).await {
-      Ok(val) => match serde_json::from_str(val.as_str()) {
-        Ok(val) => val,
-        Err(e) => return Err(SJMCLError::from(e)),
-      },
-      Err(e) => return Err(SJMCLError::from(e)),
-    };
-    Ok(meta)
+    let content = tokio::fs::read_to_string(fabric_file_path).await?;
+    parse_fabric_mod_metadata(&content)
   }
 
   fn get_icon_from_jar<R: Read + Seek>(

--- a/src-tauri/src/instance/helpers/mods/fabric.rs
+++ b/src-tauri/src/instance/helpers/mods/fabric.rs
@@ -13,6 +13,7 @@ use zip::ZipArchive;
 use crate::instance::helpers::mods::common::{LocalModMetadataParser, compress_icon};
 use crate::instance::models::misc::{LocalModInfo, ModLoaderType};
 use crate::utils::image::{ImageWrapper, load_image_from_dir_async, load_image_from_jar};
+use crate::utils::string::deserialize_lenient_json;
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -41,23 +42,6 @@ impl From<FabricModMetadata> for LocalModInfo {
 #[derive(Clone, Copy)]
 pub struct FabricModMetadataParser;
 
-fn parse_fabric_mod_metadata(content: &str) -> SJMCLResult<FabricModMetadata> {
-  Ok(match serde_json::from_str(content) {
-    Ok(meta) => meta,
-    Err(_) => serde_json::from_str(&strip_json_control_chars(content))?,
-  })
-}
-
-// Removes C0 control characters before a fallback parse of invalid Fabric metadata.
-// Some mods ship non-standard metadata with raw control characters, so after
-// strict JSON parsing fails, strips them and tries parsing again.
-fn strip_json_control_chars(input: &str) -> String {
-  input
-    .chars()
-    .filter(|c| !matches!(c, '\u{0000}'..='\u{001F}'))
-    .collect()
-}
-
 #[async_trait]
 impl LocalModMetadataParser for FabricModMetadataParser {
   type Metadata = FabricModMetadata;
@@ -69,13 +53,13 @@ impl LocalModMetadataParser for FabricModMetadataParser {
     jar
       .by_name("fabric.mod.json")?
       .read_to_string(&mut content)?;
-    parse_fabric_mod_metadata(&content)
+    Ok(deserialize_lenient_json(&content)?)
   }
 
   async fn get_mod_metadata_from_dir(dir_path: &Path) -> SJMCLResult<Self::Metadata> {
     let fabric_file_path = dir_path.join("fabric.mod.json");
     let content = tokio::fs::read_to_string(fabric_file_path).await?;
-    parse_fabric_mod_metadata(&content)
+    Ok(deserialize_lenient_json(&content)?)
   }
 
   fn get_icon_from_jar<R: Read + Seek>(

--- a/src-tauri/src/utils/string.rs
+++ b/src-tauri/src/utils/string.rs
@@ -1,3 +1,5 @@
+use serde::de::DeserializeOwned;
+
 pub fn snake_to_camel_case(snake: &str) -> String {
   let mut camel = String::new();
   let mut capitalize_next = false;
@@ -24,4 +26,26 @@ pub fn camel_to_snake_case(camel: &str) -> String {
     snake.push(ch.to_ascii_lowercase());
   }
   snake
+}
+
+/// Deserializes JSON, stripping raw C0 control characters and retrying if strict parsing fails.
+///
+/// Some files ship non-standard metadata with raw control characters, so after
+/// strict JSON parsing fails, SJMCL strips them and tries parsing again.
+pub fn deserialize_lenient_json<T>(input: &str) -> serde_json::Result<T>
+where
+  T: DeserializeOwned,
+{
+  Ok(match serde_json::from_str(input) {
+    Ok(value) => value,
+    Err(_) => serde_json::from_str(&strip_json_control_chars(input))?,
+  })
+}
+
+/// Removes C0 control characters before a fallback parse of invalid JSON.
+pub fn strip_json_control_chars(input: &str) -> String {
+  input
+    .chars()
+    .filter(|c| !matches!(c, '\u{0000}'..='\u{001F}'))
+    .collect()
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

fix #1764 

### Description

部分fabric模组元数据json未对字符串中\u{0000}~\u{001F}的控制字符转义，导致json解析失败。
修改后，当json解析失败后，尝试从json文件删除上述控制字符重新解析。

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Relax Fabric mod metadata JSON parsing to tolerate invalid control characters in metadata files.

Bug Fixes:
- Handle Fabric mod metadata files that include unescaped C0 control characters by retrying deserialization after stripping them.

Enhancements:
- Introduce a reusable lenient JSON deserialization helper that strips control characters and falls back to strict parsing.