### PR TITLE
fix: correct potato entry category on discover > shader page

### DIFF
--- a/src/enums/resource.ts
+++ b/src/enums/resource.ts
@@ -172,9 +172,8 @@ export const shaderPackTagList = {
       "pbr",
       "reflections",
       "shadows",
-      "potato",
     ],
-    performance: ["low", "medium", "high", "screenshot"],
+    performance: ["potato", "low", "medium", "high", "screenshot"],
   },
 };
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

resolves https://github.com/UNIkeEN/SJMCL/issues/1901

### Description

N/A

### Additional Context

N/A

## Summary by Sourcery

Bug Fixes:
- Fix misclassified "potato" entry on the discover shader page by moving it into the performance category for shader packs.