### PR TITLE
feat(frontend): auto select first mod loader version

### DIFF
--- a/src/components/loader-selector.tsx
+++ b/src/components/loader-selector.tsx
@@ -167,6 +167,10 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
                 }))
                 .map(buildOptionItems)
             );
+            if (res.data.length > 0) {
+              onSelectModLoader(res.data[0]);
+              setSelectedId(res.data[0].version);
+            }
           } else {
             setVersionList([]);
             toast({
@@ -178,7 +182,7 @@ export const LoaderSelector: React.FC<LoaderSelectorProps> = ({
         })
         .finally(() => setIsLoading(false));
     },
-    [selectedGameVersion.id, buildOptionItems, t, toast]
+    [selectedGameVersion.id, buildOptionItems, onSelectModLoader, t, toast]
   );
 
   const handleFetchOptiFineVersionList = useCallback(() => {


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - fix #1765

### Description

> - 加载器版本列表加载完成后自动选中第一项

## Summary by Sourcery

Automatically select an initial mod loader version once the version list has loaded for a chosen game version.

New Features:
- Auto-select the first available mod loader version after successfully loading the loader version list.

Enhancements:
- Update loader selector hook dependencies to include the mod loader selection callback to keep effects in sync.