### PR TITLE
feat(instance): show schematics in nested folders

### DIFF
--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -76,7 +76,8 @@ use crate::tasks::commands::schedule_progressive_task_group;
 use crate::tasks::download::DownloadParam;
 use crate::utils::fs::{
   RemoveDirGuard, copy_whole_dir, create_url_shortcut, generate_unique_filename,
-  get_files_with_regex, get_subdirectories, normalize_relative_path,
+  get_files_with_regex, get_files_with_regex_recursive, get_subdirectories,
+  normalize_relative_path,
 };
 use crate::utils::image::ImageWrapper;
 
@@ -835,7 +836,15 @@ pub fn retrieve_schematic_list(
     .build()
     .unwrap();
   let mut schematic_list = Vec::new();
-  for schematic_path in get_files_with_regex(schematics_dir.as_path(), &valid_extensions)? {
+  for schematic_path in
+    get_files_with_regex_recursive(schematics_dir.as_path(), &valid_extensions, Some(3))?
+  {
+    let Ok(relative_path) = schematic_path
+      .strip_prefix(&schematics_dir)
+      .map(Path::to_path_buf)
+    else {
+      continue;
+    };
     schematic_list.push(SchematicInfo {
       name: schematic_path
         .file_stem()
@@ -843,8 +852,10 @@ pub fn retrieve_schematic_list(
         .to_string_lossy()
         .to_string(),
       file_path: schematic_path,
+      relative_path,
     });
   }
+  schematic_list.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
 
   Ok(schematic_list)
 }

--- a/src-tauri/src/instance/models/misc.rs
+++ b/src-tauri/src/instance/models/misc.rs
@@ -229,6 +229,7 @@ pub struct ResourcePackInfo {
 pub struct SchematicInfo {
   pub name: String,
   pub file_path: PathBuf,
+  pub relative_path: PathBuf,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize, Default)]

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -8,6 +8,7 @@ use std::path::{Component, Path, PathBuf};
 use std::{fs, io};
 use tauri::path::BaseDirectory;
 use tauri::{AppHandle, Manager};
+use walkdir::WalkDir;
 use zip::write::{ExtendedFileOptions, FileOptions};
 use zip::{CompressionMethod, ZipWriter};
 
@@ -185,29 +186,39 @@ pub fn get_subdirectories<P: AsRef<Path>>(path: P) -> SJMCLResult<Vec<PathBuf>> 
 /// let mod_paths = get_files_with_regex(&mods_dir, &valid_extensions).unwrap_or_default();
 /// ```
 pub fn get_files_with_regex<P: AsRef<Path>>(path: P, pattern: &Regex) -> SJMCLResult<Vec<PathBuf>> {
-  let dir_entries = fs::read_dir(&path).map_err(|e| {
-    let error_message = match e.kind() {
-      io::ErrorKind::NotFound => "Path does not exist".to_string(),
-      _ => format!("IO Error: {}", e),
-    };
-    SJMCLError(error_message)
-  })?;
+  get_files_with_regex_recursive(path, pattern, Some(0))
+}
 
-  let mut matching_files = Vec::new();
-
-  for entry in dir_entries {
-    let entry = entry.map_err(|e| SJMCLError(format!("Read Entry Error: {}", e)))?;
-    let path = entry.path();
-
-    if let Some(file_name) = path.file_name()
-      && let Some(file_name_str) = file_name.to_str()
-      && pattern.is_match(file_name_str)
-    {
-      matching_files.push(path);
-    }
+/// Recursively retrieves files that match a specified regular expression.
+///
+/// `max_depth` limits the number of subdirectory levels to traverse. `None` traverses all levels.
+pub fn get_files_with_regex_recursive<P: AsRef<Path>>(
+  path: P,
+  pattern: &Regex,
+  max_depth: Option<usize>,
+) -> SJMCLResult<Vec<PathBuf>> {
+  let mut walker = WalkDir::new(path).min_depth(1);
+  if let Some(max_depth) = max_depth {
+    walker = walker.max_depth(max_depth + 1);
   }
 
-  Ok(matching_files)
+  walker
+    .into_iter()
+    .filter_map(|entry| match entry {
+      Ok(entry)
+        if (entry.file_type().is_file()
+          || (entry.file_type().is_symlink() && entry.path().is_file()))
+          && entry
+            .file_name()
+            .to_str()
+            .is_some_and(|name| pattern.is_match(name)) =>
+      {
+        Some(Ok(entry.into_path()))
+      }
+      Ok(_) => None,
+      Err(e) => Some(Err(SJMCLError(format!("Walk Directory Error: {}", e)))),
+    })
+    .collect()
 }
 
 /// Retrieves the full filesystem path to an application resource, choosing between

--- a/src/models/instance/misc.ts
+++ b/src/models/instance/misc.ts
@@ -104,6 +104,7 @@ export interface ResourcePackInfo {
 export interface SchematicInfo {
   name: string;
   filePath: string;
+  relativePath: string;
 }
 
 export interface ShaderPackInfo {

--- a/src/models/mock/instance.ts
+++ b/src/models/mock/instance.ts
@@ -20,9 +20,11 @@ export const mockSchematics: SchematicInfo[] = [
   {
     name: "TestFile.schematic",
     filePath: "/.minecraft/schematics",
+    relativePath: "TestFile.schematic",
   },
   {
     name: "McDonalds-Minhang-Campus.litematic",
     filePath: "/.minecraft/schematics",
+    relativePath: "McDonalds-Minhang-Campus.litematic",
   },
 ];

--- a/src/pages/instances/details/[id]/schematics.tsx
+++ b/src/pages/instances/details/[id]/schematics.tsx
@@ -1,4 +1,4 @@
-import { Center, HStack } from "@chakra-ui/react";
+import { Center, HStack, Text } from "@chakra-ui/react";
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -117,6 +117,21 @@ const InstanceSchematicsPage = () => {
     },
   ];
 
+  const renderSchematicPath = (relativePath: string) => {
+    const fileNameStart =
+      Math.max(relativePath.lastIndexOf("/"), relativePath.lastIndexOf("\\")) +
+      1;
+
+    return (
+      <Text fontSize="xs-sm">
+        <Text as="span" className="secondary-text">
+          {relativePath.slice(0, fileNameStart)}
+        </Text>
+        {relativePath.slice(fileNameStart)}
+      </Text>
+    );
+  };
+
   return (
     <>
       <Section
@@ -144,7 +159,10 @@ const InstanceSchematicsPage = () => {
         ) : schematics.length > 0 ? (
           <OptionItemGroup
             items={schematics.map((schem) => (
-              <OptionItem key={schem.name} title={schem.name}>
+              <OptionItem
+                key={schem.relativePath}
+                title={renderSchematicPath(schem.relativePath)}
+              >
                 <HStack spacing={0}>
                   {schemItemMenuOperations(schem).map((item, index) => (
                     <CommonIconButton


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

close #1790 

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Support listing and displaying schematics from nested folders within an instance, including tracking their relative paths.

New Features:
- Allow recursive discovery of schematic files within a limited directory depth and include their relative paths in the instance schematic metadata.

Enhancements:
- Improve schematic listing sorting and UI by using relative paths as identifiers and rendering folder paths distinctly from file names in the schematics view.