### PR TITLE
feat(instance): support listing world zips with extract

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -16,6 +16,7 @@ dependencies = [
  "config",
  "csv",
  "dotenvy",
+ "encoding_rs",
  "flume",
  "font-loader",
  "futures",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ chrono = { version = "0.4.40", features = ["serde"] }
 config = "0.15.18"
 csv = "1.3"
 dotenvy = "0.15.7"
+encoding_rs = "0.8.35"
 flume = { version = "0.11.1", features = ["async", "select"] }
 font-loader = "0.11.0"
 futures = "0.3.31"
@@ -173,6 +174,7 @@ chacha20poly1305.workspace = true
 chrono.workspace = true
 config.workspace = true
 csv.workspace = true
+encoding_rs.workspace = true
 flume.workspace = true
 font-loader.workspace = true
 futures.workspace = true

--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -49,7 +49,10 @@ use crate::instance::helpers::server::{
   GameServerInfo, get_servers_nbt_path_by_instance_id, load_servers_info_from_nbt,
   query_servers_online, save_servers_to_nbt,
 };
-use crate::instance::helpers::world::{load_level_data_from_nbt, load_world_info_from_dir};
+use crate::instance::helpers::world::{
+  load_level_data_from_nbt, load_world_data_from_zip, load_world_info_from_dir,
+  load_world_info_from_zip,
+};
 use crate::instance::models::misc::{
   Instance, InstanceError, InstanceSubdirType, InstanceSummary, LocalModInfo, ModLoader,
   ModLoaderStatus, ModLoaderType, ModpackFileList, OptiFine, ResourcePackInfo, SchematicInfo,
@@ -509,11 +512,23 @@ pub async fn retrieve_world_list(
       Some(path) => path,
       None => return Ok(Vec::new()),
     };
-  if let Ok(world_paths) = get_subdirectories(worlds_dir) {
+  let zip_pattern = RegexBuilder::new(r"\.zip$")
+    .case_insensitive(true)
+    .build()
+    .unwrap();
+  let zip_paths = get_files_with_regex(&worlds_dir, &zip_pattern).unwrap_or(vec![]);
+
+  if let Ok(world_paths) = get_subdirectories(&worlds_dir) {
     for path in world_paths {
       if let Ok(info) = load_world_info_from_dir(&path, has_difficulty_support).await {
         world_list.push(info);
       }
+    }
+  }
+
+  for path in zip_paths {
+    if let Some(info) = load_world_info_from_zip(&path, has_difficulty_support) {
+      world_list.push(info);
     }
   }
 
@@ -998,8 +1013,12 @@ pub async fn retrieve_world_details(
       Some(path) => path,
       None => return Err(InstanceError::WorldNotExistError.into()),
     };
-  let level_path = worlds_dir.join(world_name).join("level.dat");
+  let level_path = worlds_dir.join(&world_name).join("level.dat");
   if tokio::fs::metadata(&level_path).await.is_err() {
+    let zip_path = worlds_dir.join(format!("{world_name}.zip"));
+    if let Ok(level_data) = load_world_data_from_zip(&zip_path) {
+      return Ok(level_data);
+    }
     return Err(InstanceError::LevelNotExistError.into());
   }
   if let Ok(level_data) = load_level_data_from_nbt(&level_path).await {

--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -390,7 +390,7 @@ pub async fn copy_resources_to_instances(
             .and_then(|ext| if ext == "zip" { Some(()) } else { None })
             .and_then(|_| Path::new(file_name).file_stem())
             .unwrap_or(file_name);
-          let dest_path = generate_unique_filename(tgt_path, base_name);
+          let dest_path = generate_unique_filename(tgt_path, base_name, false);
 
           let file = fs::File::open(src_path).map_err(|_| InstanceError::ZipFileProcessFailed)?;
           let mut archive =
@@ -429,21 +429,22 @@ pub async fn copy_resources_to_instances(
             let tmp_path = generate_unique_filename(
               tgt_path,
               OsStr::new(&format!(".sjmcl_extract_{decoded_name}")),
+              false,
             );
             fs::rename(inner_dir, &tmp_path).map_err(|_| InstanceError::ZipFileProcessFailed)?;
             fs::remove_dir_all(&dest_path).map_err(|_| InstanceError::ZipFileProcessFailed)?;
-            let final_path = generate_unique_filename(tgt_path, OsStr::new(&decoded_name));
+            let final_path = generate_unique_filename(tgt_path, OsStr::new(&decoded_name), false);
             fs::rename(&tmp_path, &final_path).map_err(|_| InstanceError::ZipFileProcessFailed)?;
           }
         } else {
-          let dest_path = generate_unique_filename(tgt_path, file_name);
+          let dest_path = generate_unique_filename(tgt_path, file_name, true);
           fs::copy(src_path, &dest_path).map_err(|_| InstanceError::FileCopyFailed)?;
         }
       } else if src_path.is_dir() {
         let dir_name = src_path
           .file_name()
           .ok_or(InstanceError::InvalidSourcePath)?;
-        let dest_path = generate_unique_filename(tgt_path, dir_name);
+        let dest_path = generate_unique_filename(tgt_path, dir_name, false);
         copy_whole_dir(src_path, &dest_path).map_err(|_| InstanceError::FileCopyFailed)?;
       } else {
         return Err(InstanceError::InvalidSourcePath.into());
@@ -503,7 +504,7 @@ pub fn move_resource_to_instance(
     fs::create_dir_all(&tgt_path).map_err(|_| InstanceError::FolderCreationFailed)?;
   }
 
-  let dest_path = generate_unique_filename(&tgt_path, file_name);
+  let dest_path = generate_unique_filename(&tgt_path, file_name, true);
   fs::rename(&src_file_path, &dest_path).map_err(|_| InstanceError::FileMoveFailed)?;
   Ok(())
 }

--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -5,6 +5,7 @@ use sjmcl_types::error::SJMCLResult;
 use sjmcl_types::partial::{PartialError, PartialUpdate};
 use sjmcl_types::storage::{Storage, load_json_async, save_json_async};
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -408,10 +409,31 @@ pub async fn copy_resources_to_instances(
             .collect::<Vec<_>>();
           if inner.len() == 1 && inner[0].is_dir() {
             let inner_dir = &inner[0];
-            let final_path =
-              generate_unique_filename(tgt_path, inner_dir.file_name().unwrap_or(file_name));
-            fs::rename(inner_dir, &final_path).map_err(|_| InstanceError::ZipFileProcessFailed)?;
+            let mut decoded_name = inner_dir
+              .file_name()
+              .unwrap_or(file_name)
+              .to_string_lossy()
+              .into_owned();
+            for i in 0..archive.len() {
+              let Ok(entry) = archive.by_index(i) else {
+                continue;
+              };
+              let Some(first) = entry.name_raw().split(|&b| b == b'/').next() else {
+                continue;
+              };
+              if !first.is_empty() {
+                decoded_name = decode_zip_name(first);
+                break;
+              }
+            }
+            let tmp_path = generate_unique_filename(
+              tgt_path,
+              OsStr::new(&format!(".sjmcl_extract_{decoded_name}")),
+            );
+            fs::rename(inner_dir, &tmp_path).map_err(|_| InstanceError::ZipFileProcessFailed)?;
             fs::remove_dir_all(&dest_path).map_err(|_| InstanceError::ZipFileProcessFailed)?;
+            let final_path = generate_unique_filename(tgt_path, OsStr::new(&decoded_name));
+            fs::rename(&tmp_path, &final_path).map_err(|_| InstanceError::ZipFileProcessFailed)?;
           }
         } else {
           let dest_path = generate_unique_filename(tgt_path, file_name);
@@ -1000,6 +1022,13 @@ pub fn toggle_mod_by_extension(file_path: PathBuf, enable: bool) -> SJMCLResult<
   }
 
   Ok(())
+}
+
+fn decode_zip_name(raw: &[u8]) -> String {
+  match std::str::from_utf8(raw) {
+    Ok(s) => s.to_string(),
+    Err(_) => encoding_rs::GBK.decode(raw).0.into_owned(),
+  }
 }
 
 #[tauri::command]

--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -397,6 +397,19 @@ pub async fn copy_resources_to_instances(
           archive
             .extract(&dest_path)
             .map_err(|_| InstanceError::ZipFileProcessFailed)?;
+
+          let inner = fs::read_dir(&dest_path)
+            .map_err(|_| InstanceError::ZipFileProcessFailed)?
+            .flatten()
+            .map(|e| e.path())
+            .collect::<Vec<_>>();
+          if inner.len() == 1 && inner[0].is_dir() {
+            let inner_dir = &inner[0];
+            let final_path =
+              generate_unique_filename(tgt_path, inner_dir.file_name().unwrap_or(file_name));
+            fs::rename(inner_dir, &final_path).map_err(|_| InstanceError::ZipFileProcessFailed)?;
+            fs::remove_dir_all(&dest_path).map_err(|_| InstanceError::ZipFileProcessFailed)?;
+          }
         } else {
           let dest_path = generate_unique_filename(tgt_path, file_name);
           fs::copy(src_path, &dest_path).map_err(|_| InstanceError::FileCopyFailed)?;

--- a/src-tauri/src/instance/helpers/world.rs
+++ b/src-tauri/src/instance/helpers/world.rs
@@ -1,10 +1,15 @@
 use quartz_nbt::io::Flavor;
 use quartz_nbt::serde::deserialize;
 use sjmcl_types::error::{SJMCLError, SJMCLResult};
+use std::fs::File;
+use std::io::Read;
 use std::path::{Path, PathBuf};
+use zip::ZipArchive;
 
+use crate::instance::helpers::mods::common::compress_icon;
 use crate::instance::models::world::base::WorldInfo;
 use crate::instance::models::world::level::{Level, LevelData};
+use crate::utils::image::{ImageWrapper, decode_image};
 
 pub async fn load_world_info_from_dir(
   path: &Path,
@@ -23,8 +28,71 @@ pub async fn load_world_info_from_dir(
     last_played_at: last_played,
     difficulty: has_difficulty_support.then(|| difficulty.to_string()),
     gamemode: gamemode.to_string(),
-    icon_src: icon_path,
+    icon_src: icon_path.to_string_lossy().into_owned(),
     dir_path: path.to_path_buf(),
+    is_zip: false,
+  })
+}
+
+pub fn load_world_info_from_zip(path: &Path, has_difficulty_support: bool) -> Option<WorldInfo> {
+  let name = path.file_stem()?.to_string_lossy().into_owned();
+  let file = File::open(path).ok()?;
+  let mut zip = ZipArchive::new(file).ok()?;
+
+  let mut level_bytes = None;
+  let mut icon_bytes = None;
+  for i in 0..zip.len() {
+    let Ok(mut entry) = zip.by_index(i) else {
+      continue;
+    };
+    let Some(entry_name) = entry.enclosed_name() else {
+      continue;
+    };
+    match entry_name.file_name().and_then(|n| n.to_str()) {
+      Some("level.dat") if level_bytes.is_none() => {
+        let mut bytes = Vec::new();
+        if entry.read_to_end(&mut bytes).is_ok() {
+          level_bytes = Some(bytes);
+        }
+      }
+      Some("icon.png") if icon_bytes.is_none() => {
+        let mut bytes = Vec::new();
+        if entry.read_to_end(&mut bytes).is_ok() {
+          icon_bytes = Some(bytes);
+        }
+      }
+      _ => {}
+    }
+    if level_bytes.is_some() && icon_bytes.is_some() {
+      break;
+    }
+  }
+
+  let level_bytes = level_bytes?;
+  let (level, _) = deserialize::<Level>(&level_bytes, Flavor::GzCompressed).ok()?;
+  let (last_played, difficulty, gamemode) = level_data_to_world_info(&level.data).ok()?;
+
+  let icon_src = match icon_bytes {
+    Some(bytes) => decode_image(bytes)
+      .ok()
+      .map(|img| {
+        let wrapper = compress_icon(ImageWrapper::from(img));
+        serde_json::to_string(&wrapper)
+          .map(|s| s.trim_matches('"').to_string())
+          .unwrap_or_default()
+      })
+      .unwrap_or_default(),
+    None => String::new(),
+  };
+
+  Some(WorldInfo {
+    name,
+    last_played_at: last_played,
+    difficulty: has_difficulty_support.then(|| difficulty.to_string()),
+    gamemode: gamemode.to_string(),
+    icon_src,
+    dir_path: path.to_path_buf(),
+    is_zip: true,
   })
 }
 
@@ -32,6 +100,26 @@ pub async fn load_level_data_from_nbt(path: &PathBuf) -> SJMCLResult<LevelData> 
   let nbt_bytes = tokio::fs::read(path).await?;
   let (level, _) = deserialize::<Level>(&nbt_bytes, Flavor::GzCompressed)?;
   Ok(level.data)
+}
+
+pub fn load_world_data_from_zip(path: &Path) -> SJMCLResult<LevelData> {
+  let file = File::open(path)?;
+  let mut zip = ZipArchive::new(file).map_err(SJMCLError::from)?;
+  for i in 0..zip.len() {
+    let Ok(mut entry) = zip.by_index(i) else {
+      continue;
+    };
+    let Some(entry_name) = entry.enclosed_name() else {
+      continue;
+    };
+    if entry_name.file_name().and_then(|n| n.to_str()) == Some("level.dat") {
+      let mut bytes = Vec::new();
+      entry.read_to_end(&mut bytes)?;
+      let (level, _) = deserialize::<Level>(&bytes, Flavor::GzCompressed)?;
+      return Ok(level.data);
+    }
+  }
+  Err(SJMCLError("level.dat not found in world zip".to_string()))
 }
 
 fn level_data_to_world_info(data: &LevelData) -> SJMCLResult<(i64, String, String)> {

--- a/src-tauri/src/instance/models/world/base.rs
+++ b/src-tauri/src/instance/models/world/base.rs
@@ -8,6 +8,7 @@ pub struct WorldInfo {
   pub last_played_at: i64,
   pub difficulty: Option<String>,
   pub gamemode: String,
-  pub icon_src: PathBuf,
+  pub icon_src: String,
   pub dir_path: PathBuf,
+  pub is_zip: bool,
 }

--- a/src-tauri/src/launcher_config/commands.rs
+++ b/src-tauri/src/launcher_config/commands.rs
@@ -199,7 +199,7 @@ pub fn add_custom_background(app: AppHandle, source_src: String) -> SJMCLResult<
   }
 
   let file_name = source_path.file_name().unwrap();
-  let dest_path = generate_unique_filename(&custom_bg_dir, file_name);
+  let dest_path = generate_unique_filename(&custom_bg_dir, file_name, true);
   fs::copy(source_path, &dest_path)?;
 
   Ok(dest_path.file_name().unwrap().to_string_lossy().to_string())

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -48,10 +48,18 @@ pub fn copy_whole_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
 /// # Examples
 ///
 /// ```rust
-/// let dest_path = generate_unique_filename(&tgt_path, base_name);
+/// let dest_path = generate_unique_filename(&tgt_path, base_name, true);
 /// ```
-pub fn generate_unique_filename(base_path: &Path, filename: &OsStr) -> PathBuf {
-  let (name, extension) = split_filename(filename);
+pub fn generate_unique_filename(
+  base_path: &Path,
+  filename: &OsStr,
+  keep_extension: bool,
+) -> PathBuf {
+  let (name, extension) = if keep_extension {
+    split_filename(filename)
+  } else {
+    (filename.to_string_lossy().into_owned(), String::new())
+  };
   let mut dest_path = base_path.join(filename);
   let mut counter = 1;
 

--- a/src/contexts/instance.tsx
+++ b/src/contexts/instance.tsx
@@ -8,6 +8,7 @@ import React, {
   useEffect,
   useState,
 } from "react";
+import { useTranslation } from "react-i18next";
 import { useGlobalData, useGlobalDataDispatch } from "@/contexts/global-data";
 import { useToast } from "@/contexts/toast";
 import { InstanceSubdirType } from "@/enums/instance";
@@ -89,6 +90,7 @@ export const InstanceContextProvider: React.FC<{
 }> = ({ children }) => {
   const router = useRouter();
   const toast = useToast();
+  const { t } = useTranslation();
   const { getInstanceList } = useGlobalData();
   const { setInstanceList } = useGlobalDataDispatch();
 
@@ -248,12 +250,22 @@ export const InstanceContextProvider: React.FC<{
               ? [selectedPath]
               : [];
           if (selectedPaths.length === 0) return;
+          const toastId = decompress
+            ? toast({
+                title: t("General.extracting"),
+                status: "loading",
+                duration: null,
+              })
+            : undefined;
           InstanceService.copyResourcesToInstances(
             selectedPaths,
             [instanceId],
             tgtDirType,
             decompress
           ).then((response) => {
+            if (toastId !== undefined) {
+              toast.close(toastId);
+            }
             if (response.status === "success") {
               toast({
                 title: response.message,
@@ -271,7 +283,7 @@ export const InstanceContextProvider: React.FC<{
         });
       }
     },
-    [instanceId, toast]
+    [instanceId, toast, t]
   );
 
   const handleRetrieveWorldList = useCallback(async () => {

--- a/src/contexts/instance.tsx
+++ b/src/contexts/instance.tsx
@@ -1,3 +1,4 @@
+import { useToast as useChakraToast } from "@chakra-ui/react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { openPath } from "@tauri-apps/plugin-opener";
 import { useRouter } from "next/router";
@@ -90,6 +91,7 @@ export const InstanceContextProvider: React.FC<{
 }> = ({ children }) => {
   const router = useRouter();
   const toast = useToast();
+  const { close: closeToast } = useChakraToast();
   const { t } = useTranslation();
   const { getInstanceList } = useGlobalData();
   const { setInstanceList } = useGlobalDataDispatch();
@@ -264,7 +266,7 @@ export const InstanceContextProvider: React.FC<{
             decompress
           ).then((response) => {
             if (toastId !== undefined) {
-              toast.close(toastId);
+              closeToast(toastId);
             }
             if (response.status === "success") {
               toast({
@@ -283,7 +285,7 @@ export const InstanceContextProvider: React.FC<{
         });
       }
     },
-    [instanceId, toast, t]
+    [instanceId, toast, t, closeToast]
   );
 
   const handleRetrieveWorldList = useCallback(async () => {

--- a/src/contexts/toast.tsx
+++ b/src/contexts/toast.tsx
@@ -14,7 +14,6 @@ interface ToastContextProviderProps {
 
 interface ToastContextType {
   (options: UseToastOptions): ToastId;
-  close: (id: ToastId) => void;
 }
 
 const ToastContext = createContext<ToastContextType | null>(null);
@@ -46,9 +45,7 @@ export const ToastContextProvider: React.FC<ToastContextProviderProps> = ({
       });
       return id;
     };
-    return Object.assign(toast, {
-      close: (id: ToastId) => chakraToast.close(id),
-    }) as ToastContextType;
+    return toast;
   }, [chakraToast, toastVariant]);
 
   return (

--- a/src/contexts/toast.tsx
+++ b/src/contexts/toast.tsx
@@ -5,12 +5,7 @@ import {
   useToast as chakraUseToast,
   useColorModeValue,
 } from "@chakra-ui/react";
-import React, {
-  ReactNode,
-  createContext,
-  useCallback,
-  useContext,
-} from "react";
+import React, { ReactNode, createContext, useContext, useMemo } from "react";
 import { BeatLoader } from "react-spinners";
 
 interface ToastContextProviderProps {
@@ -19,6 +14,7 @@ interface ToastContextProviderProps {
 
 interface ToastContextType {
   (options: UseToastOptions): ToastId;
+  close: (id: ToastId) => void;
 }
 
 const ToastContext = createContext<ToastContextType | null>(null);
@@ -29,8 +25,8 @@ export const ToastContextProvider: React.FC<ToastContextProviderProps> = ({
   const chakraToast = chakraUseToast();
   const toastVariant = useColorModeValue("left-accent", "solid");
 
-  const customToast: ToastContextType = useCallback(
-    (options) => {
+  const customToast = useMemo(() => {
+    const toast = (options: UseToastOptions): ToastId => {
       let id = chakraToast({
         position: "bottom-left",
         duration: options.status === "loading" ? null : 3000,
@@ -49,9 +45,11 @@ export const ToastContextProvider: React.FC<ToastContextProviderProps> = ({
         ...options,
       });
       return id;
-    },
-    [chakraToast, toastVariant]
-  );
+    };
+    return Object.assign(toast, {
+      close: (id: ToastId) => chakraToast.close(id),
+    }) as ToastContextType;
+  }, [chakraToast, toastVariant]);
 
   return (
     <ToastContext.Provider value={customToast}>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1154,6 +1154,7 @@
     "exit": "Exit",
     "finish": "Finish",
     "import": "Import",
+    "extracting": "Extracting...",
     "launch": "Launch",
     "more": "More",
     "new": "New",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1654,7 +1654,8 @@
       "gamemodeDesc": ", {{gamemode}}",
       "difficultyDesc": " (Difficulty: {{difficulty}})",
       "viewLevelData": "View Level Data",
-      "launch": "Play this World"
+      "launch": "Play this World",
+      "extract": "Smart Extract"
     },
     "serverList": {
       "title": "Servers",

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -1154,6 +1154,7 @@
     "exit": "退出",
     "finish": "完成",
     "import": "导入",
+    "extracting": "解压中...",
     "launch": "启动",
     "more": "更多",
     "new": "新",

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -1654,7 +1654,8 @@
       "gamemodeDesc": "，{{gamemode}}",
       "difficultyDesc": "（难度：{{difficulty}}）",
       "viewLevelData": "世界基础数据",
-      "launch": "游玩此世界"
+      "launch": "游玩此世界",
+      "extract": "智能解压"
     },
     "serverList": {
       "title": "服务器",

--- a/src/models/instance/world.ts
+++ b/src/models/instance/world.ts
@@ -5,6 +5,7 @@ export interface WorldInfo {
   gamemode: string;
   iconSrc: string;
   dirPath: string;
+  isZip: boolean;
 }
 
 // level and player data

--- a/src/pages/instances/details/[id]/worlds.tsx
+++ b/src/pages/instances/details/[id]/worlds.tsx
@@ -11,7 +11,7 @@ import { convertFileSrc } from "@tauri-apps/api/core";
 import { openPath } from "@tauri-apps/plugin-opener";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { LuCheck, LuEarth, LuX } from "react-icons/lu";
+import { LuArchiveRestore, LuCheck, LuEarth, LuX } from "react-icons/lu";
 import { BeatLoader } from "react-spinners";
 import { CommonIconButton } from "@/components/common/common-icon-button";
 import CountTag from "@/components/common/count-tag";
@@ -247,20 +247,38 @@ const InstanceWorldsPage = () => {
         onWorldLevelDataModallOpen();
       },
     },
-    ...(summary?.supportQuickPlay
+    ...(save.isZip
       ? [
           {
-            label: t("InstanceWorldsPage.worldList.launch"),
-            icon: "launch",
+            label: t("InstanceWorldsPage.worldList.extract"),
+            icon: LuArchiveRestore,
             onClick: () => {
-              openSharedModal("launch", {
-                instanceId: instanceId,
-                quickPlaySingleplayer: save.name,
+              handleImportResources({
+                filterName: t("InstanceDetailsLayout.instanceTabList.worlds"),
+                filterExt: ["zip"],
+                tgtDirType: InstanceSubdirType.Saves,
+                paths: [save.dirPath],
+                multiple: false,
+                decompress: true,
+                onSuccessCallback: () => getWorldListWrapper(true),
               });
             },
           },
         ]
-      : []),
+      : summary?.supportQuickPlay
+        ? [
+            {
+              label: t("InstanceWorldsPage.worldList.launch"),
+              icon: "launch",
+              onClick: () => {
+                openSharedModal("launch", {
+                  instanceId: instanceId,
+                  quickPlaySingleplayer: save.name,
+                });
+              },
+            },
+          ]
+        : []),
   ];
 
   const serverItemMenuOperations = (server: GameServerInfo) => [
@@ -361,10 +379,23 @@ const InstanceWorldsPage = () => {
                 <OptionItem
                   key={world.name}
                   title={world.name}
+                  titleExtra={
+                    world.isZip ? (
+                      <Tag colorScheme="blue" className="tag-xs">
+                        ZIP
+                      </Tag>
+                    ) : undefined
+                  }
                   description={description}
                   prefixElement={
                     <Image
-                      src={convertFileSrc(world.iconSrc)}
+                      src={
+                        world.isZip
+                          ? world.iconSrc
+                            ? base64ImgSrc(world.iconSrc)
+                            : undefined
+                          : convertFileSrc(world.iconSrc)
+                      }
                       fallbackSrc="/images/icons/UnknownWorld.webp"
                       alt={world.name}
                       boxSize="28px"


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - fix #1170

### Description

> rt，顺便修复了两个问题：
> - 没有正确处理嵌套文件夹（解压后是一个包含地图文件夹的文件夹）
> - 中文乱码

### Additional Context

> - Add any other relevant information or screenshots here.
<img width="1278" height="1003" alt="image" src="https://github.com/user-attachments/assets/c02a8d1b-d68d-43a9-940d-ab6642ae1443" /><br>
解压后不会自动删除，这是等待之后为存档添加删除按钮

## Summary by Sourcery

Add support for listing and extracting zipped Minecraft worlds within instances, including proper handling of nested folders and encoded names.

New Features:
- Allow retrieving world list and world details from .zip saves alongside directory-based worlds.
- Expose an extract action in the instance worlds UI for zipped saves, showing a ZIP badge and rendering in-memory icons for zip-based worlds.

Bug Fixes:
- Fix handling of archives that contain an extra nested world directory when importing resources.
- Resolve garbled Chinese filenames in imported zip archives by decoding names with appropriate character encoding.

Enhancements:
- Extend toast context to support programmatic closing and show a loading toast during long extract operations.
- Generalize unique filename generation to optionally ignore file extensions, enabling cleaner extracted world directory names.

Build:
- Add encoding_rs as a dependency for handling non-UTF-8 zip entry names.