### PR TITLE
fix(l10n): replace all terms meaning “factory reset” with “reset” [skip ci] [skip sourcery]

### DIFF
--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -211,7 +211,7 @@ pub fn retrieve_instance_game_config(
 }
 
 #[tauri::command]
-pub async fn restore_instance_game_config(app: AppHandle, instance_id: String) -> SJMCLResult<()> {
+pub async fn reset_instance_game_config(app: AppHandle, instance_id: String) -> SJMCLResult<()> {
   let instance = {
     let binding = app.state::<Mutex<HashMap<String, Instance>>>();
     let mut state = binding.lock().unwrap();

--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/instance.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/instance.rs
@@ -244,9 +244,9 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
       }
     ),
     mcp_tool!(
-      "restore_instance_game_config",
-      restore_instance_game_config,
-      "Restore a Minecraft instance's dedicated game configuration to the current global game configuration.",
+      "reset_instance_game_config",
+      reset_instance_game_config,
+      "Reset a Minecraft instance's dedicated game configuration to the current global game configuration.",
       #[serde(deny_unknown_fields)]
       {
         #[schemars(description = "Minecraft instance ID returned by `retrieve_instance_list`.")]

--- a/src-tauri/src/launcher_config/commands.rs
+++ b/src-tauri/src/launcher_config/commands.rs
@@ -44,7 +44,7 @@ pub fn update_launcher_config(app: AppHandle, key_path: String, value: String) -
 }
 
 #[tauri::command]
-pub fn restore_launcher_config(app: AppHandle) -> SJMCLResult<LauncherConfig> {
+pub fn reset_launcher_config(app: AppHandle) -> SJMCLResult<LauncherConfig> {
   let mut default_config = LauncherConfig::default();
   default_config.setup_with_app(&app)?;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -87,7 +87,7 @@ pub async fn run() {
       .invoke_handler(tauri::generate_handler![
         launcher_config::commands::retrieve_launcher_config,
         launcher_config::commands::update_launcher_config,
-        launcher_config::commands::restore_launcher_config,
+        launcher_config::commands::reset_launcher_config,
         launcher_config::commands::export_launcher_config,
         launcher_config::commands::import_launcher_config,
         launcher_config::commands::reveal_launcher_config,
@@ -127,7 +127,7 @@ pub async fn run() {
         instance::commands::create_instance,
         instance::commands::update_instance_config,
         instance::commands::retrieve_instance_game_config,
-        instance::commands::restore_instance_game_config,
+        instance::commands::reset_instance_game_config,
         instance::commands::retrieve_instance_subdir_path,
         instance::commands::read_instance_file,
         instance::commands::delete_instance,

--- a/src/contexts/instance.tsx
+++ b/src/contexts/instance.tsx
@@ -77,7 +77,7 @@ export interface InstanceContextType {
   ) => Promise<string | null>;
   handleImportResources: (options: ImportResourcesOptions) => void;
   handleUpdateInstanceConfig: (path: string, value: any) => void;
-  handleRestoreInstanceGameConfig: () => void;
+  handleResetInstanceGameConfig: () => void;
 }
 
 export const InstanceContext = createContext<InstanceContextType | undefined>(
@@ -501,9 +501,9 @@ export const InstanceContextProvider: React.FC<{
     ]
   );
 
-  const handleRestoreInstanceGameConfig = useCallback(() => {
+  const handleResetInstanceGameConfig = useCallback(() => {
     if (instanceId !== undefined) {
-      InstanceService.restoreInstanceGameConfig(instanceId).then((response) => {
+      InstanceService.resetInstanceGameConfig(instanceId).then((response) => {
         if (response.status === "success") {
           toast({
             title: response.message,
@@ -628,7 +628,7 @@ export const InstanceContextProvider: React.FC<{
         handleRetrieveInstanceSubdirPath,
         handleImportResources,
         handleUpdateInstanceConfig,
-        handleRestoreInstanceGameConfig,
+        handleResetInstanceGameConfig,
       }}
     >
       {children}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1214,9 +1214,9 @@
           "description": "Automatically purge launcher log files older than 30 days"
         },
         "restoreAll": {
-          "title": "Restore All Settings",
-          "description": "Restore all launcher settings to their default values",
-          "restore": "Restore"
+          "title": "Reset All Settings",
+          "description": "Reset all launcher settings to their default values",
+          "restore": "Reset"
         }
       }
     }
@@ -1536,9 +1536,9 @@
     "colorTag": "Color Tag",
     "icon": "Instance Icon",
     "applySettings": "Apply the following specific settings",
-    "restoreSettings": "Restore specific settings",
-    "restoreSettingsDesc": "Restore the following specific settings to the global game settings.",
-    "restore": "Restore",
+    "restoreSettings": "Reset specific settings",
+    "restoreSettingsDesc": "Reset the following specific settings to the global game settings.",
+    "restore": "Reset",
     "errorMessage": {
       "error-1": "Instance name cannot be empty",
       "error-2": "Instance name is invalid",
@@ -2185,12 +2185,12 @@
     }
   },
   "RestoreConfigConfirmDialog": {
-    "title": "Restore Launcher Settings",
-    "body": "This action will restore all launcher settings to their default values. Are you sure you want to proceed?"
+    "title": "Reset Launcher Settings",
+    "body": "This action will reset all launcher settings to their default values. Are you sure you want to proceed?"
   },
   "RestoreInstanceConfigConfirmDialog": {
-    "title": "Restore Instance Settings",
-    "body": "This action will restore this instance's specific game settings to the current global settings. Are you sure you want to proceed?"
+    "title": "Reset Instance Settings",
+    "body": "This action will reset this instance's specific game settings to the current global settings. Are you sure you want to proceed?"
   },
   "RevealConfigJsonConfirmDialog": {
     "body": "Please be cautious when editing the raw launcher settings file. Incorrect formatting may lead to the loss of original settings or prevent the launcher from working properly."
@@ -2226,9 +2226,9 @@
         }
       },
       "restoreLauncherConfig": {
-        "success": "Successfully restored launcher settings",
+        "success": "Successfully reset launcher settings",
         "error": {
-          "title": "Failed to restore launcher settings"
+          "title": "Failed to reset launcher settings"
         }
       },
       "exportLauncherConfig": {
@@ -2729,9 +2729,9 @@
         }
       },
       "restoreInstanceGameConfig": {
-        "success": "Successfully restored instance game settings",
+        "success": "Successfully reset instance game settings",
         "error": {
-          "title": "Failed to restore instance game settings",
+          "title": "Failed to reset instance game settings",
           "description": {
             "INSTANCE_NOT_FOUND_BY_ID": "Instance ID does not exist",
             "SAVE_ERROR": "Failed to save instance settings"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1213,10 +1213,10 @@
           "title": "Auto Purge Launcher Logs",
           "description": "Automatically purge launcher log files older than 30 days"
         },
-        "restoreAll": {
+        "resetAll": {
           "title": "Reset All Settings",
           "description": "Reset all launcher settings to their default values",
-          "restore": "Reset"
+          "reset": "Reset"
         }
       }
     }
@@ -1536,9 +1536,9 @@
     "colorTag": "Color Tag",
     "icon": "Instance Icon",
     "applySettings": "Apply the following specific settings",
-    "restoreSettings": "Reset specific settings",
-    "restoreSettingsDesc": "Reset the following specific settings to the global game settings.",
-    "restore": "Reset",
+    "resetSettings": "Reset specific settings",
+    "resetSettingsDesc": "Reset the following specific settings to the global game settings.",
+    "reset": "Reset",
     "errorMessage": {
       "error-1": "Instance name cannot be empty",
       "error-2": "Instance name is invalid",
@@ -1890,6 +1890,14 @@
       "content": "Are you sure you want to remove OptiFine {{version}} installed for {{instanceName}}? Your shader packs may stop working."
     }
   },
+  "ResetConfigConfirmDialog": {
+    "title": "Reset Launcher Settings",
+    "body": "This action will reset all launcher settings to their default values. Are you sure you want to proceed?"
+  },
+  "ResetInstanceConfigConfirmDialog": {
+    "title": "Reset Instance Settings",
+    "body": "This action will reset this instance's specific game settings to the current global settings. Are you sure you want to proceed?"
+  },
   "ResourceDownloader": {
     "label": {
       "source": "Source",
@@ -2184,14 +2192,6 @@
       "later": "Later"
     }
   },
-  "RestoreConfigConfirmDialog": {
-    "title": "Reset Launcher Settings",
-    "body": "This action will reset all launcher settings to their default values. Are you sure you want to proceed?"
-  },
-  "RestoreInstanceConfigConfirmDialog": {
-    "title": "Reset Instance Settings",
-    "body": "This action will reset this instance's specific game settings to the current global settings. Are you sure you want to proceed?"
-  },
   "RevealConfigJsonConfirmDialog": {
     "body": "Please be cautious when editing the raw launcher settings file. Incorrect formatting may lead to the loss of original settings or prevent the launcher from working properly."
   },
@@ -2225,7 +2225,7 @@
           "title": "Failed to update launcher settings"
         }
       },
-      "restoreLauncherConfig": {
+      "resetLauncherConfig": {
         "success": "Successfully reset launcher settings",
         "error": {
           "title": "Failed to reset launcher settings"
@@ -2728,7 +2728,7 @@
           }
         }
       },
-      "restoreInstanceGameConfig": {
+      "resetInstanceGameConfig": {
         "success": "Successfully reset instance game settings",
         "error": {
           "title": "Failed to reset instance game settings",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -2729,9 +2729,9 @@
         }
       },
       "resetInstanceGameConfig": {
-        "success": "Configuración del juego de la instancia restaurada exitosamente",
+        "success": "Configuración del juego de la instancia restablecida exitosamente",
         "error": {
-          "title": "Error al restaurar la configuración del juego de la instancia",
+          "title": "Error al restablecer la configuración del juego de la instancia",
           "description": {
             "INSTANCE_NOT_FOUND_BY_ID": "El ID de instancia no existe",
             "SAVE_ERROR": "Error al guardar la configuración de la instancia"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1213,10 +1213,10 @@
           "title": "Purgar Automáticamente los Registros del Lanzador",
           "description": "Purgar automáticamente los archivos de registro del lanzador con más de 30 días de antigüedad"
         },
-        "restoreAll": {
+        "resetAll": {
           "title": "Restablecer Todas las Configuraciones",
           "description": "Restablecer todas las configuraciones del lanzador a sus valores predeterminados",
-          "restore": "Restablecer"
+          "reset": "Restablecer"
         }
       }
     }
@@ -1536,9 +1536,9 @@
     "colorTag": "Etiqueta de Color",
     "icon": "Icono de la Instancia",
     "applySettings": "Aplicar la siguiente configuración específica",
-    "restoreSettings": "Restablecer configuración específica",
-    "restoreSettingsDesc": "Restablecer la siguiente configuración específica a la configuración global del juego.",
-    "restore": "Restablecer",
+    "resetSettings": "Restablecer configuración específica",
+    "resetSettingsDesc": "Restablecer la siguiente configuración específica a la configuración global del juego.",
+    "reset": "Restablecer",
     "errorMessage": {
       "error-1": "El nombre de la instancia no puede estar vacío",
       "error-2": "El nombre de la instancia es inválido",
@@ -1890,6 +1890,14 @@
       "content": "¿Está seguro de que desea eliminar OptiFine {{version}} instalado para {{instanceName}}? Es posible que sus shader packs dejen de funcionar."
     }
   },
+  "ResetConfigConfirmDialog": {
+    "title": "Restablecer configuración del lanzador",
+    "body": "Esta acción restablecerá todas las configuraciones del lanzador a sus valores predeterminados. ¿Estás seguro de que deseas continuar?"
+  },
+  "ResetInstanceConfigConfirmDialog": {
+    "title": "Restablecer configuración de instancia",
+    "body": "Esta acción restablecerá la configuración específica del juego de esta instancia a la configuración global actual. ¿Estás seguro de que deseas continuar?"
+  },
   "ResourceDownloader": {
     "label": {
       "source": "Fuente",
@@ -2184,14 +2192,6 @@
       "later": "Más tarde"
     }
   },
-  "RestoreConfigConfirmDialog": {
-    "title": "Restablecer configuración del lanzador",
-    "body": "Esta acción restablecerá todas las configuraciones del lanzador a sus valores predeterminados. ¿Estás seguro de que deseas continuar?"
-  },
-  "RestoreInstanceConfigConfirmDialog": {
-    "title": "Restablecer configuración de instancia",
-    "body": "Esta acción restablecerá la configuración específica del juego de esta instancia a la configuración global actual. ¿Estás seguro de que deseas continuar?"
-  },
   "RevealConfigJsonConfirmDialog": {
     "body": "Ten cuidado al editar el archivo de configuración sin procesar del lanzador. Un formato incorrecto puede provocar la pérdida de la configuración original o impedir que el lanzador funcione correctamente."
   },
@@ -2225,7 +2225,7 @@
           "title": "Error al actualizar la configuración del lanzador"
         }
       },
-      "restoreLauncherConfig": {
+      "resetLauncherConfig": {
         "success": "Configuración del lanzador restablecido exitosamente",
         "error": {
           "title": "Error al restablecer la configuración del lanzador"
@@ -2728,7 +2728,7 @@
           }
         }
       },
-      "restoreInstanceGameConfig": {
+      "resetInstanceGameConfig": {
         "success": "Configuración del juego de la instancia restaurada exitosamente",
         "error": {
           "title": "Error al restaurar la configuración del juego de la instancia",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -2185,12 +2185,12 @@
     }
   },
   "RestoreConfigConfirmDialog": {
-    "title": "Restaurar configuración del lanzador",
-    "body": "Esta acción restaurará todas las configuraciones del lanzador a sus valores predeterminados. ¿Estás seguro de que deseas continuar?"
+    "title": "Restablecer configuración del lanzador",
+    "body": "Esta acción restablecerá todas las configuraciones del lanzador a sus valores predeterminados. ¿Estás seguro de que deseas continuar?"
   },
   "RestoreInstanceConfigConfirmDialog": {
-    "title": "Restaurar configuración de instancia",
-    "body": "Esta acción restaurará la configuración específica del juego de esta instancia a la configuración global actual. ¿Estás seguro de que deseas continuar?"
+    "title": "Restablecer configuración de instancia",
+    "body": "Esta acción restablecerá la configuración específica del juego de esta instancia a la configuración global actual. ¿Estás seguro de que deseas continuar?"
   },
   "RevealConfigJsonConfirmDialog": {
     "body": "Ten cuidado al editar el archivo de configuración sin procesar del lanzador. Un formato incorrecto puede provocar la pérdida de la configuración original o impedir que el lanzador funcione correctamente."
@@ -2226,9 +2226,9 @@
         }
       },
       "restoreLauncherConfig": {
-        "success": "Configuración del lanzador restaurada exitosamente",
+        "success": "Configuración del lanzador restablecido exitosamente",
         "error": {
-          "title": "Error al restaurar la configuración del lanzador"
+          "title": "Error al restablecer la configuración del lanzador"
         }
       },
       "exportLauncherConfig": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1213,10 +1213,10 @@
           "title": "Nettoyage automatique des journaux du lanceur",
           "description": "Nettoyage automatique des fichiers journaux du lanceur datant de 30 jours ou plus"
         },
-        "restoreAll": {
+        "resetAll": {
           "title": "Réinitialiser tous les paramètres",
           "description": "Réinitialiser tous les paramètres du lanceur à leur valeur par défaut",
-          "restore": "Réinitialiser"
+          "reset": "Réinitialiser"
         }
       }
     }
@@ -1536,9 +1536,9 @@
     "colorTag": "Étiquette de couleur",
     "icon": "Icône de l'instance",
     "applySettings": "Utiliser des paramètres de jeu spécifiques",
-    "restoreSettings": "Réinitialiser les paramètres spécifiques ci-dessous",
-    "restoreSettingsDesc": "Réinitialiser les paramètres spécifiques ci-dessous aux paramètres globaux du jeu",
-    "restore": "Réinitialiser",
+    "resetSettings": "Réinitialiser les paramètres spécifiques ci-dessous",
+    "resetSettingsDesc": "Réinitialiser les paramètres spécifiques ci-dessous aux paramètres globaux du jeu",
+    "reset": "Réinitialiser",
     "errorMessage": {
       "error-1": "Le nom de l'instance ne peut pas être vide",
       "error-2": "Le nom de l'instance contient des caractères illégaux",
@@ -1890,6 +1890,14 @@
       "content": "Êtes-vous sûr de vouloir supprimer OptiFine {{version}} installé pour {{instanceName}} ? Vos shader packs pourraient ne plus fonctionner."
     }
   },
+  "ResetConfigConfirmDialog": {
+    "title": "Réinitialiser les paramètres du lanceur",
+    "body": "Cette opération réinitialisera tous les paramètres du lanceur à leur valeur par défaut. Voulez-vous continuer ?"
+  },
+  "ResetInstanceConfigConfirmDialog": {
+    "title": "Réinitialiser les paramètres de l'instance",
+    "body": "Cette action réinitialisera les paramètres spécifiques de cette instance vers les paramètres globaux actuels. Voulez-vous continuer ?"
+  },
   "ResourceDownloader": {
     "label": {
       "source": "Source",
@@ -2184,14 +2192,6 @@
       "later": "Plus tard"
     }
   },
-  "RestoreConfigConfirmDialog": {
-    "title": "Réinitialiser les paramètres du lanceur",
-    "body": "Cette opération réinitialisera tous les paramètres du lanceur à leur valeur par défaut. Voulez-vous continuer ?"
-  },
-  "RestoreInstanceConfigConfirmDialog": {
-    "title": "Réinitialiser les paramètres de l'instance",
-    "body": "Cette action réinitialisera les paramètres spécifiques de cette instance vers les paramètres globaux actuels. Voulez-vous continuer ?"
-  },
   "RevealConfigJsonConfirmDialog": {
     "body": "Veuillez éditer le fichier de configuration original du lanceur avec précaution. Un format incorrect peut entraîner la perte des paramètres existants ou un dysfonctionnement du lanceur"
   },
@@ -2225,7 +2225,7 @@
           "title": "Échec de la mise à jour des paramètres du lanceur"
         }
       },
-      "restoreLauncherConfig": {
+      "resetLauncherConfig": {
         "success": "Paramètres restaurés avec succès",
         "error": {
           "title": "Échec de la restauration des paramètres, veuillez réessayer"
@@ -2728,7 +2728,7 @@
           }
         }
       },
-      "restoreInstanceGameConfig": {
+      "resetInstanceGameConfig": {
         "success": "Paramètres du jeu de l'instance réinitialisés",
         "error": {
           "title": "Échec de la réinitialisation des paramètres du jeu de l'instance",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -2226,9 +2226,9 @@
         }
       },
       "resetLauncherConfig": {
-        "success": "Paramètres restaurés avec succès",
+        "success": "Paramètres du lanceur réinitialisés",
         "error": {
-          "title": "Échec de la restauration des paramètres, veuillez réessayer"
+          "title": "Échec de la réinitialisation des paramètres, veuillez réessayer"
         }
       },
       "exportLauncherConfig": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1214,9 +1214,9 @@
           "description": "Nettoyage automatique des fichiers journaux du lanceur datant de 30 jours ou plus"
         },
         "restoreAll": {
-          "title": "Restaurer tous les paramètres",
-          "description": "Restaurer tous les paramètres du lanceur à leur valeur par défaut",
-          "restore": "Restaurer"
+          "title": "Réinitialiser tous les paramètres",
+          "description": "Réinitialiser tous les paramètres du lanceur à leur valeur par défaut",
+          "restore": "Réinitialiser"
         }
       }
     }
@@ -2185,12 +2185,12 @@
     }
   },
   "RestoreConfigConfirmDialog": {
-    "title": "Restaurer les paramètres du lanceur",
-    "body": "Cette opération restaurera tous les paramètres du lanceur à leur valeur par défaut. Voulez-vous continuer ?"
+    "title": "Réinitialiser les paramètres du lanceur",
+    "body": "Cette opération réinitialisera tous les paramètres du lanceur à leur valeur par défaut. Voulez-vous continuer ?"
   },
   "RestoreInstanceConfigConfirmDialog": {
-    "title": "Restaurer les paramètres de l'instance",
-    "body": "Cette action restaurera les paramètres spécifiques de cette instance vers les paramètres globaux actuels. Voulez-vous continuer ?"
+    "title": "Réinitialiser les paramètres de l'instance",
+    "body": "Cette action réinitialisera les paramètres spécifiques de cette instance vers les paramètres globaux actuels. Voulez-vous continuer ?"
   },
   "RevealConfigJsonConfirmDialog": {
     "body": "Veuillez éditer le fichier de configuration original du lanceur avec précaution. Un format incorrect peut entraîner la perte des paramètres existants ou un dysfonctionnement du lanceur"

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1213,10 +1213,10 @@
           "title": "起動ログの自動クリーンアップ",
           "description": "30日以上前の起動ログファイルを自動削除"
         },
