### PR TITLE
perf(frontend): lazy render accordion sections and load mod versions incrementally

### DIFF
--- a/src/components/common/option-item.tsx
+++ b/src/components/common/option-item.tsx
@@ -40,7 +40,7 @@ export interface OptionItemGroupProps extends SectionProps {
   withDivider?: boolean;
   maxFirstVisibleItems?: number;
   enableShowAll?: boolean;
-  showAllStep?: number;
+  showMoreStep?: number;
 }
 
 export const OptionItem: React.FC<OptionItemProps> = ({
@@ -187,7 +187,7 @@ export const OptionItemGroup: React.FC<OptionItemGroupProps> = ({
   withDivider = true,
   maxFirstVisibleItems,
   enableShowAll = true,
-  showAllStep,
+  showMoreStep,
   ...props
 }) => {
   const { t } = useTranslation();
@@ -204,7 +204,7 @@ export const OptionItemGroup: React.FC<OptionItemGroupProps> = ({
     );
   }
 
-  const isIncremental = !!showAllStep && showAllStep > 0;
+  const isIncremental = !!showMoreStep && showMoreStep > 0;
 
   const hasShowAllBtn = !!maxFirstVisibleItems && items.length > limit;
   const effectiveVisibleCount = hasShowAllBtn
@@ -216,7 +216,7 @@ export const OptionItemGroup: React.FC<OptionItemGroupProps> = ({
 
   const handleShowAll = () => {
     if (isIncremental) {
-      setVisibleCount((count) => Math.min(count + showAllStep, items.length));
+      setVisibleCount((count) => Math.min(count + showMoreStep, items.length));
     } else {
       setVisibleCount(items.length);
     }

--- a/src/components/common/option-item.tsx
+++ b/src/components/common/option-item.tsx
@@ -40,6 +40,7 @@ export interface OptionItemGroupProps extends SectionProps {
   withDivider?: boolean;
   maxFirstVisibleItems?: number;
   enableShowAll?: boolean;
+  showAllStep?: number;
 }
 
 export const OptionItem: React.FC<OptionItemProps> = ({
@@ -186,12 +187,15 @@ export const OptionItemGroup: React.FC<OptionItemGroupProps> = ({
   withDivider = true,
   maxFirstVisibleItems,
   enableShowAll = true,
+  showAllStep,
   ...props
 }) => {
   const { t } = useTranslation();
   const { config } = useLauncherConfig();
   const primaryColor = config.appearance.theme.primaryColor;
-  const [showAll, setShowAll] = useState(false);
+
+  const limit = maxFirstVisibleItems ?? items.length;
+  const [visibleCount, setVisibleCount] = useState(limit);
 
   function isOptionItemProps(item: any): item is OptionItemProps {
     return (
@@ -200,40 +204,48 @@ export const OptionItemGroup: React.FC<OptionItemGroupProps> = ({
     );
   }
 
-  const hasShowAllBtn = !(
-    !maxFirstVisibleItems ||
-    showAll ||
-    items.length <= maxFirstVisibleItems
-  );
+  const isIncremental = !!showAllStep && showAllStep > 0;
 
-  const visibleItems = hasShowAllBtn
-    ? [...items.slice(0, maxFirstVisibleItems)]
-    : items;
+  const hasShowAllBtn = !!maxFirstVisibleItems && items.length > limit;
+  const effectiveVisibleCount = hasShowAllBtn
+    ? Math.min(visibleCount, items.length)
+    : items.length;
+  const remainingCount = items.length - effectiveVisibleCount;
+
+  const visibleItems = items.slice(0, effectiveVisibleCount);
+
+  const handleShowAll = () => {
+    if (isIncremental) {
+      setVisibleCount((count) => Math.min(count + showAllStep, items.length));
+    } else {
+      setVisibleCount(items.length);
+    }
+  };
 
   const renderItems = () => (
     <>
-      {[...visibleItems].map((item, index) => (
+      {visibleItems.map((item, index) => (
         <React.Fragment key={index}>
           {isOptionItemProps(item) ? <OptionItem {...item} /> : item}
           {index !== visibleItems.length - 1 &&
             (withDivider ? <Divider my={1.5} /> : <Box h={1.5} />)}
         </React.Fragment>
       ))}
-      {hasShowAllBtn && (
+      {hasShowAllBtn && remainingCount > 0 && (
         <Box>
           <Button
             key="show-all"
             size="xs"
             colorScheme={primaryColor}
             variant="ghost"
-            onClick={() => setShowAll(!showAll)}
+            onClick={handleShowAll}
             mt={1.5}
             ml={-1.5}
             disabled={!enableShowAll}
           >
-            {t("OptionItemGroup.button.showAll", {
-              left: items.length - maxFirstVisibleItems,
-            })}
+            {isIncremental
+              ? t("OptionItemGroup.button.loadMore", { left: remainingCount })
+              : t("OptionItemGroup.button.showAll", { left: remainingCount })}
           </Button>
         </Box>
       )}

--- a/src/components/common/section.tsx
+++ b/src/components/common/section.tsx
@@ -131,7 +131,7 @@ export const Section: React.FC<SectionProps> = ({
         </Flex>
       )}
       {isAccordion ? (
-        <Collapse in={isOpen} animateOpacity>
+        <Collapse in={isOpen} animateOpacity unmountOnExit>
           {children}
         </Collapse>
       ) : (

--- a/src/components/modals/download-specific-resource-modal.tsx
+++ b/src/components/modals/download-specific-resource-modal.tsx
@@ -531,7 +531,7 @@ const DownloadSpecificResourceModal: React.FC<
   ) => {
     return (
       <Section
-        key={index}
+        key={pack.name}
         isAccordion
         title={pack.name}
         initialIsOpen={initialIsOpen}
@@ -540,6 +540,8 @@ const DownloadSpecificResourceModal: React.FC<
       >
         {pack.items.length > 0 ? (
           <OptionItemGroup
+            maxFirstVisibleItems={20}
+            showAllStep={20}
             items={pack.items.map((item, index) => (
               <OptionItem
                 key={index}

--- a/src/components/modals/download-specific-resource-modal.tsx
+++ b/src/components/modals/download-specific-resource-modal.tsx
@@ -541,7 +541,7 @@ const DownloadSpecificResourceModal: React.FC<
         {pack.items.length > 0 ? (
           <OptionItemGroup
             maxFirstVisibleItems={20}
-            showAllStep={20}
+            showMoreStep={20}
             items={pack.items.map((item, index) => (
               <OptionItem
                 key={index}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1864,6 +1864,7 @@
   },
   "OptionItemGroup": {
     "button": {
+      "loadMore": "Load More (+{{left}})",
       "showAll": "Show All (+{{left}})"
     }
   },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1864,6 +1864,7 @@
   },
   "OptionItemGroup": {
     "button": {
+      "loadMore": "Cargar más (+{{left}})",
       "showAll": "Mostrar todo (+{{left}})"
     }
   },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1864,6 +1864,7 @@
   },
   "OptionItemGroup": {
     "button": {
+      "loadMore": "Charger plus (+{{left}})",
       "showAll": "Tout afficher (+{{left}})"
     }
   },

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1864,6 +1864,7 @@
   },
   "OptionItemGroup": {
     "button": {
+      "loadMore": "さらに読み込む（+{{left}}）",
       "showAll": "すべて表示（+{{left}}）"
     }
   },

--- a/src/locales/lzh.json
+++ b/src/locales/lzh.json
@@ -1864,6 +1864,7 @@
   },
   "OptionItemGroup": {
     "button": {
+      "loadMore": "續載（+{{left}}）",
       "showAll": "顯全覽（+{{left}}）"
     }
   },

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -1864,6 +1864,7 @@
   },
   "OptionItemGroup": {
     "button": {
+      "loadMore": "加载更多（+{{left}}）",
       "showAll": "显示全部（+{{left}}）"
     }
   },

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -1864,6 +1864,7 @@
   },
   "OptionItemGroup": {
     "button": {
+      "loadMore": "載入更多（+{{left}}）",
       "showAll": "顯示全部（+{{left}}）"
     }
   },


### PR DESCRIPTION
### Checklist

- [ ] 已在本地测试并验证通过
- [ ] 工作流中的所有测试通过
- [ ] 如有必要已更新文档
- [x] 代码格式与提交信息符合项目规范

### This PR is a ..

- [x] ⚡️ 性能优化

### Related Issues

close #1825

### Description

修复打开/安装版本较多的模组时的界面卡顿（例如 Biomes O' Plenty 有 48 个版本分组、共 2000+ 个文件条目）。

资源弹窗会一次性拉取该模组的全部版本，且此前即使分组处于折叠状态也会挂载所有 `OptionItem`，导致任何交互（选择版本、打开实例选择器、安装）都要重渲染数千个重型 Chakra 节点。

改动：
- `Section`：折叠时卸载子节点（`unmountOnExit`），折叠分组只渲染轻量标题
- `OptionItemGroup`：新增 `showMoreStep` 属性，把「显示全部」改为增量「加载更多」，避免一次挂载整份列表
- 下载资源弹窗：每个版本分组默认显示 20 条，每次点击再多加载 20 条；分组以 MC 版本号作为 key，切换筛选时分组状态自动重置

### Additional Context

已通过 `tsc --noEmit`、`eslint` 与 locale diff 脚本验证。
