### PR TITLE
perf(resource): filter resource versions locally

### DIFF
--- a/src-tauri/src/resource/helpers/curseforge/misc.rs
+++ b/src-tauri/src/resource/helpers/curseforge/misc.rs
@@ -489,37 +489,6 @@ pub fn cvt_mod_loader_to_id(mod_loader: &str) -> u32 {
   }
 }
 
-// https://api.curseforge.com/v1/minecraft/version
-pub fn cvt_version_to_type_id(version: &str) -> u32 {
-  match version {
-    "26.2" => 86297,
-    "26.1" => 83806,
-    "1.21" => 77784,
-    "1.20" => 75125,
-    "1.19" => 73407,
-    "1.18" => 73250,
-    "1.17" => 73242,
-    "1.16" => 70886,
-    "1.15" => 68722,
-    "1.14" => 64806,
-    "1.13" => 55023,
-    "1.12" => 628,
-    "1.11" => 599,
-    "1.10" => 572,
-    "1.9" => 552,
-    "1.8" => 4,
-    "1.7" => 5,
-    "1.6" => 6,
-    "1.5" => 11,
-    "1.4" => 12,
-    "1.3" => 13,
-    "1.2" => 14,
-    "1.1" => 15,
-    "1.0" => 16,
-    _ => 0,
-  }
-}
-
 pub fn cvt_id_to_release_type(release_type: u32) -> String {
   match release_type {
     1 => "release".to_string(),

--- a/src-tauri/src/resource/helpers/curseforge/mod.rs
+++ b/src-tauri/src/resource/helpers/curseforge/mod.rs
@@ -4,7 +4,7 @@ use hex;
 use misc::{
   CurseForgeFileInfo, CurseForgeFingerprintRes, CurseForgeGetProjectRes, CurseForgeSearchRes,
   CurseForgeVersionPackSearchRes, cvt_category_to_id, cvt_mod_loader_to_id, cvt_sort_by_to_id,
-  cvt_type_to_class_id, cvt_version_to_type_id, get_curseforge_api, make_curseforge_request,
+  cvt_type_to_class_id, get_curseforge_api, make_curseforge_request,
   map_curseforge_file_to_version_pack,
 };
 use murmur2::murmur2;
@@ -178,10 +178,7 @@ pub async fn fetch_resource_version_packs_curseforge(
     if let Some(version) = game_versions.first()
       && version != ALL_FILTER
     {
-      params.insert(
-        "gameVersionTypeId".to_string(),
-        cvt_version_to_type_id(version).to_string(),
-      );
+      params.insert("gameVersion".to_string(), version.to_string());
     }
     params.insert("index".to_string(), (page * page_size).to_string());
     params.insert("pageSize".to_string(), page_size.to_string());

--- a/src/components/modals/check-mod-update-modal.tsx
+++ b/src/components/modals/check-mod-update-modal.tsx
@@ -170,7 +170,7 @@ const CheckModUpdateModal: React.FC<CheckModUpdateModalProps> = ({
               handleFetchLatestMod(
                 cfRemoteMod.resourceId,
                 mod.loaderType,
-                [currentSummary?.majorVersion || "All"],
+                [currentSummary?.version || "All"],
                 OtherResourceSource.CurseForge
               )
             );

--- a/src/components/modals/download-specific-resource-modal.tsx
+++ b/src/components/modals/download-specific-resource-modal.tsx
@@ -180,23 +180,35 @@ const DownloadSpecificResourceModal: React.FC<
     [toast]
   ); // this is because TaskContext is now inside the SharedModalContext, use a separated function to avoid circular dependency
 
-  const versionLabelToParam = useCallback(
-    (label: string) => {
-      if (label === "All") return ["All"];
-      if (resource.source === OtherResourceSource.Modrinth)
-        return gameVersionList.filter((version) => version.startsWith(label));
-      return [label];
-    },
-    [gameVersionList, resource.source]
-  );
+  const filteredVersionPacks = useMemo(() => {
+    const shouldFilterLoader =
+      resource.type === OtherResourceType.Mod &&
+      !resource.tags.includes("datapack") &&
+      selectedModLoader !== "All";
 
-  const versionPackFilter = (pack: OtherResourceVersionPack): boolean => {
-    const matchesVersion =
-      selectedVersionLabel === "All" ||
-      new RegExp(`^${selectedVersionLabel}(\\.|$)`).test(pack.name);
-
-    return matchesVersion;
-  };
+    return versionPacks
+      .filter(
+        (pack) =>
+          selectedVersionLabel === "All" ||
+          new RegExp(`^${selectedVersionLabel}(\\.|$)`).test(pack.name)
+      )
+      .map((pack) => ({
+        ...pack,
+        items: shouldFilterLoader
+          ? pack.items.filter(
+              (item) =>
+                item.loader?.toLowerCase() === selectedModLoader.toLowerCase()
+            )
+          : pack.items,
+      }))
+      .filter((pack) => pack.items.length > 0);
+  }, [
+    resource.tags,
+    resource.type,
+    selectedModLoader,
+    selectedVersionLabel,
+    versionPacks,
+  ]);
 
   const buildVersionLabelItem = (version: string) => {
     return version !== "All"
@@ -483,22 +495,15 @@ const DownloadSpecificResourceModal: React.FC<
   );
 
   const reFetchVersionPacks = useCallback(() => {
-    if (!resource.id || !resource.source || !selectedVersionLabel) return;
+    if (!resource.id || !resource.source) return;
 
     handleFetchResourceVersionPacks(
       resource.id,
-      selectedModLoader,
-      versionLabelToParam(selectedVersionLabel),
+      "All",
+      ["All"],
       resource.source
     );
-  }, [
-    resource.id,
-    resource.source,
-    selectedModLoader,
-    selectedVersionLabel,
-    handleFetchResourceVersionPacks,
-    versionLabelToParam,
-  ]);
+  }, [resource.id, resource.source, handleFetchResourceVersionPacks]);
 
   const buildModLoaderItem = (modLoader: string) => {
     return modLoader !== "All" ? (
@@ -795,7 +800,7 @@ const DownloadSpecificResourceModal: React.FC<
             </VStack>
           ) : (
             (() => {
-              const normalPacks = versionPacks.filter(versionPackFilter);
+              const normalPacks = filteredVersionPacks;
               const recommendedPacks = shouldShowRecommendedSection()
                 ? [
                     {


### PR DESCRIPTION
### Checklist

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [x] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

close #1851

### Description

Load all resource file pages once when opening the resource details modal, then filter Minecraft versions and mod loaders locally. Changing filters no longer triggers additional backend requests.

Remove the hardcoded CurseForge game version type ID mapping and use exact `gameVersion` filtering for mod update checks.

### Additional Context

Validated with ESLint, TypeScript type checking, Rust formatting checks, and the repository commit hooks.

## Summary by Sourcery

Load all resource version packs upfront and perform Minecraft version and mod loader filtering locally to reduce backend queries and improve performance.

Bug Fixes:
- Avoid mismatches caused by coarse CurseForge game version type ID mapping when searching for mod updates.

Enhancements:
- Filter resource version packs by Minecraft version and mod loader on the client while keeping the backend query unfiltered.
- Use CurseForge `gameVersion` parameter directly instead of relying on a hardcoded version type ID mapping for version pack searches.
- Use the full mod version string instead of the major version when checking for latest CurseForge mod updates.