-        "restoreAll": {
-          "title": "すべての設定を復元",
-          "description": "すべてのランチャー設定をデフォルトに復元",
-          "restore": "復元"
+        "resetAll": {
+          "title": "すべての設定をリセット",
+          "description": "すべてのランチャー設定をデフォルト値にリセット",
+          "reset": "リセット"
         }
       }
     }
@@ -1536,9 +1536,9 @@
     "colorTag": "カラータグ",
     "icon": "インスタンスアイコン",
     "applySettings": "インスタンス限定設定を有効化",
-    "restoreSettings": "限定設定をリセット",
-    "restoreSettingsDesc": "以下の設定をグローバル設定にリセット",
-    "restore": "リセット",
+    "resetSettings": "限定設定をリセット",
+    "resetSettingsDesc": "以下の設定をグローバル設定にリセット",
+    "reset": "リセット",
     "errorMessage": {
       "error-1": "インスタンス名称が必須",
       "error-2": "インスタンス名が無効",
@@ -1890,6 +1890,14 @@
       "content": "{{instanceName}} にインストールされた OptiFine {{version}} を削除してもよろしいですか？シェーダーパックが動作しなくなる可能性があります。"
     }
   },
+  "ResetConfigConfirmDialog": {
+    "title": "ランチャー設定をリセット",
+    "body": "この操作により、すべてのランチャー設定がデフォルト値にリセットされます。続行しますか？"
+  },
+  "ResetInstanceConfigConfirmDialog": {
+    "title": "インスタンス設定をリセット",
+    "body": "この操作により、このインスタンスの個別ゲーム設定が現在のグローバル設定にリセットされます。続行しますか？"
+  },
   "ResourceDownloader": {
     "label": {
       "source": "ダウンロードソース",
@@ -2184,14 +2192,6 @@
       "later": "後で"
     }
   },
