### PR TITLE
feat(frontend): continue launch after game files patching

### DIFF
--- a/src/components/modals/launch-process-modal.tsx
+++ b/src/components/modals/launch-process-modal.tsx
@@ -33,13 +33,16 @@ import SelectPlayerModal from "@/components/modals/select-player-modal";
 import { useLauncherConfig } from "@/contexts/config";
 import { useGlobalData } from "@/contexts/global-data";
 import { useSharedModals } from "@/contexts/shared-modal";
+import { parseTaskGroup } from "@/contexts/task";
 import { useToast } from "@/contexts/toast";
 import { LaunchServiceError } from "@/enums/service-error";
 import { Player } from "@/models/account";
 import { InstanceSummary } from "@/models/instance/misc";
 import { ResponseError } from "@/models/response";
+import { GTaskEventStatusEnums } from "@/models/task";
 import { AccountService } from "@/services/account";
 import { LaunchService } from "@/services/launch";
+import { TaskService } from "@/services/task";
 
 // This modal will use shared-modal-context
 interface LaunchProcessModalProps extends Omit<ModalProps, "children"> {
@@ -73,6 +76,8 @@ const LaunchProcessModal: React.FC<LaunchProcessModalProps> = ({
   const [activeStep, setActiveStep] = useState<number>(-1);
 
   const previousStep = useRef<number>(-1);
+  const awaitingPatchRef = useRef(false);
+  const [revalidateNonce, setRevalidateNonce] = useState(0);
   const candidatePlayers = getPlayerList();
   const candidateInstances = getInstanceList();
   const shouldPickInstance = instanceId?.toLowerCase() === "tbd";
@@ -182,15 +187,17 @@ const LaunchProcessModal: React.FC<LaunchProcessModalProps> = ({
         isOK: (data: any) => true,
         onResCallback: (data: any) => {}, // TODO
         onErrCallback: (error: ResponseError) => {
+          if (error.raw_error === LaunchServiceError.GameFilesIncomplete) {
+            awaitingPatchRef.current = true;
+            setErrorPaused(false);
+            setErrorDesc("");
+            return;
+          }
           toast({
             title: error.message,
             description: error.details,
             status: "error",
           });
-          if (error.raw_error === LaunchServiceError.GameFilesIncomplete) {
-            handleCloseModalWithCancel();
-            router.push("/downloads");
-          }
         },
       },
       {
@@ -243,7 +250,6 @@ const LaunchProcessModal: React.FC<LaunchProcessModalProps> = ({
       closeSharedModal,
       effectiveInstance,
       effectiveSelectedPlayer,
-      handleCloseModalWithCancel,
       openGenericConfirmDialog,
       openSharedModal,
       quickPlaySingleplayer,
@@ -334,9 +340,35 @@ const LaunchProcessModal: React.FC<LaunchProcessModalProps> = ({
     requestedPlayer,
     selectedPlayer,
     update,
+    revalidateNonce,
     t,
     toast,
   ]);
+
+  useEffect(() => {
+    const unlisten = TaskService.onTaskGroupUpdate((payload) => {
+      if (!awaitingPatchRef.current) return;
+      const { name, params } = parseTaskGroup(payload.taskGroup);
+      if (name !== "patch-files") return;
+      if (payload.event === GTaskEventStatusEnums.Completed) {
+        awaitingPatchRef.current = false;
+        previousStep.current = 0;
+        setRevalidateNonce((n) => n + 1);
+      } else if (
+        payload.event === GTaskEventStatusEnums.Failed ||
+        payload.event === GTaskEventStatusEnums.Stopped
+      ) {
+        awaitingPatchRef.current = false;
+        setErrorPaused(true);
+        setErrorDesc(
+          t("Services.task.onTaskGroupUpdate.status.Failed", {
+            param: t("DownloadTasksPage.task.patch-files", params),
+          })
+        );
+      }
+    });
+    return unlisten;
+  }, [t]);
 
   return (
     <Modal


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - fix #1367

### Description

> -  启动校验发现文件缺失时，不再取消启动进程、不再跳转到下载页，启动弹窗保持等待
> -  补全任务组完成后自动重新校验并继续启动流程
> -  补全失败或停止时恢复错误提示；用户可随时取消启动，下载任务不受影响

## Summary by Sourcery

Handle game file patching asynchronously during launch so the modal waits for patch completion and then resumes or restores errors accordingly.

Bug Fixes:
- Prevent launch process from being cancelled and redirected to downloads when missing game files are detected.

Enhancements:
- Subscribe to patch task group updates to automatically re-validate game files and continue the launch after successful patching.
- Restore error messaging in the launch modal when the patch task group fails or is stopped.