### PR TITLE
fix(account): restore custom offline skins in NeoForge

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -72,7 +72,7 @@ serde_json = "1.0"
 serde_with = "3.12.0"
 sjmcl-macros = { path = "./crates/sjmcl-macros" }
 sjmcl-types = { path = "./crates/sjmcl-types" }
-sha1 = "0.10.1"
+sha1 = { version = "0.10.1", features = ["oid"] }
 sha2 = "0.10.9"
 shlex = "1.3.0"
 smart-default = "0.7.1"

--- a/src-tauri/src/account/helpers/offline/yggdrasil_server.rs
+++ b/src-tauri/src/account/helpers/offline/yggdrasil_server.rs
@@ -56,7 +56,7 @@ fn get_public_key() -> String {
 }
 
 fn sign_data(data: &str) -> String {
-  let signing_key = SigningKey::<Sha1>::new_unprefixed(key_pair().0.clone());
+  let signing_key = SigningKey::<Sha1>::new(key_pair().0.clone());
   let signature = signing_key.sign(data.as_bytes());
   general_purpose::STANDARD.encode(signature.to_bytes())
 }
@@ -130,7 +130,7 @@ impl YggdrasilServer {
     let port = find_free_port(Some(18960)).unwrap(); // 饮水思源，爱国荣校
 
     Self {
-      root_url: format!("http://localhost:{}", port),
+      root_url: format!("http://127.0.0.1:{}", port),
       port,
       players: Arc::new(Mutex::new(vec![])),
     }


### PR DESCRIPTION
### Checklist

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

fix #1740

### Description

The local Yggdrasil service published a `localhost` URL while listening only on the IPv4 loopback address. This could make authlib-injector profile requests fail in environments where `localhost` resolves to an unavailable address.

Use `127.0.0.1` consistently for the published endpoint and listener. Also generate standard SHA1withRSA texture signatures by enabling the SHA-1 OID feature and using the prefixed PKCS#1 v1.5 signing format.

### Additional Context

The affected NeoForge offline skin scenario was tested successfully. `cargo check`, formatting, diff checks, and all workflow tests passed.

This PR does not change the local Yggdrasil server startup lifecycle or error handling.

## Summary by Sourcery

Ensure NeoForge offline Yggdrasil server uses a stable loopback endpoint and compatible texture signature format to restore custom offline skins.

Bug Fixes:
- Use 127.0.0.1 instead of localhost for the local Yggdrasil server URL to avoid resolution issues in certain environments.
- Switch to standard SHA1withRSA signing with OID support and prefixed PKCS#1 v1.5 format for texture signatures to match authlib-injector expectations.

Build:
- Enable the sha1 crate OID feature in Cargo.toml to support standard SHA1withRSA signatures.