-  "RestoreConfigConfirmDialog": {
-    "title": "ランチャー設定復元",
-    "body": "ランチャーの設定をデフォルトに復元しますか。"
-  },
-  "RestoreInstanceConfigConfirmDialog": {
-    "title": "インスタンス設定を復元",
-    "body": "この操作により、このインスタンスの個別ゲーム設定は現在のグローバル設定に復元されます。続行しますか？"
-  },
   "RevealConfigJsonConfirmDialog": {
     "body": "原始設定ファイルの編集には注意してください。誤った形式は既存の設定が失われたり、ランチャーが正常に動作しなくなる可能性があります"
   },
@@ -2225,10 +2225,10 @@
           "title": "ランチャーの設定の更新に失敗"
         }
       },
-      "restoreLauncherConfig": {
-        "success": "設定を復元した",
+      "resetLauncherConfig": {
+        "success": "設定をリセットしました",
         "error": {
-          "title": "設定の復元に失敗、再試行してください。"
+          "title": "設定のリセットに失敗しました。再試行してください。"
         }
       },
       "exportLauncherConfig": {
@@ -2728,7 +2728,7 @@
           }
         }
       },
-      "restoreInstanceGameConfig": {
+      "resetInstanceGameConfig": {
         "success": "インスタンスゲーム設定をリセットした",
         "error": {
           "title": "インスタンスゲーム設定のリセットに失敗",

--- a/src/locales/lzh.json
+++ b/src/locales/lzh.json
@@ -1213,10 +1213,10 @@
           "title": "自調除快取啟者誌",
           "description": "自調除快取 30 天及以前的啟者誌案"
         },
-        "restoreAll": {
-          "title": "復原諸置設",
-          "description": "將諸啟者置設復原為本值",
-          "restore": "復原"
+        "resetAll": {
+          "title": "重置諸置設",
+          "description": "將諸啟者置設重置為本值",
+          "reset": "重置"
         }
       }
     }
@@ -1536,9 +1536,9 @@
     "colorTag": "色籤",
     "icon": "例圖示",
     "applySettings": "啟特定戲置設",
-    "restoreSettings": "重置以下特定置設",
-    "restoreSettingsDesc": "將以下特定置設重置為全例戲置設",
-    "restore": "復初",
+    "resetSettings": "重置以下特定置設",
+    "resetSettingsDesc": "將以下特定置設重置為全例戲置設",
+    "reset": "重置",
     "errorMessage": {
       "error-1": "例名不可空",
       "error-2": "例名不合法",
@@ -1890,6 +1890,14 @@
       "content": "確認要移除為 {{instanceName}} 已安裝的 OptiFine {{version}} 嗎？您的光影可能將無法使用。"
     }
   },
