### PR TITLE
fix(instance): protect modpack download integrity

### DIFF
--- a/src-tauri/src/instance/helpers/modpack/curseforge.rs
+++ b/src-tauri/src/instance/helpers/modpack/curseforge.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use sjmcl_types::error::{SJMCLError, SJMCLResult};
 use std::fs::File;
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use tauri::{AppHandle, Manager};
 use tauri_plugin_http::reqwest;
@@ -220,7 +220,7 @@ impl ModpackManifest for CurseForgeManifest {
     Ok(task_params)
   }
 
-  fn get_overrides_path(&self) -> String {
-    self.overrides.clone()
+  fn get_overrides_paths(&self) -> Vec<PathBuf> {
+    vec![PathBuf::from(&self.overrides)]
   }
 }

--- a/src-tauri/src/instance/helpers/modpack/import.rs
+++ b/src-tauri/src/instance/helpers/modpack/import.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use sjmcl_types::error::SJMCLResult;
 use std::fs;
 use std::fs::File;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tauri::AppHandle;
 use zip::ZipArchive;
 
@@ -28,7 +28,7 @@ pub trait ModpackManifest {
     app: &AppHandle,
     instance_path: &Path,
   ) -> SJMCLResult<Vec<PTaskParam>>;
-  fn get_overrides_path(&self) -> String;
+  fn get_overrides_paths(&self) -> Vec<PathBuf>;
 }
 
 type ManifestBox = Box<dyn ModpackManifest + Send + Sync>;
