### PR TITLE
feat(instance): generate modpack lock files on import

### DIFF
--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -36,7 +36,7 @@ use crate::instance::helpers::modpack::export::{
   validate_export_options,
 };
 use crate::instance::helpers::modpack::import::{
-  ModpackMetaInfo, extract_overrides, get_download_params,
+  ModpackMetaInfo, build_install_plan, extract_overrides,
 };
 use crate::instance::helpers::mods::common::{
   check_potential_incompatibility, compress_icon, get_mod_info_from_dir, get_mod_info_from_jar,
@@ -1224,8 +1224,11 @@ pub async fn create_instance(
   if let Some(modpack_path) = modpack_path {
     let path = PathBuf::from(modpack_path);
     let file = fs::File::open(&path).map_err(|_| InstanceError::FileNotFoundError)?;
-    task_params.extend(get_download_params(&app, &file, &version_path).await?);
-    extract_overrides(&file, &version_path)?;
+    let plan = build_install_plan(&app, &file, &version_path).await?;
+    let override_files = extract_overrides(&file, &version_path, &plan)?;
+    let lock = plan.create_lock(&version_path, override_files)?;
+    task_params.extend(plan.download_params.clone());
+    lock.save(&version_path)?;
   }
 
   schedule_progressive_task_group(

--- a/src-tauri/src/instance/constants.rs
+++ b/src-tauri/src/instance/constants.rs
@@ -1,3 +1,4 @@
 pub const INSTANCE_CFG_FILE_NAME: &str = "sjmclcfg.json";
+pub const MODPACK_LOCK_FILE_PATH: &str = ".sjmcl/modpack.lock.json";
 
 pub const COMPRESSED_ICON_SIZE: (u32, u32) = (64, 64);

--- a/src-tauri/src/instance/constants.rs
+++ b/src-tauri/src/instance/constants.rs
@@ -1,4 +1,4 @@
 pub const INSTANCE_CFG_FILE_NAME: &str = "sjmclcfg.json";
-pub const MODPACK_LOCK_FILE_PATH: &str = ".sjmcl/modpack.lock.json";
+pub const MODPACK_LOCK_FILE_PATH: &str = "modpack.lock.json";
 
 pub const COMPRESSED_ICON_SIZE: (u32, u32) = (64, 64);

--- a/src-tauri/src/instance/helpers/modpack/curseforge.rs
+++ b/src-tauri/src/instance/helpers/modpack/curseforge.rs
@@ -9,7 +9,9 @@ use tauri::{AppHandle, Manager};
 use tauri_plugin_http::reqwest;
 use zip::ZipArchive;
 
-use crate::instance::helpers::modpack::import::{ModpackManifest, ModpackMetaInfo};
+use crate::instance::helpers::modpack::import::{
+  ModpackLockInfo, ModpackManifest, ModpackMetaInfo,
+};
 use crate::instance::models::misc::{InstanceError, ModLoader, ModLoaderType};
 use crate::resource::helpers::curseforge::misc::{CURSEFORGE_API_KEY, CurseForgeProject};
 use crate::resource::models::OtherResourceSource;
@@ -222,5 +224,12 @@ impl ModpackManifest for CurseForgeManifest {
 
   fn get_overrides_path(&self) -> String {
     self.overrides.clone()
+  }
+
+  fn get_lock_info(&self) -> ModpackLockInfo {
+    ModpackLockInfo {
+      source: OtherResourceSource::CurseForge,
+      version: self.version.clone(),
+    }
   }
 }

--- a/src-tauri/src/instance/helpers/modpack/export.rs
+++ b/src-tauri/src/instance/helpers/modpack/export.rs
@@ -123,6 +123,7 @@ static BLACKLIST: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     "log4j2.xml",
     "hmclversion.cfg",
     // SJMCL
+    ".sjmcl",
     "install_profile.json",
     "sjmclcfg.json",
     // Curse

--- a/src-tauri/src/instance/helpers/modpack/export.rs
+++ b/src-tauri/src/instance/helpers/modpack/export.rs
@@ -10,6 +10,7 @@ use walkdir::WalkDir;
 use zip::write::{ExtendedFileOptions, FileOptions};
 use zip::{CompressionMethod, ZipWriter};
 
+use crate::instance::constants::MODPACK_LOCK_FILE_PATH;
 use crate::instance::helpers::modpack::{
   modrinth::build_modrinth_export_bundle, multimc::build_multimc_export_bundle,
 };
@@ -123,7 +124,7 @@ static BLACKLIST: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
     "log4j2.xml",
     "hmclversion.cfg",
     // SJMCL
-    ".sjmcl",
+    MODPACK_LOCK_FILE_PATH,
     "install_profile.json",
     "sjmclcfg.json",
     // Curse

--- a/src-tauri/src/instance/helpers/modpack/import.rs
+++ b/src-tauri/src/instance/helpers/modpack/import.rs
@@ -1,12 +1,14 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use sjmcl_types::error::SJMCLResult;
+use std::collections::HashMap;
 use std::fs;
 use std::fs::File;
 use std::path::Path;
 use tauri::AppHandle;
 use zip::ZipArchive;
 
+use crate::instance::constants::MODPACK_LOCK_FILE_PATH;
 use crate::instance::helpers::modpack::curseforge::CurseForgeManifest;
 use crate::instance::helpers::modpack::modrinth::ModrinthManifest;
 use crate::instance::helpers::modpack::multimc::MultiMcManifest;
@@ -14,6 +16,7 @@ use crate::instance::models::misc::{InstanceError, ModLoader, ModLoaderType};
 use crate::resource::commands::fetch_mod_loader_version_list;
 use crate::resource::models::OtherResourceSource;
 use crate::tasks::PTaskParam;
+use crate::utils::fs::calculate_sha1;
 
 #[async_trait]
 pub trait ModpackManifest {
@@ -29,6 +32,7 @@ pub trait ModpackManifest {
     instance_path: &Path,
   ) -> SJMCLResult<Vec<PTaskParam>>;
   fn get_overrides_path(&self) -> String;
+  fn get_lock_info(&self) -> ModpackLockInfo;
 }
 
 type ManifestBox = Box<dyn ModpackManifest + Send + Sync>;
@@ -83,6 +87,92 @@ pub struct ModpackMetaInfo {
   pub mod_loader: Option<ModLoader>,
 }
 
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ModpackManagedFileKind {
+  Download,
+  Override,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ModpackManagedFile {
+  pub path: String,
+  pub sha1: Option<String>,
+  pub kind: ModpackManagedFileKind,
+}
+
+pub struct ModpackLockInfo {
+  pub source: OtherResourceSource,
+  pub version: Option<String>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ModpackLock {
+  pub schema_version: u32,
+  pub source: OtherResourceSource,
+  pub version: Option<String>,
+  pub files: Vec<ModpackManagedFile>,
+}
+
+impl ModpackLock {
+  pub fn save(&self, instance_path: &Path) -> SJMCLResult<()> {
+    let path = instance_path.join(MODPACK_LOCK_FILE_PATH);
+    if let Some(parent) = path.parent() {
+      fs::create_dir_all(parent)?;
+    }
+    fs::write(path, serde_json::to_vec_pretty(self)?)?;
+    Ok(())
+  }
+}
+
+pub struct ModpackInstallPlan {
+  pub download_params: Vec<PTaskParam>,
+  lock_info: ModpackLockInfo,
+  overrides_path: String,
+}
+
+impl ModpackInstallPlan {
+  pub fn download_files(&self, instance_path: &Path) -> SJMCLResult<Vec<ModpackManagedFile>> {
+    self
+      .download_params
+      .iter()
+      .map(|param| match param {
+        PTaskParam::Download(param) => Ok(ModpackManagedFile {
+          path: relative_path_string(instance_path, &param.dest)?,
+          sha1: param.sha1.clone(),
+          kind: ModpackManagedFileKind::Download,
+        }),
+      })
+      .collect()
+  }
+
+  pub fn create_lock(
+    &self,
+    instance_path: &Path,
+    override_files: Vec<ModpackManagedFile>,
+  ) -> SJMCLResult<ModpackLock> {
+    let mut files = HashMap::new();
+    for file in override_files {
+      files.insert(file.path.clone(), file);
+    }
+    // Downloaded manifest files are applied after overrides and therefore own duplicate paths.
+    for file in self.download_files(instance_path)? {
+      files.insert(file.path.clone(), file);
+    }
+    let mut files = files.into_values().collect::<Vec<_>>();
+    files.sort_by(|a, b| a.path.cmp(&b.path));
+
+    Ok(ModpackLock {
+      schema_version: 1,
+      source: self.lock_info.source.clone(),
+      version: self.lock_info.version.clone(),
+      files,
+    })
+  }
+}
+
 impl ModpackMetaInfo {
   pub async fn from_archive(app: &AppHandle, file: &File) -> SJMCLResult<Self> {
     for parser in get_parsers() {
@@ -95,37 +185,50 @@ impl ModpackMetaInfo {
   }
 }
 
-pub async fn get_download_params(
+pub async fn build_install_plan(
   app: &AppHandle,
   file: &File,
   instance_path: &Path,
-) -> SJMCLResult<Vec<PTaskParam>> {
+) -> SJMCLResult<ModpackInstallPlan> {
   for parser in get_parsers() {
     if let Ok(manifest) = parser(file) {
-      return manifest.get_download_params(app, instance_path).await;
+      return Ok(ModpackInstallPlan {
+        download_params: manifest.get_download_params(app, instance_path).await?,
+        lock_info: manifest.get_lock_info(),
+        overrides_path: manifest.get_overrides_path(),
+      });
     }
   }
 
   Err(InstanceError::ModpackManifestParseError.into())
 }
 
-pub fn extract_overrides(file: &File, instance_path: &Path) -> SJMCLResult<()> {
-  let get_overrides_path = |file| {
-    for parser in get_parsers() {
-      if let Ok(manifest) = parser(file) {
-        return Some(manifest.get_overrides_path());
-      }
-    }
-    None
-  };
-  let overrides_path = get_overrides_path(file).ok_or(InstanceError::ModpackManifestParseError)?;
+pub fn extract_overrides(
+  file: &File,
+  instance_path: &Path,
+  plan: &ModpackInstallPlan,
+) -> SJMCLResult<Vec<ModpackManagedFile>> {
+  let overrides_path = plan.overrides_path.trim_end_matches('/');
+  if overrides_path.is_empty() {
+    return Ok(Vec::new());
+  }
+  let overrides_path = Path::new(overrides_path);
   let mut archive = ZipArchive::new(file)?;
+  let mut managed_files = Vec::new();
   for i in 0..archive.len() {
     let mut file = archive.by_index(i)?;
     let path = file.mangled_name();
-    let outpath = if path.starts_with(format!("{}/", overrides_path)) {
+    let outpath = if path.starts_with(overrides_path) {
       // Remove "{overrides}/" prefix and join with instance path
-      let relative_path = path.strip_prefix(format!("{}/", overrides_path)).unwrap();
+      let relative_path = path
+        .strip_prefix(overrides_path)
+        .map_err(|_| InstanceError::InvalidSourcePath)?;
+      let relative_path = relative_path
+        .strip_prefix(Path::new("/"))
+        .unwrap_or(relative_path);
+      if relative_path.as_os_str().is_empty() {
+        continue;
+      }
       instance_path.join(relative_path)
     } else {
       continue;
@@ -142,7 +245,25 @@ pub fn extract_overrides(file: &File, instance_path: &Path) -> SJMCLResult<()> {
       // Extract file
       let mut outfile = File::create(&outpath)?;
       std::io::copy(&mut file, &mut outfile)?;
+      managed_files.push(ModpackManagedFile {
+        path: relative_path_string(instance_path, &outpath)?,
+        sha1: Some(calculate_sha1(&outpath)?),
+        kind: ModpackManagedFileKind::Override,
+      });
     }
   }
-  Ok(())
+  Ok(managed_files)
+}
+
+fn relative_path_string(root: &Path, path: &Path) -> SJMCLResult<String> {
+  let relative = path
+    .strip_prefix(root)
+    .map_err(|_| InstanceError::InvalidSourcePath)?;
+  Ok(
+    relative
+      .components()
+      .map(|component| component.as_os_str().to_string_lossy())
+      .collect::<Vec<_>>()
+      .join("/"),
+  )
 }

--- a/src-tauri/src/instance/helpers/modpack/import.rs
+++ b/src-tauri/src/instance/helpers/modpack/import.rs
@@ -259,11 +259,18 @@ fn relative_path_string(root: &Path, path: &Path) -> SJMCLResult<String> {
   let relative = path
     .strip_prefix(root)
     .map_err(|_| InstanceError::InvalidSourcePath)?;
-  Ok(
-    relative
-      .components()
-      .map(|component| component.as_os_str().to_string_lossy())
-      .collect::<Vec<_>>()
-      .join("/"),
-  )
+  let mut result = String::new();
+
+  for (index, component) in relative.components().enumerate() {
+    if index > 0 {
+      result.push('/');
+    }
+    let component = component
+      .as_os_str()
+      .to_str()
+      .ok_or(InstanceError::InvalidSourcePath)?;
+    result.push_str(component);
+  }
+
+  Ok(result)
 }

--- a/src-tauri/src/instance/helpers/modpack/modrinth.rs
+++ b/src-tauri/src/instance/helpers/modpack/modrinth.rs
@@ -16,7 +16,9 @@ use zip::ZipArchive;
 use crate::instance::helpers::modpack::export::{
   ExportModpackOptions, ModpackExportBundle, normalize_mod_loader_version,
 };
-use crate::instance::helpers::modpack::import::{ModpackManifest, ModpackMetaInfo};
+use crate::instance::helpers::modpack::import::{
+  ModpackLockInfo, ModpackManifest, ModpackMetaInfo,
+};
 use crate::instance::models::misc::{Instance, InstanceError, ModLoader, ModLoaderType};
 use crate::resource::helpers::{
   curseforge::fetch_remote_resource_by_local_curseforge,
@@ -147,6 +149,13 @@ impl ModpackManifest for ModrinthManifest {
 
   fn get_overrides_path(&self) -> String {
     "overrides/".to_string()
+  }
+
+  fn get_lock_info(&self) -> ModpackLockInfo {
+    ModpackLockInfo {
+      source: OtherResourceSource::Modrinth,
+      version: Some(self.version_id.clone()),
+    }
   }
 }
 

--- a/src-tauri/src/instance/helpers/modpack/multimc.rs
+++ b/src-tauri/src/instance/helpers/modpack/multimc.rs
@@ -12,7 +12,9 @@ use zip::ZipArchive;
 use crate::instance::helpers::modpack::export::{
   ExportModpackOptions, ModpackExportBundle, normalize_mod_loader_version,
 };
-use crate::instance::helpers::modpack::import::{ModpackManifest, ModpackMetaInfo};
+use crate::instance::helpers::modpack::import::{
+  ModpackLockInfo, ModpackManifest, ModpackMetaInfo,
+};
 use crate::instance::models::misc::{Instance, InstanceError, ModLoader, ModLoaderType};
 use crate::resource::models::OtherResourceSource;
 use crate::tasks::PTaskParam;
@@ -163,6 +165,13 @@ impl ModpackManifest for MultiMcManifest {
 
   fn get_overrides_path(&self) -> String {
     format!("{}.minecraft/", self.base_path)
+  }
+
+  fn get_lock_info(&self) -> ModpackLockInfo {
+    ModpackLockInfo {
+      source: OtherResourceSource::MultiMc,
+      version: None,
+    }
   }
 }
 

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -455,6 +455,13 @@ pub fn validate_sha1(dest_path: PathBuf, truth: String) -> SJMCLResult<()> {
   }
 }
 
+pub fn calculate_sha1(path: &Path) -> SJMCLResult<String> {
+  let mut file = fs::File::open(path)?;
+  let mut hasher = Sha1::new();
+  std::io::copy(&mut file, &mut hasher)?;
+  Ok(hex::encode(hasher.finalize()))
+}
+
 /// Calculates the SHA256 hash of a file.
 ///
 /// # Parameters

--- a/src-tauri/src/utils/fs.rs
+++ b/src-tauri/src/utils/fs.rs
@@ -426,23 +426,7 @@ Terminal=false
 }
 
 pub fn validate_sha1(dest_path: PathBuf, truth: String) -> SJMCLResult<()> {
-  let mut f = std::fs::File::options()
-    .read(true)
-    .create(false)
-    .write(false)
-    .open(&dest_path)
-    .map_err(|e| {
-      SJMCLError(format!(
-        "Failed to open file {}: {}",
-        dest_path.display(),
-        e
-      ))
-    })?;
-  let mut hasher = Sha1::new();
-  std::io::copy(&mut f, &mut hasher)
-    .map_err(|e| SJMCLError(format!("Failed to copy data for SHA1 validation: {}", e)))?;
-
-  let sha1 = hex::encode(hasher.finalize());
+  let sha1 = calculate_sha1(&dest_path)?;
   if sha1 != truth {
     Err(SJMCLError(format!(
       "SHA1 mismatch for {}: expected {}, got {}",


### PR DESCRIPTION
### Checklist

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature

### Related Issues

- Partially addresses #1410 without closing it.

### Description

- Generate `.sjmcl/modpack.lock.json` when importing CurseForge, Modrinth, and MultiMC modpacks.
- Record the modpack source, version, managed file paths, SHA-1 hashes, and whether each file comes from the manifest or overrides.
- Exclude the SJMCL internal metadata directory when exporting modpacks.

### Additional Context

This PR only introduces lock-file generation during initial import. Reading the lock file and updating existing modpack instances are intentionally left for subsequent work.

Validation completed with `cargo check` and `rustfmt --check`.

## Summary by Sourcery

Generate initial modpack lock files during supported modpack imports while keeping SJMCL metadata out of exported archives.

New Features:
- Generate versioned modpack lock files during CurseForge, Modrinth, and MultiMC imports, recording managed downloads and overrides with source metadata and SHA-1 hashes.

Bug Fixes:
- Prevent SJMCL modpack lock metadata from being included when exporting modpacks.

Enhancements:
- Unify modpack import planning so downloaded and override files can be tracked consistently.
- Centralize SHA-1 calculation for file validation and lock-file generation.