+  "ResetConfigConfirmDialog": {
+    "title": "重置啟者置設",
+    "body": "此操作將會重置啟者諸置設為本值，您誠欲續乎？"
+  },
+  "ResetInstanceConfigConfirmDialog": {
+    "title": "重置例置設",
+    "body": "此操作將會重置本例的戲置設為今全例戲置設，您誠欲續乎？"
+  },
   "ResourceDownloader": {
     "label": {
       "source": "引源",
@@ -2184,14 +2192,6 @@
       "later": "稍後"
     }
   },
-  "RestoreConfigConfirmDialog": {
-    "title": "復原啟者置設",
-    "body": "此操作將會復原啟者的諸置設為本值，您誠欲續乎？"
-  },
-  "RestoreInstanceConfigConfirmDialog": {
-    "title": "復初例置設",
-    "body": "此操作將會重置本例的戲置設為今全例戲置設，您誠欲續乎？"
-  },
   "RevealConfigJsonConfirmDialog": {
     "body": "請謹慎改啟者原始置設案，謬的格式或致原有置設丟失或啟者不能正常工作"
   },
@@ -2225,10 +2225,10 @@
           "title": "迭更啟者置設未成"
         }
       },
-      "restoreLauncherConfig": {
-        "success": "置設已既成復原",
+      "resetLauncherConfig": {
+        "success": "置設已重置",
         "error": {
-          "title": "復原置設未成，請復試"
+          "title": "重置置設未成，請復試"
         }
       },
       "exportLauncherConfig": {
@@ -2728,7 +2728,7 @@
           }
         }
       },
