### PR TITLE
chore: change `x` to `×` for resolution option on game settings page

### DIFF
--- a/src/components/game-settings-groups.tsx
+++ b/src/components/game-settings-groups.tsx
@@ -211,7 +211,7 @@ const GameSettingsGroups: React.FC<GameSettingsGroupsProps> = ({
                 }}
                 options={resolutionPresets.map((p, i) => ({
                   value: String(i),
-                  label: `${p.width} x ${p.height}`,
+                  label: `${p.width} × ${p.height}`,
                   disabled:
                     resolutionUpbound != null &&
                     (p.width > resolutionUpbound.width ||


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

N/A

### Description

N/A

### Additional Context

N/A

## Summary by Sourcery

Bug Fixes:
- Correct the resolution label character to use the proper multiplication symbol in the game settings UI.