@@ -110,39 +110,92 @@ pub async fn get_download_params(
 }
 
 pub fn extract_overrides(file: &File, instance_path: &Path) -> SJMCLResult<()> {
-  let get_overrides_path = |file| {
+  let get_overrides_paths = |file| {
     for parser in get_parsers() {
       if let Ok(manifest) = parser(file) {
-        return Some(manifest.get_overrides_path());
+        return Some(manifest.get_overrides_paths());
       }
     }
     None
   };
-  let overrides_path = get_overrides_path(file).ok_or(InstanceError::ModpackManifestParseError)?;
+  let overrides_paths =
+    get_overrides_paths(file).ok_or(InstanceError::ModpackManifestParseError)?;
   let mut archive = ZipArchive::new(file)?;
-  for i in 0..archive.len() {
-    let mut file = archive.by_index(i)?;
-    let path = file.mangled_name();
-    let outpath = if path.starts_with(format!("{}/", overrides_path)) {
-      // Remove "{overrides}/" prefix and join with instance path
-      let relative_path = path.strip_prefix(format!("{}/", overrides_path)).unwrap();
-      instance_path.join(relative_path)
-    } else {
-      continue;
-    };
-
-    if file.is_file() {
-      // Create parent directories if they don't exist
-      if let Some(p) = outpath.parent()
-        && !p.exists()
-      {
-        fs::create_dir_all(p)?;
+  for overrides_path in overrides_paths {
+    for i in 0..archive.len() {
+      let mut file = archive.by_index(i)?;
+      let path = file.mangled_name();
+      let Ok(relative_path) = path.strip_prefix(&overrides_path) else {
+        continue;
+      };
+      if relative_path.as_os_str().is_empty() {
+        continue;
       }
+      let outpath = instance_path.join(relative_path);
 
-      // Extract file
-      let mut outfile = File::create(&outpath)?;
-      std::io::copy(&mut file, &mut outfile)?;
+      if file.is_file() {
+        if let Some(p) = outpath.parent()
+          && !p.exists()
+        {
+          fs::create_dir_all(p)?;
+        }
+
+        let mut outfile = File::create(&outpath)?;
+        std::io::copy(&mut file, &mut outfile)?;
+      }
     }
   }
   Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use std::io::Write;
+
+  use uuid::Uuid;
+  use zip::ZipWriter;
+  use zip::write::SimpleFileOptions;
+
+  use super::*;
+
+  #[test]
+  fn applies_modrinth_client_overrides_after_common_overrides() {
+    let test_root = std::env::temp_dir().join(format!("sjmcl-modpack-{}", Uuid::new_v4()));
+    let archive_path = test_root.join("test.mrpack");
+    let instance_path = test_root.join("instance");
+    fs::create_dir_all(&instance_path).unwrap();
+
+    let archive_file = File::create(&archive_path).unwrap();
+    let mut archive = ZipWriter::new(archive_file);
+    archive
+      .start_file("modrinth.index.json", SimpleFileOptions::default())
+      .unwrap();
+    archive
+      .write_all(
+        br#"{"formatVersion":1,"game":"minecraft","versionId":"test","name":"test","files":[],"dependencies":{"minecraft":"1.20.1"}}"#,
+      )
+      .unwrap();
+    archive
+      .start_file("overrides/config/test.txt", SimpleFileOptions::default())
+      .unwrap();
+    archive.write_all(b"common").unwrap();
+    archive
+      .start_file(
+        "client-overrides/config/test.txt",
+        SimpleFileOptions::default(),
+      )
+      .unwrap();
+    archive.write_all(b"client").unwrap();
+    archive.finish().unwrap();
+
+    let archive_file = File::open(&archive_path).unwrap();
+    extract_overrides(&archive_file, &instance_path).unwrap();
+    drop(archive_file);
+
+    assert_eq!(
+      fs::read(instance_path.join("config/test.txt")).unwrap(),
+      b"client"
+    );
+    fs::remove_dir_all(test_root).unwrap();
+  }
 }

--- a/src-tauri/src/instance/helpers/modpack/modrinth.rs
+++ b/src-tauri/src/instance/helpers/modpack/modrinth.rs
@@ -25,6 +25,7 @@ use crate::resource::helpers::{
 use crate::resource::models::OtherResourceSource;
 use crate::tasks::PTaskParam;
 use crate::tasks::download::DownloadParam;
+use crate::utils::fs::normalize_relative_path;
 
 structstruck::strike! {
 #[strikethrough[serialize_skip_none]]
@@ -58,6 +59,12 @@ pub struct ModrinthManifest {
   pub summary: Option<String>,
   pub files: Vec<ModrinthFile>,
   pub dependencies: HashMap<String, String>,
+}
+
+fn resolve_download_path(instance_path: &Path, path: &str) -> SJMCLResult<PathBuf> {
+  let relative_path =
+    normalize_relative_path(Path::new(path)).map_err(|_| InstanceError::InvalidSourcePath)?;
+  Ok(instance_path.join(relative_path))
 }
 
 #[async_trait]
@@ -138,15 +145,18 @@ impl ModpackManifest for ModrinthManifest {
         Ok(PTaskParam::Download(DownloadParam {
           src: url::Url::parse(download_url).map_err(|_| InstanceError::InvalidSourcePath)?,
           sha1: Some(file.hashes.sha1.clone()),
-          dest: instance_path.join(&file.path),
+          dest: resolve_download_path(instance_path, &file.path)?,
           filename: None,
         }))
       })
       .collect::<SJMCLResult<Vec<_>>>()
   }
 
-  fn get_overrides_path(&self) -> String {
-    "overrides/".to_string()
+  fn get_overrides_paths(&self) -> Vec<PathBuf> {
+    vec![
+      PathBuf::from("overrides"),
+      PathBuf::from("client-overrides"),
+    ]
   }
 }
 
@@ -329,4 +339,20 @@ async fn collect_modrinth_files(
   }
 
   Ok((modrinth_files, override_files))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn rejects_modrinth_files_outside_instance_directory() {
+    let instance_path = Path::new("instance");
+    assert!(resolve_download_path(instance_path, "../outside.jar").is_err());
+    assert!(resolve_download_path(instance_path, "/outside.jar").is_err());
+    assert_eq!(
+      resolve_download_path(instance_path, "mods/example.jar").unwrap(),
+      PathBuf::from("instance/mods/example.jar")
+    );
+  }
 }

--- a/src-tauri/src/instance/helpers/modpack/multimc.rs
+++ b/src-tauri/src/instance/helpers/modpack/multimc.rs
@@ -161,8 +161,8 @@ impl ModpackManifest for MultiMcManifest {
     Ok(Vec::new())
   }
 
-  fn get_overrides_path(&self) -> String {
-    format!("{}.minecraft/", self.base_path)
+  fn get_overrides_paths(&self) -> Vec<PathBuf> {
+    vec![PathBuf::from(format!("{}.minecraft", self.base_path))]
   }
 }
 

--- a/src-tauri/src/tasks/download.rs
+++ b/src-tauri/src/tasks/download.rs
@@ -171,10 +171,9 @@ impl DownloadTask {
       -1
     };
     Ok((
-      resp.bytes_stream().map(|res| match res {
-        Ok(bytes) => Ok(bytes),
-        Err(_) => Ok(bytes::Bytes::new()),
-      }),
+      resp
+        .bytes_stream()
+        .map(|res| res.map_err(std::io::Error::other)),
       total_progress,
     ))
   }


### PR DESCRIPTION
> [!NOTE]
> 本 comment 由 Codex with GPT-5.6 Sol 自动评论，仅供参考

### Checklist

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

No directly related issue was found after searching the existing issue and pull request history.

### Description

This PR fixes three integrity issues in modpack installation and downloads:

- validate Modrinth manifest download paths before joining them with the instance directory, rejecting absolute paths and parent-directory traversal;
- apply `client-overrides` after common Modrinth overrides so client-specific files are installed with the required precedence;
- propagate response-body stream errors instead of treating interrupted downloads as successful empty chunks.

Regression tests cover malicious Modrinth paths and override precedence using a minimal `.mrpack` fixture.

### Additional Context

Validated with:

- `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets`
- `git diff --check origin/main...HEAD`

The repository currently has 21 pre-existing failing doctests caused by incomplete documentation examples. None are introduced or modified by this PR.

## Summary by Sourcery

Harden modpack installation and download handling to preserve instance integrity and correct override precedence.

Bug Fixes:
- Validate Modrinth file download paths against the instance directory and reject absolute or parent-traversal paths.
- Ensure Modrinth client-specific overrides are applied after common overrides so client files take precedence.
- Propagate HTTP response stream errors during downloads instead of treating interrupted transfers as successful empty chunks.

Enhancements:
- Support multiple override roots in modpack manifests to unify handling across Modrinth, CurseForge, and MultiMC packs.

Tests:
- Add unit tests covering Modrinth path validation and client-overrides precedence, using minimal archive fixtures.