-      "restoreInstanceGameConfig": {
+      "resetInstanceGameConfig": {
         "success": "例戲置設已重置",
         "error": {
           "title": "例戲置設重置未成",

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -1213,10 +1213,10 @@
           "title": "自动清理启动器日志",
           "description": "自动清理 30 天及以前的启动器日志文件"
         },
-        "restoreAll": {
+        "resetAll": {
           "title": "重置所有设置",
           "description": "将所有启动器设置重置为默认值",
-          "restore": "重置"
+          "reset": "重置"
         }
       }
     }
@@ -1536,9 +1536,9 @@
     "colorTag": "颜色标签",
     "icon": "实例图标",
     "applySettings": "启用特定游戏设置",
-    "restoreSettings": "重置以下特定设置",
-    "restoreSettingsDesc": "将以下特定设置重置为全局游戏设置",
-    "restore": "重置",
+    "resetSettings": "重置以下特定设置",
+    "resetSettingsDesc": "将以下特定设置重置为全局游戏设置",
+    "reset": "重置",
     "errorMessage": {
       "error-1": "实例名称不能为空",
       "error-2": "实例名称不合法",
@@ -1890,6 +1890,14 @@
       "content": "确认要移除为 {{instanceName}} 已安装的 OptiFine {{version}} 吗？您的光影可能将无法使用。"
     }
   },
