### PR TITLE
fix(instance): prevent duplicate legacy Forge game arguments

### DIFF
--- a/src-tauri/src/instance/helpers/client_json.rs
+++ b/src-tauri/src/instance/helpers/client_json.rs
@@ -399,6 +399,17 @@ pub fn reset_fields_from_patches(client_info: &mut McClientInfo) {
   let mut patch_refs = patches.iter().skip(1).collect::<Vec<_>>();
   patch_refs.sort_by_key(|patch| patch.priority.unwrap_or(i64::MIN));
 
+  // Legacy Forge provides a complete argument template rather than incremental arguments.
+  if let Some(minecraft_arguments) = patch_refs
+    .iter()
+    .rev()
+    .find(|patch| matches!(patch.id.as_str(), "forge" | "legacyforge"))
+    .and_then(|patch| patch.minecraft_arguments.as_ref())
+    .filter(|arguments| !arguments.is_empty())
+  {
+    client_info.minecraft_arguments = Some(minecraft_arguments.clone());
+  }
+
   for patch in patch_refs {
     if let Some(main_class) = &patch.main_class {
       client_info.main_class = Some(main_class.clone());
@@ -432,6 +443,11 @@ pub fn reset_fields_from_patches(client_info: &mut McClientInfo) {
       if minecraft_arguments.is_empty() {
         continue;
       }
+
+      if matches!(patch.id.as_str(), "forge" | "legacyforge") {
+        continue;
+      }
+
       match &mut client_info.minecraft_arguments {
         Some(base_arguments) if !base_arguments.is_empty() => {
           if !base_arguments.ends_with(' ') {

--- a/src-tauri/src/instance/helpers/client_json.rs
+++ b/src-tauri/src/instance/helpers/client_json.rs
@@ -399,13 +399,13 @@ pub fn reset_fields_from_patches(client_info: &mut McClientInfo) {
   let mut patch_refs = patches.iter().skip(1).collect::<Vec<_>>();
   patch_refs.sort_by_key(|patch| patch.priority.unwrap_or(i64::MIN));
 
-  // Legacy Forge provides a complete argument template rather than incremental arguments.
+  // Non-OptiFine `minecraftArguments` replace the inherited template; OptiFine arguments are incremental.
   if let Some(minecraft_arguments) = patch_refs
     .iter()
     .rev()
-    .find(|patch| matches!(patch.id.as_str(), "forge" | "legacyforge"))
-    .and_then(|patch| patch.minecraft_arguments.as_ref())
-    .filter(|arguments| !arguments.is_empty())
+    .filter(|patch| patch.id != "optifine")
+    .filter_map(|patch| patch.minecraft_arguments.as_ref())
+    .find(|arguments| !arguments.is_empty())
   {
     client_info.minecraft_arguments = Some(minecraft_arguments.clone());
   }
@@ -444,7 +444,7 @@ pub fn reset_fields_from_patches(client_info: &mut McClientInfo) {
         continue;
       }
 
-      if matches!(patch.id.as_str(), "forge" | "legacyforge") {
+      if patch.id != "optifine" {
         continue;
       }
 

--- a/src-tauri/src/instance/helpers/client_json.rs
+++ b/src-tauri/src/instance/helpers/client_json.rs
@@ -399,7 +399,7 @@ pub fn reset_fields_from_patches(client_info: &mut McClientInfo) {
   let mut patch_refs = patches.iter().skip(1).collect::<Vec<_>>();
   patch_refs.sort_by_key(|patch| patch.priority.unwrap_or(i64::MIN));
 
-  // Non-OptiFine `minecraftArguments` replace the inherited template; OptiFine arguments are incremental.
+  // Non-OptiFine `minecraftArguments` replace the inherited template; OptiFine arguments are incremental (ref: #1897).
   if let Some(minecraft_arguments) = patch_refs
     .iter()
     .rev()


### PR DESCRIPTION
### Checklist

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

fix #1882

### Description

Legacy Forge provides a complete `minecraftArguments` template. SJMCL previously appended it to the vanilla template while rebuilding patches, causing arguments such as `--gameDir` to appear twice.

Use the legacy Forge template as the base and only append incremental arguments from other patches, preserving loader changes, removal, and OptiFine combinations.

### Additional Context

`cargo check`, formatting, and diff checks passed. The affected Minecraft versions were not launched locally.

## Summary by Sourcery

Bug Fixes:
- Prevent duplicate Minecraft game arguments (such as --gameDir) when combining legacy Forge with other patches in client configuration.