### PR TITLE
fix(instance): handle missing instance directory on open

### DIFF
--- a/src-tauri/src/instance/helpers/misc.rs
+++ b/src-tauri/src/instance/helpers/misc.rs
@@ -37,6 +37,9 @@ pub fn get_instance_subdir_paths(
   directory_types: &[&InstanceSubdirType],
 ) -> Option<Vec<PathBuf>> {
   let version_path = &instance.version_path;
+  if !version_path.exists() {
+    return None;
+  }
   let game_dir = version_path.parent()?.parent()?; // safe unwrap to `?`
 
   let version_isolation = get_instance_game_config(app, instance).version_isolation;

--- a/src/contexts/instance.tsx
+++ b/src/contexts/instance.tsx
@@ -1,5 +1,7 @@
 import { open } from "@tauri-apps/plugin-dialog";
+import { exists } from "@tauri-apps/plugin-fs";
 import { openPath } from "@tauri-apps/plugin-opener";
+import { t } from "i18next";
 import { useRouter } from "next/router";
 import React, {
   createContext,
@@ -172,18 +174,44 @@ export const InstanceContextProvider: React.FC<{
   );
 
   useEffect(() => {
+    if (instanceId === undefined) return;
     // get summary
     const instanceList = getInstanceList() || [];
-    if (instanceId !== undefined) {
-      const summary = instanceList.find(
-        (instance) => instance.id === instanceId
-      );
-      if (summary && summary?.id) {
-        setInstanceSummary(summary);
-        handleRetrieveInstanceGameConfig(instanceId);
-      }
+    const summary = instanceList.find((instance) => instance.id === instanceId);
+
+    const handleMissing = () => {
+      toast({
+        title: t(
+          "Services.instance.retrieveInstanceGameConfig.error.description.INSTANCE_NOT_FOUND_BY_ID"
+        ),
+        status: "error",
+      });
+      getInstanceList(true);
+      router.replace("/instances/list");
+    };
+
+    if (!summary?.id) {
+      handleMissing();
+      return;
     }
-  }, [instanceId, getInstanceList, handleRetrieveInstanceGameConfig]);
+
+    exists(summary.versionPath)
+      .then((dirExists) => {
+        if (dirExists) {
+          setInstanceSummary(summary);
+          handleRetrieveInstanceGameConfig(instanceId);
+        } else {
+          handleMissing();
+        }
+      })
+      .catch(handleMissing);
+  }, [
+    instanceId,
+    getInstanceList,
+    handleRetrieveInstanceGameConfig,
+    router,
+    toast,
+  ]);
 
   const handleRetrieveInstanceSubdirPath = useCallback(
     (dirType: InstanceSubdirType): Promise<string | null> => {


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - close #1073

### Description

> - 在点击实例前检查是否存在，不存在则退回上级页面而非自动创建实例目录

## Summary by Sourcery

Handle missing instance directories when opening instances and prevent automatic recreation of non-existent paths.

Bug Fixes:
- Prevent opening instances that no longer exist by validating their presence in the instance list and filesystem before loading configuration.
- Return early from Tauri helper when the instance version path is missing to avoid operating on non-existent directories.