+  "ResetConfigConfirmDialog": {
+    "title": "重置启动器设置",
+    "body": "此操作将会重置启动器的所有设置为默认值，您确定要继续吗？"
+  },
+  "ResetInstanceConfigConfirmDialog": {
+    "title": "重置实例设置",
+    "body": "此操作将会重置本实例的游戏设置为当前全局游戏设置，您确定要继续吗？"
+  },
   "ResourceDownloader": {
     "label": {
       "source": "下载源",
@@ -2184,14 +2192,6 @@
       "later": "稍后"
     }
   },
-  "RestoreConfigConfirmDialog": {
-    "title": "重置启动器设置",
-    "body": "此操作将会重置启动器的所有设置为默认值，您确定要继续吗？"
-  },
-  "RestoreInstanceConfigConfirmDialog": {
-    "title": "重置实例设置",
-    "body": "此操作将会重置本实例的游戏设置为当前全局游戏设置，您确定要继续吗？"
-  },
   "RevealConfigJsonConfirmDialog": {
     "body": "请谨慎编辑启动器原始设置文件，错误的格式可能导致原有设置丢失或启动器无法正常工作"
   },
@@ -2225,7 +2225,7 @@
           "title": "更新启动器设置失败"
         }
       },
-      "restoreLauncherConfig": {
+      "resetLauncherConfig": {
         "success": "设置已成功重置",
         "error": {
           "title": "重置设置失败，请重试"
@@ -2728,7 +2728,7 @@
           }
         }
       },
-      "restoreInstanceGameConfig": {
+      "resetInstanceGameConfig": {
         "success": "实例游戏设置已重置",
         "error": {
           "title": "实例游戏设置重置失败",

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -1214,9 +1214,9 @@
           "description": "自动清理 30 天及以前的启动器日志文件"
         },
         "restoreAll": {
-          "title": "还原所有设置",
-          "description": "将所有启动器设置还原为默认值",
-          "restore": "还原"
+          "title": "重置所有设置",
+          "description": "将所有启动器设置重置为默认值",
+          "restore": "重置"
         }
       }
     }
