### PR TITLE
fix(resource): preserve CurseForge API key at build time

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -6,7 +6,19 @@ fn main() {
   if std::env::var("GITHUB_ACTIONS").is_err() {
     // Load env variables from ".env" file, if not exists, use ".env.template" to set default value.
     from_filename(".env.template").ok();
-    dotenv_override().ok();
+    if let Ok(path) = dotenv_override()
+      && let Ok(contents) = fs::read_to_string(path)
+      && let Some(value) = contents.lines().find_map(|line| {
+        line
+          .trim()
+          .strip_prefix("SJMCL_CURSEFORGE_API_KEY")
+          .and_then(|line| line.trim_start().strip_prefix('='))
+          .map(|value| value.trim().trim_matches(['\'', '"']).to_string())
+      })
+    {
+      // CurseForge keys can contain '$', which dotenv treats as interpolation.
+      unsafe { env::set_var("SJMCL_CURSEFORGE_API_KEY", value) };
+    }
   }
 
   let out_dir = env::var("OUT_DIR").unwrap_or_else(|_| "".to_string());


### PR DESCRIPTION
### Checklist

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🐞 Bug fix

### Related Issues

N/A

### Description

Preserve the raw `SJMCL_CURSEFORGE_API_KEY` value after loading `.env`.

`dotenvy` interpolates `$` characters in environment values, which truncates valid CurseForge API keys containing `$`. The build script now reloads only this key from the original file and overrides the interpolated value before generating compile-time secrets.

### Additional Context

No user-facing configuration changes are required.

## Summary by Sourcery

Bug Fixes:
- Prevent CurseForge API keys containing '$' from being truncated by dotenv interpolation during the build script’s environment loading.