### PR TITLE
feat(resource): keep dependency alert open when opening a dependency

### DIFF
--- a/src/components/modals/alert-resource-dependency-modal.tsx
+++ b/src/components/modals/alert-resource-dependency-modal.tsx
@@ -186,7 +186,9 @@ const AlertResourceDependencyModal: React.FC<
         }
         isFullClickZone
         onClick={() => {
-          modalProps.onClose();
+          if (dependencies.length < 2) {
+            modalProps.onClose();
+          }
           openSharedModal("download-specific-resource", {
             resource,
             curInstanceMajorVersion,


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - fix #1623

### Description

> - 当资源存在多个前置依赖时，在"存在前置资源"弹窗中点击依赖项不再关闭该弹窗，关闭新打开的”资源下载”后可继续下载其它前置

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Bug Fixes:
- Prevent the dependency alert modal from closing when selecting a prerequisite resource if there are multiple dependencies, so users can continue downloading remaining prerequisites.