@@ -2185,8 +2185,8 @@
     }
   },
   "RestoreConfigConfirmDialog": {
-    "title": "还原启动器设置",
-    "body": "此操作将会还原启动器的所有设置为默认值，您确定要继续吗？"
+    "title": "重置启动器设置",
+    "body": "此操作将会重置启动器的所有设置为默认值，您确定要继续吗？"
   },
   "RestoreInstanceConfigConfirmDialog": {
     "title": "重置实例设置",
@@ -2226,9 +2226,9 @@
         }
       },
       "restoreLauncherConfig": {
-        "success": "设置已成功还原",
+        "success": "设置已成功重置",
         "error": {
-          "title": "还原设置失败，请重试"
+          "title": "重置设置失败，请重试"
         }
       },
       "exportLauncherConfig": {

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -1213,10 +1213,10 @@
           "title": "自動清理啟動器日誌",
           "description": "自動清理 30 天及以前的啟動器日誌檔案"
         },
-        "restoreAll": {
+        "resetAll": {
           "title": "重設所有設定",
           "description": "將所有啟動器設定重設為預設值",
-          "restore": "重設"
+          "reset": "重設"
         }
       }
     }
@@ -1536,9 +1536,9 @@
     "colorTag": "顏色標籤",
     "icon": "實例圖示",
     "applySettings": "啟用特定遊戲設定",
-    "restoreSettings": "重設以下特定設定",
-    "restoreSettingsDesc": "將以下特定設定重設為全域性遊戲設定",
-    "restore": "重設",
+    "resetSettings": "重設以下特定設定",
+    "resetSettingsDesc": "將以下特定設定重設為全域性遊戲設定",
+    "reset": "重設",
     "errorMessage": {
       "error-1": "實例名稱不能為空",
       "error-2": "實例名稱不合法",
@@ -1890,6 +1890,14 @@
       "content": "確認要移除為 {{instanceName}} 已安裝的 OptiFine {{version}} 嗎？您的光影可能將無法使用。"
     }
   },
+  "ResetConfigConfirmDialog": {
+    "title": "重設啟動器設定",
+    "body": "此操作將會重設啟動器的所有設定為預設值，您確定要繼續嗎？"
+  },
+  "ResetInstanceConfigConfirmDialog": {
+    "title": "重設實例設定",
+    "body": "此操作將會重設本實例的遊戲設定為目前全域性遊戲設定，您確定要繼續嗎？"
+  },
   "ResourceDownloader": {
     "label": {
       "source": "下載源",
@@ -2184,14 +2192,6 @@
       "later": "稍後"
     }
   },
-  "RestoreConfigConfirmDialog": {
-    "title": "重設啟動器設定",
-    "body": "此操作將會重設啟動器的所有設定為預設值，您確定要繼續嗎？"
-  },
-  "RestoreInstanceConfigConfirmDialog": {
-    "title": "重設實例設定",
-    "body": "此操作將會重設本實例的遊戲設定為目前全域性遊戲設定，您確定要繼續嗎？"
-  },
   "RevealConfigJsonConfirmDialog": {
     "body": "請謹慎編輯啟動器原始設定檔案，錯誤的格式可能導致原有設定遺失或啟動器無法正常工作"
   },
@@ -2225,7 +2225,7 @@
           "title": "更新啟動器設定失敗"
         }
       },
-      "restoreLauncherConfig": {
+      "resetLauncherConfig": {
         "success": "設定已成功重設",
         "error": {
           "title": "重設設定失敗，請重試"
@@ -2728,7 +2728,7 @@
           }
         }
       },
-      "restoreInstanceGameConfig": {
+      "resetInstanceGameConfig": {
         "success": "實例遊戲設定已重設",
         "error": {
           "title": "實例遊戲設定重設失敗",

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -1214,9 +1214,9 @@
           "description": "自動清理 30 天及以前的啟動器日誌檔案"
         },
         "restoreAll": {
-          "title": "還原所有設定",
-          "description": "將所有啟動器設定還原為預設值",
-          "restore": "還原"
+          "title": "重設所有設定",
+          "description": "將所有啟動器設定重設為預設值",
+          "restore": "重設"
         }
       }
     }
