### PR TITLE
fix(l10n): localize file size units in download progress display

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3189,6 +3189,12 @@
     }
   },
   "Utils": {
+    "byteSize": {
+      "b": "B",
+      "kib": "KiB",
+      "mib": "MiB",
+      "gib": "GiB"
+    },
     "datetime": {
       "formatRelativeTime": {
         "now": "now",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -3189,6 +3189,12 @@
     }
   },
   "Utils": {
+    "byteSize": {
+      "b": "B",
+      "kib": "KiB",
+      "mib": "MiB",
+      "gib": "GiB"
+    },
     "datetime": {
       "formatRelativeTime": {
         "now": "ahora",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -3189,6 +3189,12 @@
     }
   },
   "Utils": {
+    "byteSize": {
+      "b": "o",
+      "kib": "Kio",
+      "mib": "Mio",
+      "gib": "Gio"
+    },
     "datetime": {
       "formatRelativeTime": {
         "now": "Maintenant",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -3189,6 +3189,12 @@
     }
   },
   "Utils": {
+    "byteSize": {
+      "b": "B",
+      "kib": "KiB",
+      "mib": "MiB",
+      "gib": "GiB"
+    },
     "datetime": {
       "formatRelativeTime": {
         "now": "現在",

--- a/src/locales/lzh.json
+++ b/src/locales/lzh.json
@@ -3189,6 +3189,12 @@
     }
   },
   "Utils": {
+    "byteSize": {
+      "b": "B",
+      "kib": "KiB",
+      "mib": "MiB",
+      "gib": "GiB"
+    },
     "datetime": {
       "formatRelativeTime": {
         "now": "現在",

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -3189,6 +3189,12 @@
     }
   },
   "Utils": {
+    "byteSize": {
+      "b": "B",
+      "kib": "KiB",
+      "mib": "MiB",
+      "gib": "GiB"
+    },
     "datetime": {
       "formatRelativeTime": {
         "now": "现在",

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -3189,6 +3189,12 @@
     }
   },
   "Utils": {
+    "byteSize": {
+      "b": "B",
+      "kib": "KiB",
+      "mib": "MiB",
+      "gib": "GiB"
+    },
     "datetime": {
       "formatRelativeTime": {
         "now": "現在",

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,3 +1,4 @@
+import { t } from "i18next";
 import { BuildType } from "@/enums/misc";
 
 export const base64ImgSrc = (base64: string): string => {
@@ -24,13 +25,13 @@ export const removeFileExt = (filename: string): string => {
 
 export const formatByteSize = (bytes: number) => {
   bytes = Math.max(0, bytes);
-  const sizes = ["B", "KiB", "MiB", "GiB"];
+  const units = ["b", "kib", "mib", "gib"];
 
   if (bytes >= 1024) {
     let i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), 3);
-    return `${(bytes / Math.pow(1024, i)).toFixed(2)} ${sizes[i]}`;
+    return `${(bytes / Math.pow(1024, i)).toFixed(2)} ${t(`Utils.byteSize.${units[i]}`)}`;
   } else {
-    return `${bytes} B`;
+    return `${bytes} ${t(`Utils.byteSize.${units[0]}`)}`;
   }
 };
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [x] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

fix #1843

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Localize the human-readable file size display used in download progress to use translated unit labels via i18next.

New Features:
- Introduce localized byte size unit labels for download progress display using i18n resources.

Enhancements:
- Adjust byte size formatting utility to fetch unit labels from translation files instead of hard-coded English strings.