### PR TITLE
fix(account): refresh Microsoft session before game launch

### DIFF
--- a/src-tauri/src/account/helpers/microsoft/oauth.rs
+++ b/src-tauri/src/account/helpers/microsoft/oauth.rs
@@ -279,18 +279,40 @@ pub async fn refresh(app: &AppHandle, player: &PlayerInfo) -> SJMCLResult<Player
 }
 
 pub async fn validate(app: &AppHandle, player: &PlayerInfo) -> SJMCLResult<bool> {
+  let status = validate_access_token(app, &get_access_token(app, player).await?).await?;
+
+  if status == reqwest::StatusCode::UNAUTHORIZED {
+    let current_player = misc::get_player_by_id(app, &player.id)?.ok_or(AccountError::NotFound)?;
+    let refreshed_player = refresh(app, &current_player).await?;
+    let access_token = refreshed_player
+      .access_token
+      .clone()
+      .ok_or(AccountError::Invalid)?;
+    misc::update_player_by_id(app, &player.id, refreshed_player)?;
+
+    return Ok(
+      validate_access_token(app, &access_token)
+        .await?
+        .is_success(),
+    );
+  }
+
+  Ok(status.is_success())
+}
+
+async fn validate_access_token(
+  app: &AppHandle,
+  access_token: &str,
+) -> SJMCLResult<reqwest::StatusCode> {
   let client = app.state::<reqwest::Client>();
   let response = client
     .get(PROFILE_ENDPOINT)
-    .header(
-      "Authorization",
-      format!("Bearer {}", get_access_token(app, player).await?),
-    )
+    .header("Authorization", format!("Bearer {access_token}"))
     .send()
     .await
     .map_err(|_| AccountError::NetworkError)?;
 
-  Ok(response.status().is_success())
+  Ok(response.status())
 }
 
 /// Returns the access token for the player, refreshing it if necessary.
@@ -306,13 +328,12 @@ pub async fn get_access_token(app: &AppHandle, player: &PlayerInfo) -> SJMCLResu
       .unwrap_or(true);
 
   if need_refresh {
-    let player_id = player.id.as_str();
     let refreshed_player = refresh(app, player).await?;
     let access_token = refreshed_player
       .access_token
       .clone()
       .ok_or(AccountError::Invalid)?;
-    misc::update_player_by_id(app, player_id, refreshed_player)?;
+    misc::update_player_by_id(app, &player.id, refreshed_player)?;
 
     Ok(access_token)
   } else {

--- a/src-tauri/src/account/helpers/microsoft/oauth.rs
+++ b/src-tauri/src/account/helpers/microsoft/oauth.rs
@@ -275,15 +275,26 @@ pub async fn refresh(app: &AppHandle, player: &PlayerInfo) -> SJMCLResult<Player
     .await
     .map_err(|_| AccountError::ParseError)?;
 
-  parse_profile(app, &tokens).await
+  let mut refreshed_player = parse_profile(app, &tokens).await?;
+  refreshed_player.id = player.id.clone();
+  Ok(refreshed_player)
 }
 
 pub async fn validate(app: &AppHandle, player: &PlayerInfo) -> SJMCLResult<bool> {
-  let status = validate_access_token(app, &get_access_token(app, player).await?).await?;
+  let access_token = match get_access_token(app, player).await {
+    Ok(access_token) => access_token,
+    Err(error) if error == AccountError::Expired.into() => return Ok(false),
+    Err(error) => return Err(error),
+  };
+  let status = validate_access_token(app, &access_token).await?;
 
   if status == reqwest::StatusCode::UNAUTHORIZED {
     let current_player = misc::get_player_by_id(app, &player.id)?.ok_or(AccountError::NotFound)?;
-    let refreshed_player = refresh(app, &current_player).await?;
+    let refreshed_player = match refresh(app, &current_player).await {
+      Ok(refreshed_player) => refreshed_player,
+      Err(error) if error == AccountError::Expired.into() => return Ok(false),
+      Err(error) => return Err(error),
+    };
     let access_token = refreshed_player
       .access_token
       .clone()

--- a/src-tauri/src/account/helpers/microsoft/oauth.rs
+++ b/src-tauri/src/account/helpers/microsoft/oauth.rs
@@ -276,6 +276,7 @@ pub async fn refresh(app: &AppHandle, player: &PlayerInfo) -> SJMCLResult<Player
     .map_err(|_| AccountError::ParseError)?;
 
   let mut refreshed_player = parse_profile(app, &tokens).await?;
+  // Retain the internal player ID so a profile rename does not invalidate selected_player_id (#1350).
   refreshed_player.id = player.id.clone();
   Ok(refreshed_player)
 }

--- a/src-tauri/src/launch/commands.rs
+++ b/src-tauri/src/launch/commands.rs
@@ -214,7 +214,7 @@ pub async fn validate_game_files(
 }
 
 // Step 3: validate selected player, if its type is 3rd-party, load server meta for authlib.
-// returns Ok(false) if the access_token is expired, Ok(true) if the token is valid.
+// returns Ok(false) if the access token is invalid, Ok(true) if the token is valid.
 #[tauri::command]
 pub async fn validate_selected_player(
   app: AppHandle,
@@ -222,6 +222,15 @@ pub async fn validate_selected_player(
   local_ygg_server_state: State<'_, Mutex<YggdrasilServer>>,
 ) -> SJMCLResult<bool> {
   let mut player = get_selected_player_info(&app)?;
+
+  if player.player_type == PlayerType::Microsoft {
+    if !microsoft::oauth::validate(&app, &player).await? {
+      return Ok(false);
+    }
+
+    // Validation can refresh the token, so use the persisted player for launch arguments.
+    player = get_selected_player_info(&app)?;
+  }
 
   let metadata = if player.player_type == PlayerType::ThirdParty {
     authlib_injector::jar::check_authlib_jar(&app)
@@ -258,7 +267,7 @@ pub async fn validate_selected_player(
 
   match player.player_type {
     PlayerType::ThirdParty => authlib_injector::common::validate(&app, &player).await,
-    PlayerType::Microsoft => microsoft::oauth::validate(&app, &player).await,
+    PlayerType::Microsoft => Ok(true),
     PlayerType::Offline => Ok(true),
   }
 }


### PR DESCRIPTION
### Checklist

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🐞 Bug fix

### Related Issues

close #1867

### Description

- Validate Microsoft account sessions before launching the game.
- Refresh and retry when Minecraft rejects a cached access token as unauthorized.
- Reload the persisted player after validation so launch arguments use the refreshed access token.

### Additional Context

Validated with `cargo check --manifest-path src-tauri/Cargo.toml`. Runtime authentication requires a real Microsoft account and was not tested locally.

## Summary by Sourcery

Validate and refresh Microsoft account sessions before game launch to avoid unauthorized access token failures.

Bug Fixes:
- Handle unauthorized Microsoft access tokens by refreshing the player session and retrying validation before launching the game.

Enhancements:
- Separate Microsoft access token validation into a reusable helper that returns the HTTP status for better control of validation logic.

Documentation:
- Clarify player validation comments to reflect invalid access token handling rather than only expiration.