### PR TITLE
fix(intelligence): align MCP instance default icons

### DIFF
--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/instance.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/instance.rs
@@ -73,8 +73,20 @@ async fn resolve_optifine(
     .ok_or_else(|| ResourceError::ParseError.into())
 }
 
-// In the user-facing workflow, the default icon mapping lives in the frontend create-instance modal.
-fn default_icon_for_game_type(game_type: &str) -> String {
+// Keep MCP-created instances consistent with the frontend create-instance modal.
+fn default_icon_for_instance(
+  game_type: &str,
+  mod_loader_type: ModLoaderType,
+  has_optifine: bool,
+) -> String {
+  if has_optifine {
+    return "/images/icons/OptiFine.png".to_string();
+  }
+
+  if mod_loader_type != ModLoaderType::Unknown {
+    return mod_loader_type.to_icon_path().to_string();
+  }
+
   match game_type {
     "snapshot" => "/images/icons/JEIcon_Snapshot.png",
     "old_beta" => "/images/icons/StoneOldBeta.png",
@@ -105,7 +117,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
         name: String,
         #[schemars(description = "Optional instance description. Defaults to an empty string.")]
         description: Option<String>,
-        #[schemars(description = "Optional instance icon source. Defaults to the standard icon for the selected game version type.")]
+        #[schemars(description = "Optional instance icon source. Defaults to the selected OptiFine/mod loader icon, or the standard icon for the selected game version type.")]
         icon_src: Option<String>,
         #[schemars(description = "Minecraft game version ID, for example `1.21.5`.")]
         game_version: String,
@@ -143,7 +155,13 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
         let icon_src = params
           .icon_src
           .filter(|icon_src| !icon_src.trim().is_empty())
-          .unwrap_or_else(|| default_icon_for_game_type(&game.game_type));
+          .unwrap_or_else(|| {
+            default_icon_for_instance(
+              &game.game_type,
+              mod_loader.loader_type,
+              optifine.is_some(),
+            )
+          });
 
         create_instance(
           app,


### PR DESCRIPTION
### Checklist

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

fix #1842

### Description

This PR aligns MCP-created instance default icons with the frontend create-instance flow.

When `icon_src` is omitted, MCP now defaults to:

- the OptiFine icon when OptiFine is selected
- the selected mod loader icon for Fabric, Quilt, Forge, NeoForge, etc.
- the game version type icon otherwise

### Additional Context

Verified with:

- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo check --manifest-path src-tauri/Cargo.toml`

## Summary by Sourcery

Align MCP-created instance default icons with the frontend create-instance behavior for OptiFine, mod loaders, and game version types.

Bug Fixes:
- Ensure MCP-created instances use the OptiFine icon by default when OptiFine is present.
- Ensure MCP-created instances default to the selected mod loader icon when a known mod loader is used.
- Fallback to the game version type icon when no OptiFine or known mod loader is selected for MCP-created instances.

Enhancements:
- Update the instance creation schema description to reflect the new default icon selection behavior.