### PR TITLE
feat: 记录并展示本地整合包实例的版本号

### DIFF
--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -1047,6 +1047,7 @@ pub async fn create_instance(
   modpack_path: Option<String>,
   mut is_install_fabric_api: Option<bool>,
   mut is_install_qf_api: Option<bool>,
+  modpack_version: Option<String>,
 ) -> SJMCLResult<()> {
   let client = app.state::<reqwest::Client>();
   let launcher_config_state = app.state::<Mutex<LauncherConfig>>();
@@ -1101,6 +1102,7 @@ pub async fn create_instance(
     play_time: 0,
     use_spec_game_config: false,
     spec_game_config: None,
+    modpack_version: modpack_version.clone(),
   };
 
   // Download version info

--- a/src-tauri/src/instance/models/misc.rs
+++ b/src-tauri/src/instance/models/misc.rs
@@ -104,6 +104,7 @@ structstruck::strike! {
     pub use_spec_game_config: bool,
     // if use_spec_game_config is false, this field is ignored
     pub spec_game_config: Option<GameConfig>,
+    pub modpack_version: Option<String>,
   }
 }
 
@@ -142,6 +143,7 @@ pub struct InstanceSummary {
   pub support_quick_play: bool,
   pub use_spec_game_config: bool,
   pub is_version_isolated: bool,
+  pub modpack_version: Option<String>,
 }
 
 impl InstanceSummary {
@@ -171,6 +173,7 @@ impl InstanceSummary {
         .is_ge(),
       use_spec_game_config: instance.use_spec_game_config,
       is_version_isolated,
+      modpack_version: instance.modpack_version.clone(),
     }
   }
 }

--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/instance.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/instance.rs
@@ -159,6 +159,8 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
         is_install_fabric_api: Option<bool>,
         #[schemars(description = "Whether to install QFAPI/QSL when creating a Quilt instance. Defaults to true.")]
         is_install_qf_api: Option<bool>,
+        #[schemars(description = "Optional modpack version to use.")]
+        modpack_version: Option<String>,
       } => async move {
         if params.name.trim().is_empty()
           || params.directory_name.trim().is_empty()
@@ -204,6 +206,7 @@ pub fn tool_routes() -> Vec<ToolRoute<McpContext>> {
           params.modpack_path,
           params.is_install_fabric_api.or(Some(true)),
           params.is_install_qf_api.or(Some(true)),
+          params.modpack_version,
         )
         .await
       }

--- a/src/components/instances-view.tsx
+++ b/src/components/instances-view.tsx
@@ -57,8 +57,17 @@ const InstancesView: React.FC<InstancesViewProps> = ({
     description: [generateInstanceDesc(instance), instance.description]
       .filter(Boolean)
       .join(", "),
-    titleExtra: (instance.starred || isChakraColor(instance.tag)) && (
+    titleExtra: (instance.modpackVersion != null ||
+      instance.starred ||
+      isChakraColor(instance.tag)) && (
       <HStack spacing={1}>
+        {instance.modpackVersion != null && (
+          <Text fontSize="xs-sm" color="gray.500">
+            {instance.modpackVersion.startsWith("v")
+              ? instance.modpackVersion
+              : `v${instance.modpackVersion}`}
+          </Text>
+        )}
         {instance.starred && <Icon as={FaStar} color="yellow.500" />}
         {isChakraColor(instance.tag) && (
           <Icon as={GoDotFill} color={`${instance.tag}.500`} />

--- a/src/components/modals/import-modpack-modal.tsx
+++ b/src/components/modals/import-modpack-modal.tsx
@@ -130,7 +130,10 @@ const ImportModpackModal: React.FC<ImportModpackModalProps> = ({
             } as ModLoaderResourceInfo)
           : defaultModLoaderResourceInfo,
         undefined,
-        path
+        path,
+        undefined,
+        undefined,
+        modpack.version
       );
       if (createResp.status === "success") {
         onClose();

--- a/src/models/instance/misc.ts
+++ b/src/models/instance/misc.ts
@@ -38,6 +38,7 @@ export interface InstanceSummary {
   supportQuickPlay: boolean;
   useSpecGameConfig: boolean;
   isVersionIsolated: boolean;
+  modpackVersion?: string;
 }
 
 export interface ModpackMetaInfo {

--- a/src/services/instance.ts
+++ b/src/services/instance.ts
@@ -49,6 +49,7 @@ export class InstanceService {
    * @param {string} [modpackPath] - Optional path to the modpack archive file.
    * @param {boolean} [isInstallFabricApi] - Optional flag to indicate whether to install Fabric API (only valid when modLoader is Fabric).
    * @param {boolean} [isInstallQfApi] - Optional flag to indicate whether to install QFAPI / QSL (only valid when modLoader is Quilt).
+   * @param {string} [modpackVersion] - Optional modpack version to use.
    * @returns {Promise<InvokeResponse<null>>}
    */
   @responseHandler("instance")
@@ -62,7 +63,8 @@ export class InstanceService {
     optifine?: OptiFineResourceInfo,
     modpackPath?: string,
     isInstallFabricApi?: boolean,
-    isInstallQfApi?: boolean
+    isInstallQfApi?: boolean,
+    modpackVersion?: string
   ): Promise<InvokeResponse<null>> {
     return await invoke("create_instance", {
       directory,
@@ -75,6 +77,7 @@ export class InstanceService {
       modpackPath,
       isInstallFabricApi,
       isInstallQfApi,
+      modpackVersion,
     });
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

resolves #1785

### Description
<img width="1098" height="369" alt="image" src="https://github.com/user-attachments/assets/642995b3-3a99-44a9-b310-5b42ccb5e649" />

### Additional Context

## Summary by Sourcery

Record and surface modpack version information for local instances, from creation/import through to display in the instances list.

New Features:
- Persist an optional modpack version on instances across backend models, commands, and MCP tooling.
- Display the associated modpack version in the instances list header when available, normalizing it with a leading v.

Enhancements:
- Propagate modpack version metadata from the modpack import modal into instance creation so it can be stored and reused.