@@ -2185,8 +2185,8 @@
     }
   },
   "RestoreConfigConfirmDialog": {
-    "title": "還原啟動器設定",
-    "body": "此操作將會還原啟動器的所有設定為預設值，您確定要繼續嗎？"
+    "title": "重設啟動器設定",
+    "body": "此操作將會重設啟動器的所有設定為預設值，您確定要繼續嗎？"
   },
   "RestoreInstanceConfigConfirmDialog": {
     "title": "重設實例設定",
@@ -2226,9 +2226,9 @@
         }
       },
       "restoreLauncherConfig": {
-        "success": "設定已成功還原",
+        "success": "設定已成功重設",
         "error": {
-          "title": "還原設定失敗，請重試"
+          "title": "重設設定失敗，請重試"
         }
       },
       "exportLauncherConfig": {

--- a/src/pages/instances/details/[id]/settings/index.tsx
+++ b/src/pages/instances/details/[id]/settings/index.tsx
@@ -43,7 +43,7 @@ const InstanceSettingsPage = () => {
     updateSummaryInContext,
     gameConfig: instanceGameConfig,
     handleUpdateInstanceConfig,
-    handleRestoreInstanceGameConfig,
+    handleResetInstanceGameConfig,
   } = useInstanceSharedData();
   const useSpecGameConfig = summary?.useSpecGameConfig || false;
 
@@ -193,8 +193,8 @@ const InstanceSettingsPage = () => {
         ...(useSpecGameConfig && instanceGameConfig
           ? [
               {
-                title: t("InstanceSettingsPage.restoreSettings"),
-                description: t("InstanceSettingsPage.restoreSettingsDesc"),
+                title: t("InstanceSettingsPage.resetSettings"),
+                description: t("InstanceSettingsPage.resetSettingsDesc"),
                 children: (
                   <Button
                     colorScheme="red"
@@ -202,16 +202,16 @@ const InstanceSettingsPage = () => {
                     size="xs"
                     onClick={() => {
                       openGenericConfirmDialog({
-                        title: t("RestoreInstanceConfigConfirmDialog.title"),
-                        body: t("RestoreInstanceConfigConfirmDialog.body"),
+                        title: t("ResetInstanceConfigConfirmDialog.title"),
+                        body: t("ResetInstanceConfigConfirmDialog.body"),
                         isAlert: true,
-                        onOKCallback: handleRestoreInstanceGameConfig,
+                        onOKCallback: handleResetInstanceGameConfig,
                         showSuppressBtn: true,
-                        suppressKey: "restoreInstanceSpecConfig",
+                        suppressKey: "resetInstanceSpecConfig",
                       });
                     }}
                   >
-                    {t("InstanceSettingsPage.restore")}
+                    {t("InstanceSettingsPage.reset")}
                   </Button>
                 ),
               },

--- a/src/pages/settings/general.tsx
+++ b/src/pages/settings/general.tsx
@@ -43,8 +43,8 @@ const GeneralSettingsPage = () => {
   const instancesNavTypes = ["instance", "directory", "tag", "hidden"];
   const discoverPageModes = ["on", "search-only", "off"];
 
-  const handleRestoreLauncherConfig = useCallback(async () => {
-    ConfigService.restoreLauncherConfig().then((response) => {
+  const handleResetLauncherConfig = useCallback(async () => {
+    ConfigService.resetLauncherConfig().then((response) => {
       if (response.status === "success") {
         setConfig(response.data);
         toast({
@@ -352,9 +352,9 @@ const GeneralSettingsPage = () => {
           ),
         },
         {
-          title: t("GeneralSettingsPage.advanced.settings.restoreAll.title"),
+          title: t("GeneralSettingsPage.advanced.settings.resetAll.title"),
           description: t(
-            "GeneralSettingsPage.advanced.settings.restoreAll.description"
+            "GeneralSettingsPage.advanced.settings.resetAll.description"
           ),
           children: (
             <Button
@@ -363,14 +363,14 @@ const GeneralSettingsPage = () => {
               size="xs"
               onClick={() => {
                 openGenericConfirmDialog({
-                  title: t("RestoreConfigConfirmDialog.title"),
-                  body: t("RestoreConfigConfirmDialog.body"),
+                  title: t("ResetConfigConfirmDialog.title"),
+                  body: t("ResetConfigConfirmDialog.body"),
                   isAlert: true,
-                  onOKCallback: handleRestoreLauncherConfig,
+                  onOKCallback: handleResetLauncherConfig,
                 });
               }}
             >
-              {t("GeneralSettingsPage.advanced.settings.restoreAll.restore")}
+              {t("GeneralSettingsPage.advanced.settings.resetAll.reset")}
             </Button>
           ),
         },

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -40,14 +40,12 @@ export class ConfigService {
   }
 
   /**
-   * RESTORE the launcher configs to their default state and returns the new configuration.
+   * RESET the launcher configs to their default state and returns the new configuration.
    * @returns {Promise<InvokeResponse<LauncherConfig>>}
    */
   @responseHandler("config")
-  static async restoreLauncherConfig(): Promise<
-    InvokeResponse<LauncherConfig>
-  > {
-    return await invoke("restore_launcher_config");
+  static async resetLauncherConfig(): Promise<InvokeResponse<LauncherConfig>> {
+    return await invoke("reset_launcher_config");
   }
 
   /**

--- a/src/services/instance.ts
+++ b/src/services/instance.ts
@@ -114,15 +114,15 @@ export class InstanceService {
   }
 
   /**
-   * RESTORE the instance game config to use current global game config.
+   * RESET the instance game config to use current global game config.
    * @param {string} instanceId - The ID of the instance.
    * @returns {Promise<InvokeResponse<void>>}
    */
   @responseHandler("instance")
-  static async restoreInstanceGameConfig(
+  static async resetInstanceGameConfig(
     instanceId: string
   ): Promise<InvokeResponse<void>> {
-    return await invoke("restore_instance_game_config", {
+    return await invoke("reset_instance_game_config", {
       instanceId,
     });
   }


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [x] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

- resolves https://github.com/UNIkeEN/SJMCL/issues/1834

### Description

N/A

### Additional Context

N/A

## Summary by Sourcery

Unify localization terminology for reset-related actions across supported languages.

Bug Fixes:
- Replace inconsistent translations of 'factory reset' with a standardized 'reset' term in all affected locales to align with desired wording.

Enhancements:
- Normalize reset-related phrasing in English, Spanish, French, Simplified Chinese, and Traditional Chinese locale files for clearer, more consistent UI text.