### PR TITLE
fix(resource): support CurseForge 26.2 version filter

### DIFF
--- a/src-tauri/src/resource/helpers/curseforge/misc.rs
+++ b/src-tauri/src/resource/helpers/curseforge/misc.rs
@@ -492,6 +492,7 @@ pub fn cvt_mod_loader_to_id(mod_loader: &str) -> u32 {
 // https://api.curseforge.com/v1/minecraft/version
 pub fn cvt_version_to_type_id(version: &str) -> u32 {
   match version {
+    "26.2" => 86297,
     "26.1" => 83806,
     "1.21" => 77784,
     "1.20" => 75125,


### PR DESCRIPTION
### Checklist

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🐞 Bug fix

### Related Issues

N/A

### Description

Adds the CurseForge `gameVersionTypeId` mapping for Minecraft 26.2.

This allows the resource downloader to request CurseForge files for 26.2 instead of falling back to an unsupported version type ID.

### Additional Context

The version type ID was verified through CurseForge's Minecraft version API.

## Summary by Sourcery

Bug Fixes:
- Ensure CurseForge resource downloads correctly target Minecraft 26.2 instead of falling back to an unsupported version type ID.