### PR TITLE
feat(launch): support Minecraft 26.2 native libraries

### DIFF
--- a/src-tauri/assets/game/natives.json
+++ b/src-tauri/assets/game/natives.json
@@ -781,6 +781,270 @@
         }
       }
     },
+    "org.lwjgl:lwjgl:3.4.1:natives-linux": {
+      "name": "org.lwjgl:lwjgl:3.4.1:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl/3.4.1/lwjgl-3.4.1-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.4.1/lwjgl-3.4.1-natives-linux-arm64.jar",
+          "sha1": "46883f3b622d8b4d7f27b627ca3360cda3db0e0e",
+          "size": 120615
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-jemalloc:3.4.1:natives-linux": {
+      "name": "org.lwjgl:lwjgl-jemalloc:3.4.1:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-jemalloc/3.4.1/lwjgl-jemalloc-3.4.1-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.4.1/lwjgl-jemalloc-3.4.1-natives-linux-arm64.jar",
+          "sha1": "7891964dfb723209c6d02b0401432348fb707cc0",
+          "size": 238730
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-openal:3.4.1:natives-linux": {
+      "name": "org.lwjgl:lwjgl-openal:3.4.1:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-openal/3.4.1/lwjgl-openal-3.4.1-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.4.1/lwjgl-openal-3.4.1-natives-linux-arm64.jar",
+          "sha1": "3729b70cdd42df5571b075e051fa2fc8586dc538",
+          "size": 839895
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-opengl:3.4.1:natives-linux": {
+      "name": "org.lwjgl:lwjgl-opengl:3.4.1:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-opengl/3.4.1/lwjgl-opengl-3.4.1-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.4.1/lwjgl-opengl-3.4.1-natives-linux-arm64.jar",
+          "sha1": "61a4103e56bbaeb74ad3f19ec14299fd6891c4b0",
+          "size": 79752
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-glfw:3.4.1:natives-linux": {
+      "name": "org.lwjgl:lwjgl-glfw:3.4.1:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-glfw/3.4.1/lwjgl-glfw-3.4.1-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.4.1/lwjgl-glfw-3.4.1-natives-linux-arm64.jar",
+          "sha1": "e5e87034c47118960746077dba46280e8de864b3",
+          "size": 141530
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-stb:3.4.1:natives-linux": {
+      "name": "org.lwjgl:lwjgl-stb:3.4.1:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-stb/3.4.1/lwjgl-stb-3.4.1-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.4.1/lwjgl-stb-3.4.1-natives-linux-arm64.jar",
+          "sha1": "3bc107f901f931fea07cb0d80b1d74a34b806a2b",
+          "size": 259116
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-tinyfd:3.4.1:natives-linux": {
+      "name": "org.lwjgl:lwjgl-tinyfd:3.4.1:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-tinyfd/3.4.1/lwjgl-tinyfd-3.4.1-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.4.1/lwjgl-tinyfd-3.4.1-natives-linux-arm64.jar",
+          "sha1": "20771d2b4e01f5295156912ab62e170508aef618",
+          "size": 45433
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-freetype:3.4.1:natives-linux": {
+      "name": "org.lwjgl:lwjgl-freetype:3.4.1:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-freetype/3.4.1/lwjgl-freetype-3.4.1-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-freetype/3.4.1/lwjgl-freetype-3.4.1-natives-linux-arm64.jar",
+          "sha1": "8f37d0da3386ff602ec54cd06626881895711041",
+          "size": 1309568
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-shaderc:3.4.1:natives-linux": {
+      "name": "org.lwjgl:lwjgl-shaderc:3.4.1:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-shaderc/3.4.1/lwjgl-shaderc-3.4.1-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-shaderc/3.4.1/lwjgl-shaderc-3.4.1-natives-linux-arm64.jar",
+          "sha1": "bc5c99b2eb7e2109c6db21cfced15a6851f8111b",
+          "size": 3397476
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-spvc:3.4.1:natives-linux": {
+      "name": "org.lwjgl:lwjgl-spvc:3.4.1:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-spvc/3.4.1/lwjgl-spvc-3.4.1-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-spvc/3.4.1/lwjgl-spvc-3.4.1-natives-linux-arm64.jar",
+          "sha1": "e2eaa8f516d43fe11b8253e6243b3d8e1315c9c8",
+          "size": 1139919
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-vma:3.4.1:natives-linux": {
+      "name": "org.lwjgl:lwjgl-vma:3.4.1:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-vma/3.4.1/lwjgl-vma-3.4.1-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-vma/3.4.1/lwjgl-vma-3.4.1-natives-linux-arm64.jar",
+          "sha1": "de40d43c5947c4a4f91376af8f2c00e5396cc109",
+          "size": 59715
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-sdl:3.4.1:natives-linux": {
+      "name": "org.lwjgl:lwjgl-sdl:3.4.1:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-sdl/3.4.1/lwjgl-sdl-3.4.1-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-sdl/3.4.1/lwjgl-sdl-3.4.1-natives-linux-arm64.jar",
+          "sha1": "b5a62eb82113b0227077fb270128487a80a20299",
+          "size": 1434288
+        }
+      }
+    },
+    "org.lwjgl:lwjgl:3.4.2:natives-linux": {
+      "name": "org.lwjgl:lwjgl:3.4.2:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl/3.4.2/lwjgl-3.4.2-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl/3.4.2/lwjgl-3.4.2-natives-linux-arm64.jar",
+          "sha1": "a2229c542e410157bc79aead90243bd50dbcd79c",
+          "size": 125841
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-jemalloc:3.4.2:natives-linux": {
+      "name": "org.lwjgl:lwjgl-jemalloc:3.4.2:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-jemalloc/3.4.2/lwjgl-jemalloc-3.4.2-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-jemalloc/3.4.2/lwjgl-jemalloc-3.4.2-natives-linux-arm64.jar",
+          "sha1": "8e51830cf9077fb0a89a6f43fa09df55c8c0e8ef",
+          "size": 235933
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-openal:3.4.2:natives-linux": {
+      "name": "org.lwjgl:lwjgl-openal:3.4.2:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-openal/3.4.2/lwjgl-openal-3.4.2-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-openal/3.4.2/lwjgl-openal-3.4.2-natives-linux-arm64.jar",
+          "sha1": "a3c98570beeffd241263e9bc63d8650147b33c4c",
+          "size": 866040
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-opengl:3.4.2:natives-linux": {
+      "name": "org.lwjgl:lwjgl-opengl:3.4.2:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-opengl/3.4.2/lwjgl-opengl-3.4.2-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-opengl/3.4.2/lwjgl-opengl-3.4.2-natives-linux-arm64.jar",
+          "sha1": "52f6e847226e41f60773a62314cfada4f82b578c",
+          "size": 80853
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-glfw:3.4.2:natives-linux": {
+      "name": "org.lwjgl:lwjgl-glfw:3.4.2:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-glfw/3.4.2/lwjgl-glfw-3.4.2-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-glfw/3.4.2/lwjgl-glfw-3.4.2-natives-linux-arm64.jar",
+          "sha1": "943ec4651c874e9e0a59724976923c7bd8fceb9f",
+          "size": 144523
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-stb:3.4.2:natives-linux": {
+      "name": "org.lwjgl:lwjgl-stb:3.4.2:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-stb/3.4.2/lwjgl-stb-3.4.2-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-stb/3.4.2/lwjgl-stb-3.4.2-natives-linux-arm64.jar",
+          "sha1": "30a261559033e22e7eb7f9a4ac1f2ea96d76f4d8",
+          "size": 258999
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-tinyfd:3.4.2:natives-linux": {
+      "name": "org.lwjgl:lwjgl-tinyfd:3.4.2:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-tinyfd/3.4.2/lwjgl-tinyfd-3.4.2-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-tinyfd/3.4.2/lwjgl-tinyfd-3.4.2-natives-linux-arm64.jar",
+          "sha1": "03b72a19851c1e4fa0ad51a03f78d08f664afc91",
+          "size": 45348
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-freetype:3.4.2:natives-linux": {
+      "name": "org.lwjgl:lwjgl-freetype:3.4.2:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-freetype/3.4.2/lwjgl-freetype-3.4.2-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-freetype/3.4.2/lwjgl-freetype-3.4.2-natives-linux-arm64.jar",
+          "sha1": "b5fb3db06d1ecb15f54fabda6a4914ae933525ee",
+          "size": 1319451
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-shaderc:3.4.2:natives-linux": {
+      "name": "org.lwjgl:lwjgl-shaderc:3.4.2:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-shaderc/3.4.2/lwjgl-shaderc-3.4.2-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-shaderc/3.4.2/lwjgl-shaderc-3.4.2-natives-linux-arm64.jar",
+          "sha1": "23403f5c295d946d1d2f7785c551f48be2b2fe9b",
+          "size": 3463790
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-spvc:3.4.2:natives-linux": {
+      "name": "org.lwjgl:lwjgl-spvc:3.4.2:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-spvc/3.4.2/lwjgl-spvc-3.4.2-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-spvc/3.4.2/lwjgl-spvc-3.4.2-natives-linux-arm64.jar",
+          "sha1": "8d7b46d68788d217143eee402126ea286d100683",
+          "size": 1166742
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-vma:3.4.2:natives-linux": {
+      "name": "org.lwjgl:lwjgl-vma:3.4.2:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-vma/3.4.2/lwjgl-vma-3.4.2-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-vma/3.4.2/lwjgl-vma-3.4.2-natives-linux-arm64.jar",
+          "sha1": "c6fb35dd852aedf2266d462c9b7142c41a860298",
+          "size": 60868
+        }
+      }
+    },
+    "org.lwjgl:lwjgl-sdl:3.4.2:natives-linux": {
+      "name": "org.lwjgl:lwjgl-sdl:3.4.2:natives-linux-arm64",
+      "downloads": {
+        "artifact": {
+          "path": "org/lwjgl/lwjgl-sdl/3.4.2/lwjgl-sdl-3.4.2-natives-linux-arm64.jar",
+          "url": "https://repo1.maven.org/maven2/org/lwjgl/lwjgl-sdl/3.4.2/lwjgl-sdl-3.4.2-natives-linux-arm64.jar",
+          "sha1": "e723c33b467c5ff2af02942a1459db4e3686ce57",
+          "size": 1455063
+        }
+      }
+    },
     "org.lwjgl.lwjgl:lwjgl-platform:2.9.0:natives": {
       "name": "org.glavo.hmcl:lwjgl2-natives:2.9.3",
       "downloads": {

--- a/src-tauri/src/launch/helpers/file_validator.rs
+++ b/src-tauri/src/launch/helpers/file_validator.rs
@@ -394,10 +394,12 @@ fn get_native_library_extract_dir(client_info: &McClientInfo, natives_dir: &Path
         continue;
       };
 
+      // Minecraft versions before 26.2-snapshot-1 use ${natives_directory} directly.
       if path == "${natives_directory}" {
         return natives_dir.to_path_buf();
       }
 
+      // Minecraft 26.2-snapshot-1+ may use a subdirectory such as ${natives_directory}/java.
       let Some(relative_path) = path.strip_prefix(NATIVES_SUBDIR_PREFIX) else {
         return natives_dir.to_path_buf();
       };

--- a/src-tauri/src/launch/helpers/file_validator.rs
+++ b/src-tauri/src/launch/helpers/file_validator.rs
@@ -5,7 +5,7 @@ use sjmcl_types::error::{SJMCLError, SJMCLResult};
 use sjmcl_types::storage::load_json_async;
 use std::collections::{HashMap, HashSet};
 use std::io::Cursor;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use tauri::AppHandle;
 use tokio::fs;
 use zip::ZipArchive;
@@ -376,6 +376,48 @@ pub fn get_native_library_paths(
   Ok(result)
 }
 
+fn get_native_library_extract_dir(client_info: &McClientInfo, natives_dir: &Path) -> PathBuf {
+  const JAVA_LIBRARY_PATH_PREFIX: &str = "-Djava.library.path=";
+  const NATIVES_SUBDIR_PREFIX: &str = "${natives_directory}/";
+
+  let Some(arguments) = &client_info.arguments else {
+    return natives_dir.to_path_buf();
+  };
+
+  for argument in &arguments.jvm {
+    if !argument.rules.is_empty() {
+      continue;
+    }
+
+    for value in &argument.value {
+      let Some(path) = value.strip_prefix(JAVA_LIBRARY_PATH_PREFIX) else {
+        continue;
+      };
+
+      if path == "${natives_directory}" {
+        return natives_dir.to_path_buf();
+      }
+
+      let Some(relative_path) = path.strip_prefix(NATIVES_SUBDIR_PREFIX) else {
+        return natives_dir.to_path_buf();
+      };
+      let relative_path = Path::new(relative_path);
+
+      if relative_path.as_os_str().is_empty()
+        || !relative_path
+          .components()
+          .all(|component| matches!(component, Component::Normal(_)))
+      {
+        return natives_dir.to_path_buf();
+      }
+
+      return natives_dir.join(relative_path);
+    }
+  }
+
+  natives_dir.to_path_buf()
+}
+
 pub async fn extract_native_libraries(
   client_info: &McClientInfo,
   library_path: &Path,
@@ -388,7 +430,8 @@ pub async fn extract_native_libraries(
     fs::remove_dir_all(natives_dir).await?;
   }
 
-  fs::create_dir_all(natives_dir).await?;
+  let extract_dir = get_native_library_extract_dir(client_info, natives_dir);
+  fs::create_dir_all(&extract_dir).await?;
 
   let native_libraries = get_native_library_paths(
     client_info,
@@ -399,11 +442,11 @@ pub async fn extract_native_libraries(
   let tasks: Vec<tokio::task::JoinHandle<SJMCLResult<()>>> = native_libraries
     .into_iter()
     .map(|library_path| {
-      let patches_dir_clone = natives_dir.clone();
+      let extract_dir = extract_dir.clone();
       tokio::spawn(async move {
         let file = Cursor::new(fs::read(library_path).await?);
         let mut jar = ZipArchive::new(file)?;
-        jar.extract(&patches_dir_clone)?;
+        jar.extract(&extract_dir)?;
         Ok(())
       })
     })


### PR DESCRIPTION
### Checklist

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

No related issue specified.

### Description

- Support Minecraft versions that place Java native libraries in a subdirectory of `${natives_directory}`.
- Validate the configured relative native path and fall back to the legacy root directory for unsupported or unsafe paths.
- Add Linux ARM64 native mappings for LWJGL 3.4.1 and 3.4.2.

### Additional Context

`cargo fmt --all -- --check` and `git diff --check` passed. No tests are included in this change.

## Summary by Sourcery

Support extraction of Minecraft native libraries into validated subdirectories under the configured natives directory and add mappings for newer Linux ARM64 LWJGL natives.

New Features:
- Allow configuring Minecraft native libraries to be extracted into a subdirectory of the natives directory based on JVM java.library.path arguments.
- Validate relative native subdirectory paths and fall back to the root natives directory for unsupported or unsafe configurations.
- Add Linux ARM64 native mappings for LWJGL 3.4.1 and 3.4.2 in the bundled natives configuration.