### PR TITLE
feat(macros): migrations macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ package-lock.json
 !.claude/skills
 .gemini/
 .cursor/
+src-tauri/src/launcher_config/models.rs
+src-tauri/src/launcher_config/models.rs

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "sha2",
  "shlex",
  "sjmcl-macros",
+ "sjmcl-migration",
  "sjmcl-types",
  "smart-default",
  "structstruck",
@@ -5612,7 +5613,20 @@ version = "1.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_json",
+ "sjmcl-migration",
+ "structstruck",
  "syn 2.0.117",
+ "trybuild",
+]
+
+[[package]]
+name = "sjmcl-migration"
+version = "1.2.0"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -5776,11 +5790,10 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "structstruck"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a052ec87a2d9bdd3a35f85ec6a07a5ac0816e4190b1cbede9d67cccb47ea66d"
+checksum = "f318209842d04696a2c139cd3d5d4d75c4a9e2af435b077aa5cbd391a79c34b3"
 dependencies = [
- "heck 0.4.1",
  "proc-macro2",
  "quote",
  "venial",
@@ -5996,6 +6009,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-triple"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
 
 [[package]]
 name = "tauri"
@@ -6474,6 +6493,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6939,6 +6967,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e605bf6b39357663d8ba4e984f8be8da8df6bb32e81031d6889024ea8fd68e4"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 1.1.2+spec-1.1.0",
+]
 
 [[package]]
 name = "typeid"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,7 +9,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [workspace]
-members = ["crates/sjmcl-macros", "crates/sjmcl-types"]
+members = ["crates/sjmcl-macros", "crates/sjmcl-migration", "crates/sjmcl-types"]
 resolver = "3"
 
 [workspace.package]
@@ -71,15 +71,16 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "3.12.0"
 sjmcl-macros = { path = "./crates/sjmcl-macros" }
+sjmcl-migration = { path = "./crates/sjmcl-migration" }
 sjmcl-types = { path = "./crates/sjmcl-types" }
 sha1 = { version = "0.10.1", features = ["oid"] }
 sha2 = "0.10.9"
 shlex = "1.3.0"
 smart-default = "0.7.1"
-structstruck = "0.4.1"
+structstruck = "0.5.1"
 strum = "0.27.1"
 strum_macros = "0.27.1"
-syn = { version = "2", features = ["full"] }
+syn = { version = "2", features = ["full", "extra-traits"] }
 sysinfo = "0.36.0"
 systemstat = "0.2.3"
 tauri = { version = "2.11.1", features = ["protocol-asset", "image-png"] }
@@ -201,6 +202,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
 sjmcl-macros.workspace = true
+sjmcl-migration.workspace = true
 sjmcl-types.workspace = true
 sha1.workspace = true
 sha2.workspace = true

--- a/src-tauri/crates/sjmcl-macros/Cargo.toml
+++ b/src-tauri/crates/sjmcl-macros/Cargo.toml
@@ -11,3 +11,10 @@ proc-macro = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
+
+[dev-dependencies]
+serde.workspace = true
+serde_json.workspace = true
+sjmcl-migration.workspace = true
+structstruck.workspace = true
+trybuild = "1"

--- a/src-tauri/crates/sjmcl-macros/src/lib.rs
+++ b/src-tauri/crates/sjmcl-macros/src/lib.rs
@@ -1,10 +1,17 @@
 use proc_macro::TokenStream;
 use syn::{DeriveInput, ItemStruct, parse_macro_input};
 
+mod migrations;
 mod partial;
 mod serialize;
+use migrations::migrations_impl;
 use partial::derive_partial_impl;
 use serialize::serialize_skip_none_impl;
+
+#[proc_macro]
+pub fn migrations(input: TokenStream) -> TokenStream {
+  migrations_impl(input)
+}
 
 #[proc_macro_derive(Partial)]
 pub fn derive_partial(input: TokenStream) -> TokenStream {
@@ -17,9 +24,14 @@ pub fn derive_partial(input: TokenStream) -> TokenStream {
 /// # Examples
 ///
 /// ```rust
+/// use sjmcl_macros::serialize_skip_none;
+/// use serde::Serialize;
+///
 /// #[serialize_skip_none]
 /// #[derive(Serialize)]
-/// struct Foo { ... }
+/// struct Foo {
+///   bar: Option<String>,
+/// }
 /// ```
 #[proc_macro_attribute]
 pub fn serialize_skip_none(_attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/src-tauri/crates/sjmcl-macros/src/migrations.rs
+++ b/src-tauri/crates/sjmcl-macros/src/migrations.rs
@@ -1,0 +1,1786 @@
+use proc_macro::TokenStream;
+use proc_macro2::{Span, TokenStream as TS2, TokenTree};
+use quote::{ToTokens, quote};
+use std::collections::BTreeMap;
+use syn::ext::IdentExt;
+use syn::parse::discouraged::Speculative;
+use syn::parse::{Parse, ParseStream};
+use syn::{
+  Expr, ExprPath, Ident, LitStr, Token, Type, braced, parenthesized, parse_macro_input, token,
+};
+
+// ---------------------------------------------------------------------------
+// Schema model (structstruck-compatible nested declarations)
+// ---------------------------------------------------------------------------
+
+/// Node kind in the symbol table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NodeKind {
+  Leaf,
+  Struct,
+  Enum,
+}
+
+/// A path -> type-name entry in the schema symbol table.
+#[derive(Debug, Clone)]
+struct PathEntry {
+  path: String,
+  ty: String,
+  #[allow(dead_code)]
+  kind: NodeKind,
+}
+
+type SymbolTable = BTreeMap<String, PathEntry>;
+
+/// Registry of all named structs/enums (top-level or nested), used to resolve
+/// container children during flattening and wrap checks.
+#[derive(Debug, Default)]
+struct TypeRegistry {
+  structs: BTreeMap<String, Vec<(String, String)>>,
+  enums: BTreeMap<String, Vec<VariantReg>>,
+}
+
+#[derive(Debug, Clone)]
+struct VariantReg {
+  name: String,
+  kind: NodeKind,
+  fields: Vec<(String, String)>,
+}
+
+/// A field's type: either a leaf Rust type or a nested struct/enum definition.
+#[derive(Debug, Clone)]
+enum FieldTy {
+  Leaf(Type),
+  Nested(ItemDef),
+}
+
+#[derive(Debug, Clone)]
+enum ItemDef {
+  Struct(StructDef),
+  Enum(EnumDef),
+}
+
+#[derive(Debug, Clone)]
+struct StructDef {
+  name: Ident,
+  fields: Vec<(Ident, FieldTy)>,
+}
+
+#[derive(Debug, Clone)]
+struct EnumDef {
+  name: Ident,
+  variants: Vec<VariantDef>,
+}
+
+#[derive(Debug, Clone)]
+struct VariantDef {
+  name: Ident,
+  fields: VariantFields,
+}
+
+#[derive(Debug, Clone)]
+enum VariantFields {
+  Named(Vec<(Ident, FieldTy)>),
+  Tuple,
+  Unit,
+}
+
+/// Operations understood by the DSL. Model-level operations describe schema
+/// evolution from the baseline; they also translate to runtime ops
+/// (see `op_to_tokens`).
+#[derive(Debug, Clone)]
+enum Op {
+  /// Add a new top-level model (struct/enum) to the schema. `raw` keeps the
+  /// declaration (with attributes) for structstruck type generation.
+  AddModel {
+    def: ItemDef,
+    raw: TS2,
+  },
+  /// Remove a top-level model and its subtree.
+  RemoveModel {
+    name: String,
+  },
+  /// Rename a top-level model (and every path under it).
+  RenameModel {
+    from: String,
+    to: String,
+  },
+  Rename {
+    from: String,
+    to: String,
+  },
+  Move {
+    from: String,
+    to: String,
+  },
+  /// Convert the value at `path` from `from_ty` to `to_ty`.
+  ///
+  /// Three forms:
+  /// - `convert "a.b" from B to C;` — built-in whitelist conversion
+  /// - `convert "a.b" from B to C : expr;` — fill `expr` when missing
+  /// - `convert "a.b" from B to C => fn;` — user-supplied helper; when `f`
+  ///   is absent the model-level `convert_field` helper is used as fallback,
+  ///   then the built-in whitelist.
+  Convert {
+    path: String,
+    from_ty: Option<String>,
+    to_ty: Option<String>,
+    default: Option<Expr>,
+    f: Option<ExprPath>,
+  },
+  Remove {
+    path: String,
+  },
+}
+
+/// A three-part version `major.minor.patch`, ordered lexicographically.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct Version {
+  major: u32,
+  minor: u32,
+  patch: u32,
+}
+
+impl std::fmt::Display for Version {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+  }
+}
+
+impl Version {
+  fn to_tokens(&self) -> TS2 {
+    let mj = self.major;
+    let mn = self.minor;
+    let pt = self.patch;
+    quote! { ::sjmcl_migration::Version { major: #mj, minor: #mn, patch: #pt } }
+  }
+}
+
+#[derive(Debug, Clone)]
+struct Migration {
+  from: Version,
+  to: Version,
+  ops: Vec<Op>,
+}
+
+/// One explicitly-declared schema state (a required intermediate version).
+#[derive(Debug, Clone)]
+struct SchemaBlock {
+  version: Version,
+  /// Raw schema tokens, forwarded verbatim to `structstruck::strike!`.
+  raw_tokens: TS2,
+  /// Mutable roots (expand into the symbol table; every field is addressable).
+  roots: Vec<ItemDef>,
+  /// Auxiliary types (`#[aux]`): generated as real types and referenceable as
+  /// field types, but not expanded into the symbol table (no migration paths).
+  aux: Vec<ItemDef>,
+  /// Model-level default conversion helpers (`convert_field "Model.field" from B to C => fn;`).
+  convert_fields: Vec<ConvertField>,
+}
+
+/// A model-level default conversion registration: when a `convert` op on
+/// `path` carries no helper, this helper is used instead of the whitelist.
+#[derive(Debug, Clone)]
+struct ConvertField {
+  path: String,
+  f: ExprPath,
+}
+
+/// Parsed form of the whole `migrations!` input.
+struct MigrationsInput {
+  schemas: Vec<SchemaBlock>,
+  migrations: Vec<Migration>,
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+impl Parse for MigrationsInput {
+  fn parse(input: ParseStream) -> syn::Result<Self> {
+    let mut schemas = Vec::new();
+    let mut migrations = Vec::new();
+
+    while !input.is_empty() {
+      if input.peek(Ident) && input.peek2(Ident) {
+        let kw: Ident = input.parse()?;
+        if kw != "schema" {
+          return Err(syn::Error::new(
+            kw.span(),
+            "expected `schema vN { ... }` block or a `vN -> vN { ... }` migration block",
+          ));
+        }
+        let vident: Ident = input.parse()?;
+        let version = parse_version_ident(&vident)?;
+        // Optional `.M[.P]` segments (note: `v1.1.2` lexes the tail as a float literal).
+        let (minor, patch) = parse_version_segments(&input)?;
+        let version = Version {
+          major: version,
+          minor,
+          patch,
+        };
+        let content;
+        braced!(content in input);
+        let raw_tokens: TS2 = content.parse()?;
+        let (clean_tokens, convert_fields) = extract_convert_fields(raw_tokens)?;
+        let (roots, aux) = parse_root_items(&clean_tokens)?;
+        schemas.push(SchemaBlock {
+          version,
+          raw_tokens: clean_tokens,
+          roots,
+          aux,
+          convert_fields,
+        });
+      } else {
+        migrations.push(parse_migration(input)?);
+      }
+    }
+
+    Ok(MigrationsInput {
+      schemas,
+      migrations,
+    })
+  }
+}
+
+/// Split `convert_field "Model.field" from B to C => fn;` declarations out of
+/// the schema tokens (they are DSL, not structstruck input).
+fn extract_convert_fields(ts: TS2) -> syn::Result<(TS2, Vec<ConvertField>)> {
+  let parser = |input: ParseStream| -> syn::Result<(TS2, Vec<ConvertField>)> {
+    let mut clean = TS2::new();
+    let mut fields = Vec::new();
+    while !input.is_empty() {
+      // Peek for `convert_field` (an ident followed by a string literal).
+      if input.peek(Ident) && input.peek2(LitStr) {
+        let ahead = input.fork();
+        let kw: Ident = ahead.parse()?;
+        if kw == "convert_field" {
+          let path: LitStr = ahead.parse()?;
+          let _from_kw: Ident = ahead.parse()?;
+          let _from_ty: Type = ahead.parse()?;
+          let _to_kw: Ident = ahead.parse()?;
+          let _to_ty: Type = ahead.parse()?;
+          let _arrow: Token![=>] = ahead.parse()?;
+          let f: ExprPath = ahead.parse()?;
+          let _semi: Token![;] = ahead.parse()?;
+          input.advance_to(&ahead);
+          fields.push(ConvertField {
+            path: path.value(),
+            f,
+          });
+          continue;
+        }
+      }
+      clean.extend([input.parse::<TokenTree>()?]);
+    }
+    Ok((clean, fields))
+  };
+  syn::parse::Parser::parse2(parser, ts)
+}
+
+/// Marker for a top-level declaration: `#[aux]` types are not addressable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RootMark {
+  Root,
+  Aux,
+}
+
+fn parse_root_items(ts: &TS2) -> syn::Result<(Vec<ItemDef>, Vec<ItemDef>)> {
+  let parser = |input: ParseStream| -> syn::Result<(Vec<ItemDef>, Vec<ItemDef>)> {
+    let mut roots = Vec::new();
+    let mut aux = Vec::new();
+    while !input.is_empty() {
+      let (item, mark) = parse_item_def(input)?;
+      match mark {
+        RootMark::Aux => aux.push(item),
+        RootMark::Root => roots.push(item),
+      }
+    }
+    Ok((roots, aux))
+  };
+  syn::parse::Parser::parse2(parser, ts.clone())
+}
+
+/// Skip any outer (`#[...]`) and inner (`#![...]`) attributes in a row.
+/// structstruck pseudo-attributes (`each`, `long_names`, ...) appear this way.
+/// Returns the skipped attributes so callers can inspect e.g. `#[root]`.
+fn skip_attrs(input: ParseStream) -> syn::Result<Vec<syn::Attribute>> {
+  let mut attrs = Vec::new();
+  while input.peek(Token![#]) {
+    if input.peek2(Token![!]) {
+      attrs.extend(input.call(syn::Attribute::parse_inner)?);
+    } else {
+      attrs.extend(input.call(syn::Attribute::parse_outer)?);
+    }
+  }
+  Ok(attrs)
+}
+
+fn parse_item_def(input: ParseStream) -> syn::Result<(ItemDef, RootMark)> {
+  parse_item_def_opt(input, false)
+}
+
+/// `bare_ok` allows a declaration without the `struct`/`enum` keyword, treated
+/// as a struct — used by `add_model ServerConfig { ... }`.
+fn parse_item_def_opt(input: ParseStream, bare_ok: bool) -> syn::Result<(ItemDef, RootMark)> {
+  // Skip outer attributes (e.g. #[structstruck::each[...]], #[derive(...)])
+  // and the visibility modifier (`pub`). `#[aux]` marks a non-addressable type.
+  let attrs = skip_attrs(input)?;
+  let mark = if attrs.iter().any(|a| a.path().is_ident("aux")) {
+    RootMark::Aux
+  } else {
+    RootMark::Root
+  };
+  let _: syn::Visibility = input.parse()?;
+  if input.peek(Token![struct]) {
+    let _: Token![struct] = input.parse()?;
+    let name: Ident = input.parse()?;
+    let fields = parse_named_fields(input)?;
+    Ok((ItemDef::Struct(StructDef { name, fields }), mark))
+  } else if input.peek(Token![enum]) {
+    parse_item_enum(input, mark)
+  } else if bare_ok && input.peek(Ident) {
+    // `add_model ServerConfig { ... }` — bare struct name.
+    let name: Ident = input.parse()?;
+    let fields = parse_named_fields(input)?;
+    Ok((ItemDef::Struct(StructDef { name, fields }), mark))
+  } else {
+    Err(input.error("expected `struct` or `enum` declaration in schema"))
+  }
+}
+
+fn parse_item_enum(input: ParseStream, mark: RootMark) -> syn::Result<(ItemDef, RootMark)> {
+  let _: Token![enum] = input.parse()?;
+  let name: Ident = input.parse()?;
+  let content;
+  braced!(content in input);
+  // Skip inner attributes (e.g. #![structstruck::each[...]]).
+  let _ = skip_attrs(&content)?;
+  let mut variants = Vec::new();
+  while !content.is_empty() {
+    let _ = skip_attrs(&content)?;
+    let vname: Ident = content.parse()?;
+    if content.peek(token::Brace) {
+      let fields = parse_named_fields(&content)?;
+      variants.push(VariantDef {
+        name: vname,
+        fields: VariantFields::Named(fields),
+      });
+    } else if content.peek(token::Paren) {
+      let tuple_content;
+      parenthesized!(tuple_content in content);
+      while !tuple_content.is_empty() {
+        let _ = parse_field_ty(&tuple_content, &vname.to_string())?;
+        if tuple_content.peek(Token![,]) {
+          tuple_content.parse::<Token![,]>()?;
+        }
+      }
+      variants.push(VariantDef {
+        name: vname,
+        fields: VariantFields::Tuple,
+      });
+    } else {
+      variants.push(VariantDef {
+        name: vname,
+        fields: VariantFields::Unit,
+      });
+    }
+    if content.peek(Token![,]) {
+      content.parse::<Token![,]>()?;
+    }
+  }
+  Ok((ItemDef::Enum(EnumDef { name, variants }), mark))
+}
+
+/// Parse `{ field: FieldTy, ... }` (named fields).
+fn parse_named_fields(input: ParseStream) -> syn::Result<Vec<(Ident, FieldTy)>> {
+  let content;
+  braced!(content in input);
+  // Skip inner attributes (structstruck inner-attribute style).
+  skip_attrs(&content)?;
+  let mut fields = Vec::new();
+  while !content.is_empty() {
+    // Each field may carry attributes (#[default = ...], #[serde(...)], ...)
+    // and a visibility modifier (`pub`).
+    skip_attrs(&content)?;
+    let _: syn::Visibility = content.parse()?;
+    let field: Ident = content.parse()?;
+    let _colon: Token![:] = content.parse()?;
+    let ty = parse_field_ty(&content, &field.to_string())?;
+    fields.push((field, ty));
+    if content.peek(Token![,]) {
+      content.parse::<Token![,]>()?;
+    }
+  }
+  Ok(fields)
+}
+
+/// Infer a structstruck-style type name from a field name: `basic_info` -> `BasicInfo`.
+fn pascal_case(s: &str) -> String {
+  s.split('_')
+    .filter(|p| !p.is_empty())
+    .map(|p| {
+      let mut chars = p.chars();
+      match chars.next() {
+        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+      }
+    })
+    .collect()
+}
+
+/// Convert a snake_case field name to camelCase, matching serde's
+/// `rename_all = "camelCase"`. Migration op paths address JSON document keys,
+/// so the symbol table must use the serialized names too.
+fn camel_case(s: &str) -> String {
+  let mut out = String::new();
+  let mut capitalize_next = false;
+  for c in s.chars() {
+    if c == '_' {
+      capitalize_next = true;
+    } else if capitalize_next {
+      out.extend(c.to_uppercase());
+      capitalize_next = false;
+    } else {
+      out.push(c);
+    }
+  }
+  out
+}
+
+/// A field type is either a leaf Rust type or a nested `struct`/`enum`.
+/// `name_hint` is the enclosing field name, used to infer a name for anonymous
+/// nested declarations (`basic_info: struct { ... }` -> `BasicInfo`).
+fn parse_field_ty(input: ParseStream, name_hint: &str) -> syn::Result<FieldTy> {
+  // Skip attributes preceding a nested struct/enum (structstruck style).
+  skip_attrs(input)?;
+  if input.peek(Token![struct]) {
+    let _: Token![struct] = input.parse()?;
+    let name: Ident = if input.peek(Ident) {
+      input.parse()?
+    } else {
+      Ident::new(&pascal_case(name_hint), Span::call_site())
+    };
+    let fields = parse_named_fields(input)?;
+    Ok(FieldTy::Nested(ItemDef::Struct(StructDef { name, fields })))
+  } else if input.peek(Token![enum]) {
+    let _: Token![enum] = input.parse()?;
+    let name: Ident = if input.peek(Ident) {
+      input.parse()?
+    } else {
+      Ident::new(&pascal_case(name_hint), Span::call_site())
+    };
+    let content;
+    braced!(content in input);
+    skip_attrs(&content)?;
+    let mut variants = Vec::new();
+    while !content.is_empty() {
+      let vname: Ident = content.parse()?;
+      if content.peek(token::Brace) {
+        let fields = parse_named_fields(&content)?;
+        variants.push(VariantDef {
+          name: vname,
+          fields: VariantFields::Named(fields),
+        });
+      } else if content.peek(token::Paren) {
+        let tuple_content;
+        parenthesized!(tuple_content in content);
+        while !tuple_content.is_empty() {
+          let _ = parse_field_ty(&tuple_content, &vname.to_string())?;
+          if tuple_content.peek(Token![,]) {
+            tuple_content.parse::<Token![,]>()?;
+          }
+        }
+        variants.push(VariantDef {
+          name: vname,
+          fields: VariantFields::Tuple,
+        });
+      } else {
+        variants.push(VariantDef {
+          name: vname,
+          fields: VariantFields::Unit,
+        });
+      }
+      if content.peek(Token![,]) {
+        content.parse::<Token![,]>()?;
+      }
+    }
+    Ok(FieldTy::Nested(ItemDef::Enum(EnumDef { name, variants })))
+  } else {
+    let ty: Type = input.parse()?;
+    Ok(FieldTy::Leaf(ty))
+  }
+}
+
+fn parse_migration(input: ParseStream) -> syn::Result<Migration> {
+  let v1: Ident = input.parse()?;
+  let from_major = parse_version_ident(&v1)?;
+  let (from_minor, from_patch) = parse_version_segments(input)?;
+  let _arrow: Token![->] = input.parse()?;
+  let v2: Ident = input.parse()?;
+  let to_major = parse_version_ident(&v2)?;
+  let (to_minor, to_patch) = parse_version_segments(input)?;
+
+  let content;
+  braced!(content in input);
+
+  let mut ops = Vec::new();
+  while !content.is_empty() {
+    ops.push(parse_op(&content)?);
+  }
+
+  Ok(Migration {
+    from: Version {
+      major: from_major,
+      minor: from_minor,
+      patch: from_patch,
+    },
+    to: Version {
+      major: to_major,
+      minor: to_minor,
+      patch: to_patch,
+    },
+    ops,
+  })
+}
+
+fn parse_version_ident(id: &Ident) -> syn::Result<u32> {
+  let s = id.to_string();
+  let num = s
+    .strip_prefix('v')
+    .ok_or_else(|| syn::Error::new(id.span(), format!("expected `v<N>`, found `{s}`")))?
+    .parse::<u32>()
+    .map_err(|_| syn::Error::new(id.span(), format!("invalid version `{s}`")))?;
+  Ok(num)
+}
+
+/// Parse up to two trailing `.M` / `.M.P` segments.
+///
+/// Rust lexes `v1.1.2` as `Ident(v1) Punct(.) Lit(1.2)` — the tail is a float
+/// literal — so a float is split on its `.`. Segments beyond patch are rejected.
+fn parse_version_segments(input: ParseStream) -> syn::Result<(u32, u32)> {
+  let mut segs = [0u32, 0u32];
+  let mut idx = 0usize;
+  while input.peek(Token![.]) {
+    input.parse::<Token![.]>()?;
+    let lit: syn::Lit = input.parse()?;
+    match lit {
+      syn::Lit::Int(i) => {
+        if idx >= 2 {
+          return Err(syn::Error::new(
+            i.span(),
+            "version has more than three segments",
+          ));
+        }
+        segs[idx] = i.base10_parse::<u32>()?;
+        idx += 1;
+      }
+      syn::Lit::Float(f) => {
+        let digits = f.base10_digits().to_string();
+        let mut parts = digits.split('.');
+        let major_seg = parts.next().unwrap_or("0");
+        let minor_seg = parts
+          .next()
+          .ok_or_else(|| syn::Error::new(f.span(), "invalid float version segment"))?;
+        if idx >= 2 || idx + 1 >= 2 {
+          return Err(syn::Error::new(
+            f.span(),
+            "version has more than three segments",
+          ));
+        }
+        segs[idx] = major_seg
+          .parse::<u32>()
+          .map_err(|_| syn::Error::new(f.span(), "invalid version segment"))?;
+        segs[idx + 1] = minor_seg
+          .parse::<u32>()
+          .map_err(|_| syn::Error::new(f.span(), "invalid version segment"))?;
+        idx += 2;
+      }
+      other => {
+        return Err(syn::Error::new(
+          other.span(),
+          "expected integer in version segment",
+        ));
+      }
+    }
+  }
+  Ok((segs[0], segs[1]))
+}
+
+fn parse_op(input: ParseStream) -> syn::Result<Op> {
+  // `move` is a reserved keyword; parse_any lets us accept it (or `r#move`).
+  let kw = Ident::parse_any(input)?;
+  match kw.to_string().as_str() {
+    "add_model" => {
+      // Capture attributes (they apply to the generated type) + the bare
+      // declaration, re-serialized so structstruck can generate the type.
+      let attrs = skip_attrs(input)?;
+      let def = parse_item_def_opt(input, true)?.0;
+      let raw: TS2 = {
+        let attrs_ts: TS2 = attrs.iter().map(|a| quote!(#a)).collect();
+        let def_ts = item_def_to_tokens(&def);
+        quote! { #attrs_ts #def_ts }
+      };
+      let _semi: Token![;] = input.parse()?;
+      Ok(Op::AddModel { def, raw })
+    }
+    "remove_model" => {
+      let name: Ident = input.parse()?;
+      let _semi: Token![;] = input.parse()?;
+      Ok(Op::RemoveModel {
+        name: name.to_string(),
+      })
+    }
+    "rename_model" => {
+      let from: Ident = input.parse()?;
+      let _arrow: Token![=>] = input.parse()?;
+      let to: Ident = input.parse()?;
+      let _semi: Token![;] = input.parse()?;
+      Ok(Op::RenameModel {
+        from: from.to_string(),
+        to: to.to_string(),
+      })
+    }
+    "rename" => {
+      let from: LitStr = input.parse()?;
+      let _arrow: Token![=>] = input.parse()?;
+      let to: LitStr = input.parse()?;
+      let _semi: Token![;] = input.parse()?;
+      Ok(Op::Rename {
+        from: from.value(),
+        to: to.value(),
+      })
+    }
+    "r#move" | "move" => {
+      let from: LitStr = input.parse()?;
+      let _arrow: Token![=>] = input.parse()?;
+      let to: LitStr = input.parse()?;
+      let _semi: Token![;] = input.parse()?;
+      Ok(Op::Move {
+        from: from.value(),
+        to: to.value(),
+      })
+    }
+    // `convert "a.b" from B to C [: expr | => fn];`
+    // The `from B to C` part is optional; when omitted the op only fills
+    // a default (`: expr`) or applies a helper (`=> fn`) without touching
+    // the symbol table types.
+    "convert" => {
+      let path: LitStr = input.parse()?;
+      let mut from_ty = None;
+      let mut to_ty = None;
+      if input.peek(Ident) {
+        let kw: Ident = input.parse()?;
+        if kw == "from" {
+          let ft: Type = input.parse()?;
+          let _to_kw: Ident = input.parse()?;
+          let tt: Type = input.parse()?;
+          from_ty = Some(ty_name(&ft));
+          to_ty = Some(ty_name(&tt));
+        } else {
+          return Err(syn::Error::new(
+            kw.span(),
+            format!("expected `from`, found `{kw}`"),
+          ));
+        }
+      }
+      let mut default = None;
+      let mut f = None;
+      if input.peek(Token![:]) {
+        let _colon: Token![:] = input.parse()?;
+        default = Some(input.parse()?);
+      } else if input.peek(Token![=>]) {
+        let _arrow: Token![=>] = input.parse()?;
+        f = Some(input.parse()?);
+      }
+      let _semi: Token![;] = input.parse()?;
+      Ok(Op::Convert {
+        path: path.value(),
+        from_ty,
+        to_ty,
+        default,
+        f,
+      })
+    }
+    "remove" | "remove_field" => {
+      let path: LitStr = input.parse()?;
+      let _semi: Token![;] = input.parse()?;
+      Ok(Op::Remove { path: path.value() })
+    }
+    other => Err(syn::Error::new(
+      kw.span(),
+      format!("unknown operation `{other}`"),
+    )),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Symbol table construction
+// ---------------------------------------------------------------------------
+
+fn ty_name(t: &Type) -> String {
+  t.to_token_stream().to_string().replace(' ', "")
+}
+
+fn field_ty_name(ft: &FieldTy) -> String {
+  match ft {
+    FieldTy::Leaf(t) => ty_name(t),
+    FieldTy::Nested(ItemDef::Struct(s)) => s.name.to_string(),
+    FieldTy::Nested(ItemDef::Enum(e)) => e.name.to_string(),
+  }
+}
+
+/// Build the full registry of named structs/enums from the (possibly nested)
+/// schema declaration tree.
+fn build_registry(roots: &[ItemDef]) -> TypeRegistry {
+  let mut reg = TypeRegistry::default();
+  let mut stack: Vec<ItemDef> = roots.iter().cloned().collect();
+  while let Some(item) = stack.pop() {
+    match item {
+      ItemDef::Struct(s) => {
+        let fields: Vec<(String, String)> = s
+          .fields
+          .iter()
+          .map(|(n, t)| (n.to_string(), field_ty_name(t)))
+          .collect();
+        reg.structs.insert(s.name.to_string(), fields);
+        for (_, t) in s.fields {
+          if let FieldTy::Nested(nested) = t {
+            stack.push(nested);
+          }
+        }
+      }
+      ItemDef::Enum(e) => {
+        let mut variants = Vec::new();
+        for v in e.variants {
+          let (kind, fields) = match &v.fields {
+            VariantFields::Named(fs) => {
+              let fields: Vec<(String, String)> = fs
+                .iter()
+                .map(|(n, t)| (n.to_string(), field_ty_name(t)))
+                .collect();
+              (NodeKind::Struct, fields)
+            }
+            VariantFields::Tuple => (NodeKind::Leaf, Vec::new()),
+            VariantFields::Unit => (NodeKind::Leaf, Vec::new()),
+          };
+          variants.push(VariantReg {
+            name: v.name.to_string(),
+            kind,
+            fields,
+          });
+          if let VariantFields::Named(fs) = &v.fields {
+            for (_, t) in fs {
+              if let FieldTy::Nested(nested) = t {
+                stack.push((*nested).clone());
+              }
+            }
+          }
+        }
+        reg.enums.insert(e.name.to_string(), variants);
+      }
+    }
+  }
+  reg
+}
+
+/// Flatten the schema into a path -> type symbol table.
+///
+/// Every top-level declaration is a root. A single root is flattened with flat
+/// paths (`name`, `theme.color`); with multiple roots each root is namespaced
+/// by its type name (`ServerConfig.host`). A reference cycle between types is a
+/// compile error (`A -> B -> A`).
+fn flatten_schema(roots: &[ItemDef], registry: &TypeRegistry) -> Result<SymbolTable, syn::Error> {
+  let mut table = SymbolTable::new();
+  let multi = roots.len() > 1;
+  for root in roots {
+    let name = match root {
+      ItemDef::Struct(s) => s.name.to_string(),
+      ItemDef::Enum(e) => e.name.to_string(),
+    };
+    let prefix = if multi { name.clone() } else { String::new() };
+    let mut stack = vec![name.clone()];
+    match root {
+      ItemDef::Struct(_) => flatten_named(&name, &prefix, registry, &mut table, &mut stack)?,
+      ItemDef::Enum(e) => {
+        // Root enum is unusual; flatten its variants at top level.
+        for v in &e.variants {
+          let vpath = if prefix.is_empty() {
+            v.name.to_string()
+          } else {
+            format!("{prefix}.{}", v.name)
+          };
+          let (kind, fields) = match &v.fields {
+            VariantFields::Named(fs) => {
+              let fields: Vec<(String, String)> = fs
+                .iter()
+                .map(|(n, t)| (n.to_string(), field_ty_name(t)))
+                .collect();
+              (NodeKind::Struct, fields)
+            }
+            _ => (NodeKind::Leaf, Vec::new()),
+          };
+          let vreg = VariantReg {
+            name: v.name.to_string(),
+            kind,
+            fields,
+          };
+          flatten_variant(&vpath, &vreg, registry, &mut table, &mut stack)?;
+        }
+      }
+    }
+  }
+  Ok(table)
+}
+
+fn flatten_named(
+  name: &str,
+  prefix: &str,
+  registry: &TypeRegistry,
+  table: &mut SymbolTable,
+  stack: &mut Vec<String>,
+) -> Result<(), syn::Error> {
+  if let Some(fields) = registry.structs.get(name) {
+    for (fname, fty) in fields {
+      let fname = camel_case(fname);
+      let path = if prefix.is_empty() {
+        fname
+      } else {
+        format!("{prefix}.{fname}")
+      };
+      let kind = node_kind(fty, registry);
+      table.insert(
+        path.clone(),
+        PathEntry {
+          path: path.clone(),
+          ty: fty.clone(),
+          kind,
+        },
+      );
+      if kind != NodeKind::Leaf {
+        enter_type(fty, path, registry, table, stack)?;
+      }
+    }
+  } else if let Some(variants) = registry.enums.get(name) {
+    for v in variants {
+      let vpath = if prefix.is_empty() {
+        v.name.clone()
+      } else {
+        format!("{prefix}.{}", v.name)
+      };
+      flatten_variant(&vpath, v, registry, table, stack)?;
+    }
+  }
+  Ok(())
+}
+
+/// Recurse into a container type, detecting reference cycles.
+fn enter_type(
+  ty: &str,
+  path: String,
+  registry: &TypeRegistry,
+  table: &mut SymbolTable,
+  stack: &mut Vec<String>,
+) -> Result<(), syn::Error> {
+  if stack.contains(&ty.to_string()) {
+    let mut cycle = stack.clone();
+    cycle.push(ty.to_string());
+    return Err(syn::Error::new(
+      Span::call_site(),
+      format!("circular reference between types: {}", cycle.join(" -> ")),
+    ));
+  }
+  stack.push(ty.to_string());
+  flatten_named(ty, &path, registry, table, stack)?;
+  stack.pop();
+  Ok(())
+}
+
+fn flatten_variant(
+  vpath: &str,
+  v: &VariantReg,
+  registry: &TypeRegistry,
+  table: &mut SymbolTable,
+  stack: &mut Vec<String>,
+) -> Result<(), syn::Error> {
+  table.insert(
+    vpath.to_string(),
+    PathEntry {
+      path: vpath.to_string(),
+      ty: v.name.clone(),
+      kind: v.kind,
+    },
+  );
+  if v.kind == NodeKind::Struct {
+    for (fname, fty) in &v.fields {
+      let child = format!("{vpath}.{}", camel_case(fname));
+      let kind = node_kind(fty, registry);
+      table.insert(
+        child.clone(),
+        PathEntry {
+          path: child.clone(),
+          ty: fty.clone(),
+          kind,
+        },
+      );
+      if kind != NodeKind::Leaf {
+        enter_type(fty, child, registry, table, stack)?;
+      }
+    }
+  }
+  Ok(())
+}
+
+fn node_kind(ty: &str, registry: &TypeRegistry) -> NodeKind {
+  if registry.structs.contains_key(ty) {
+    NodeKind::Struct
+  } else if registry.enums.contains_key(ty) {
+    NodeKind::Enum
+  } else {
+    NodeKind::Leaf
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Soundness validation (forward simulation against declared intermediate states)
+// ---------------------------------------------------------------------------
+
+fn validate(schemas: &[SchemaBlock], migrations: &[Migration]) -> Result<(), Vec<syn::Error>> {
+  let mut errors = Vec::new();
+
+  // 0. Exactly one baseline schema block (later versions are described as
+  //    incremental changes inside migration blocks).
+  if schemas.len() != 1 {
+    errors.push(syn::Error::new(
+      Span::call_site(),
+      format!(
+        "expected exactly one baseline `schema` block, found {}; \
+                 describe subsequent versions as changes inside `vN -> vM` blocks",
+        schemas.len()
+      ),
+    ));
+    return Err(errors);
+  }
+  let baseline = &schemas[0];
+
+  // 1. Migration chain: strictly increasing, internally contiguous (each
+  //    `from` equals the previous `to`), no duplicates, ends at baseline.
+  //    The schema block declares the current (baseline) version; migrations
+  //    describe how older documents are restored up to it.
+  let mut pairs: Vec<(Version, Version)> = migrations.iter().map(|m| (m.from, m.to)).collect();
+  pairs.sort_unstable();
+  let mut seen = std::collections::HashSet::new();
+  let mut prev_to: Option<Version> = None;
+  for (i, (from, to)) in pairs.iter().enumerate() {
+    if !seen.insert((*from, *to)) {
+      errors.push(syn::Error::new(
+        Span::call_site(),
+        format!("duplicate migration {from} -> {to}"),
+      ));
+    }
+    if *to <= *from {
+      errors.push(syn::Error::new(
+        Span::call_site(),
+        format!("migration must go forward ({from} -> {to})"),
+      ));
+    }
+    if let Some(p) = prev_to {
+      if i > 0 && *from != p {
+        errors.push(syn::Error::new(
+          Span::call_site(),
+          format!("migration chain is not contiguous: expected from version {p}, found {from}"),
+        ));
+      }
+    }
+    prev_to = Some(*to);
+  }
+  if let Some(last) = pairs.last() {
+    if last.1 != baseline.version {
+      errors.push(syn::Error::new(
+        Span::call_site(),
+        format!(
+          "migration chain must end at the baseline version {} (schema), found {}",
+          baseline.version, last.1
+        ),
+      ));
+    }
+  }
+
+  // 2. Baseline must flatten without reference cycles.
+  let (mut cur, mut reg) = match build_version_table(baseline) {
+    Ok(t) => t,
+    Err(e) => {
+      errors.push(e);
+      return Err(errors);
+    }
+  };
+  // In a multi-root schema the first root is the document itself; op paths
+  // that address it may omit the root prefix (`a.b` == `LauncherConfig.a.b`).
+  let doc_root = if baseline.roots.len() > 1 {
+    baseline
+      .roots
+      .iter()
+      .find_map(|i| match i {
+        ItemDef::Struct(s) => Some(s.name.to_string()),
+        ItemDef::Enum(_) => None,
+      })
+      .unwrap_or_default()
+  } else {
+    String::new()
+  };
+
+  // 3. Evolve the symbol table through each migration's change description.
+  //    There is no separately-declared target state to compare against; each
+  //    op validates its own references against the current evolved state.
+  for m in migrations {
+    for op in &m.ops {
+      if let Err(e) = apply_forward(op, &mut cur, &mut reg, &doc_root) {
+        errors.push(e);
+      }
+    }
+  }
+
+  if errors.is_empty() {
+    Ok(())
+  } else {
+    Err(errors)
+  }
+}
+
+/// Build the symbol table + registry for one declared version.
+/// Auxiliary (`#[aux]`) types contribute to the registry (referenceable field
+/// types) but are NOT expanded into the symbol table.
+fn build_version_table(block: &SchemaBlock) -> Result<(SymbolTable, TypeRegistry), syn::Error> {
+  let mut all: Vec<ItemDef> = block.roots.clone();
+  all.extend(block.aux.iter().cloned());
+  let reg = build_registry(&all);
+  let table = flatten_schema(&block.roots, &reg)?;
+  Ok((table, reg))
+}
+
+/// Apply a single op to the evolving symbol table/registry, validating that the
+/// referenced paths/types are consistent with the current state.
+fn apply_forward(
+  op: &Op,
+  cur: &mut SymbolTable,
+  reg: &mut TypeRegistry,
+  doc_root: &str,
+) -> Result<(), syn::Error> {
+  match op {
+    Op::AddModel { def, .. } => {
+      let name = item_name(def);
+      if reg.structs.contains_key(&name) || reg.enums.contains_key(&name) {
+        return Err(syn::Error::new(
+          Span::call_site(),
+          format!("add_model: `{name}` already exists"),
+        ));
+      }
+      add_to_registry(&mut *reg, def);
+      // Added models are always name-prefixed (they make the schema multi-root).
+      let added = flatten_added_model(def, reg)
+        .map_err(|e| syn::Error::new(Span::call_site(), format!("add_model `{name}`: {e}")))?;
+      for (p, e) in added {
+        cur.entry(p).or_insert(e);
+      }
+      Ok(())
+    }
+    Op::RemoveModel { name } => {
+      if !has_model(cur, name) {
+        return Err(syn::Error::new(
+          Span::call_site(),
+          format!("remove_model: `{name}` does not exist"),
+        ));
+      }
+      remove_subtree(cur, name);
+      reg.structs.remove(name);
+      reg.enums.remove(name);
+      Ok(())
+    }
+    Op::RenameModel { from, to } => {
+      if !has_model(cur, from) {
+        return Err(syn::Error::new(
+          Span::call_site(),
+          format!("rename_model: `{from}` does not exist"),
+        ));
+      }
+      if has_model(cur, to) {
+        return Err(syn::Error::new(
+          Span::call_site(),
+          format!("rename_model: `{to}` already exists"),
+        ));
+      }
+      if let Some(fields) = reg.structs.remove(from) {
+        reg.structs.insert(to.clone(), fields);
+      }
+      if let Some(variants) = reg.enums.remove(from) {
+        reg.enums.insert(to.clone(), variants);
+      }
+      remap_children(cur, from, to);
+      Ok(())
+    }
+    Op::Rename { from, to } => {
+      let from_res = resolve_path(cur, doc_root, from).ok_or_else(|| {
+        syn::Error::new(
+          Span::call_site(),
+          format!("rename: path `{from}` does not exist in the current schema"),
+        )
+      })?;
+      let entry = cur.remove(&from_res).unwrap();
+      let to_res = resolve_path(cur, doc_root, to).unwrap_or_else(|| {
+        if doc_root.is_empty() {
+          to.to_string()
+        } else {
+          format!("{doc_root}.{to}")
+        }
+      });
+      if cur.contains_key(&to_res) {
+        return Err(syn::Error::new(
+          Span::call_site(),
+          format!("rename: target `{to}` already exists in the simulated state"),
+        ));
+      }
+      let mut new_entry = entry.clone();
+      // An enum-variant node's type is the variant name; it follows the rename.
+      let from_leaf = from.rsplit('.').next().unwrap_or(from);
+      if new_entry.ty == from_leaf {
+        new_entry.ty = to.rsplit('.').next().unwrap_or(to).to_string();
+      }
+      new_entry.path = to_res.clone();
+      cur.insert(to_res.clone(), new_entry);
+      remap_children(cur, &from_res, &to_res);
+      Ok(())
+    }
+    Op::Move { from, to } => {
+      let from_res = resolve_path(cur, doc_root, from).ok_or_else(|| {
+        syn::Error::new(
+          Span::call_site(),
+          format!("move: path `{from}` does not exist in the current schema"),
+        )
+      })?;
+      let entry = cur.remove(&from_res).unwrap();
+      let to_res = resolve_path(cur, doc_root, to).unwrap_or_else(|| {
+        if doc_root.is_empty() {
+          to.to_string()
+        } else {
+          format!("{doc_root}.{to}")
+        }
+      });
+      if cur.contains_key(&to_res) {
+        return Err(syn::Error::new(
+          Span::call_site(),
+          format!("move: target `{to}` already exists in the simulated state"),
+        ));
+      }
+      let mut new_entry = entry.clone();
+      let from_leaf = from.rsplit('.').next().unwrap_or(from);
+      if new_entry.ty == from_leaf {
+        new_entry.ty = to.rsplit('.').next().unwrap_or(to).to_string();
+      }
+      new_entry.path = to_res.clone();
+      cur.insert(to_res.clone(), new_entry);
+      remap_children(cur, &from_res, &to_res);
+      Ok(())
+    }
+    Op::Convert {
+      path,
+      from_ty,
+      to_ty,
+      default,
+      f,
+      ..
+    } => {
+      let resolved = match resolve_path(cur, doc_root, path) {
+        Some(p) => p,
+        None => {
+          // Missing path: allowed when the op only fills a default (a
+          // field introduced at this version). Otherwise it must exist.
+          if default.is_none() {
+            return Err(syn::Error::new(
+              Span::call_site(),
+              format!("convert: path `{path}` does not exist in the current schema"),
+            ));
+          }
+          if doc_root.is_empty() {
+            path.to_string()
+          } else {
+            format!("{doc_root}.{path}")
+          }
+        }
+      };
+      if !cur.contains_key(&resolved) {
+        // Field introduced at this version: register it so later ops
+        // can reference it.
+        let ty = to_ty.clone().unwrap_or_else(|| "Value".to_string());
+        cur.insert(
+          resolved.clone(),
+          PathEntry {
+            path: resolved.clone(),
+            ty,
+            kind: NodeKind::Leaf,
+          },
+        );
+      }
+      let entry = cur.get_mut(&resolved).unwrap();
+      // A custom helper defines the conversion itself; the `from X to Y`
+      // annotation is documentation and is not enforced against the
+      // symbol table. Without a helper the built-in whitelist applies.
+      if let (Some(ft), Some(tt)) = (from_ty, to_ty) {
+        if f.is_none() {
+          if entry.ty != *ft {
+            return Err(syn::Error::new(
+              Span::call_site(),
+              format!(
+                "convert: path `{path}` has type `{}` in the current schema, but the op claims it is `{ft}`",
+                entry.ty
+              ),
+            ));
+          }
+          if !is_convertible(ft, tt) {
+            return Err(syn::Error::new(
+              Span::call_site(),
+              format!("convert: no known conversion from `{ft}` to `{tt}`"),
+            ));
+          }
+        }
+        entry.ty = tt.clone();
+      }
+      Ok(())
+    }
+    Op::Remove { path } => {
+      let resolved = resolve_path(cur, doc_root, path).ok_or_else(|| {
+        syn::Error::new(
+          Span::call_site(),
+          format!("remove: path `{path}` does not exist in the current schema"),
+        )
+      })?;
+      remove_subtree(cur, &resolved);
+      Ok(())
+    }
+  }
+}
+
+fn item_name(item: &ItemDef) -> String {
+  match item {
+    ItemDef::Struct(s) => s.name.to_string(),
+    ItemDef::Enum(e) => e.name.to_string(),
+  }
+}
+
+/// Serialize a parsed model back into declaration tokens (for structstruck).
+fn item_def_to_tokens(item: &ItemDef) -> TS2 {
+  match item {
+    ItemDef::Struct(s) => {
+      let name = &s.name;
+      let fields = s.fields.iter().map(|(n, t)| {
+        let n = n;
+        let t = field_ty_to_tokens(t);
+        quote!(#n: #t)
+      });
+      quote!(struct #name { #(#fields,)* })
+    }
+    ItemDef::Enum(e) => {
+      let name = &e.name;
+      let variants = e.variants.iter().map(|v| {
+        let vname = &v.name;
+        match &v.fields {
+          VariantFields::Named(fs) => {
+            let fields = fs.iter().map(|(n, t)| {
+              let n = n;
+              let t = field_ty_to_tokens(t);
+              quote!(#n: #t)
+            });
+            quote!(#vname { #(#fields,)* })
+          }
+          // Tuple payloads are not retained in the model; emit as unit.
+          VariantFields::Tuple | VariantFields::Unit => quote!(#vname),
+        }
+      });
+      quote!(enum #name { #(#variants,)* })
+    }
+  }
+}
+
+fn field_ty_to_tokens(ft: &FieldTy) -> TS2 {
+  match ft {
+    FieldTy::Leaf(t) => quote!(#t),
+    FieldTy::Nested(item) => item_def_to_tokens(item),
+  }
+}
+
+/// Resolve an op path to its canonical symbol-table path. Ops address the
+/// document, which is the first root model; in a multi-root schema a path that
+/// isn't present verbatim is also accepted with the document root prefixed
+/// (`a.b` == `LauncherConfig.a.b`).
+fn resolve_path(table: &SymbolTable, doc_root: &str, path: &str) -> Option<String> {
+  if table.contains_key(path) {
+    return Some(path.to_string());
+  }
+  if !doc_root.is_empty() {
+    let prefixed = format!("{doc_root}.{path}");
+    if table.contains_key(&prefixed) {
+      return Some(prefixed);
+    }
+  }
+  None
+}
+
+/// Whether a model's subtree exists in the symbol table (a model has no entry
+/// for its own name; only its descendant paths, e.g. `ServerConfig.host`).
+fn has_model(cur: &SymbolTable, name: &str) -> bool {
+  cur
+    .keys()
+    .any(|k| k == name || k.starts_with(&format!("{name}.")))
+}
+
+/// Flatten a single model with its type name as path prefix (added models are
+/// always name-prefixed, matching a multi-root schema).
+fn flatten_added_model(item: &ItemDef, reg: &TypeRegistry) -> Result<SymbolTable, syn::Error> {
+  let mut table = SymbolTable::new();
+  let name = item_name(item);
+  let mut stack = vec![name.clone()];
+  match item {
+    ItemDef::Struct(_) => flatten_named(&name, &name, reg, &mut table, &mut stack)?,
+    ItemDef::Enum(e) => {
+      for v in &e.variants {
+        let vpath = format!("{name}.{}", v.name);
+        let (kind, fields) = match &v.fields {
+          VariantFields::Named(fs) => {
+            let fields: Vec<(String, String)> = fs
+              .iter()
+              .map(|(n, t)| (n.to_string(), field_ty_name(t)))
+              .collect();
+            (NodeKind::Struct, fields)
+          }
+          _ => (NodeKind::Leaf, Vec::new()),
+        };
+        let vreg = VariantReg {
+          name: v.name.to_string(),
+          kind,
+          fields,
+        };
+        flatten_variant(&vpath, &vreg, reg, &mut table, &mut stack)?;
+      }
+    }
+  }
+  Ok(table)
+}
+
+fn add_to_registry(reg: &mut TypeRegistry, item: &ItemDef) {
+  match item {
+    ItemDef::Struct(s) => {
+      let fields: Vec<(String, String)> = s
+        .fields
+        .iter()
+        .map(|(n, t)| (n.to_string(), field_ty_name(t)))
+        .collect();
+      reg.structs.insert(s.name.to_string(), fields);
+    }
+    ItemDef::Enum(e) => {
+      let mut variants = Vec::new();
+      for v in &e.variants {
+        let (kind, fields) = match &v.fields {
+          VariantFields::Named(fs) => {
+            let fields: Vec<(String, String)> = fs
+              .iter()
+              .map(|(n, t)| (n.to_string(), field_ty_name(t)))
+              .collect();
+            (NodeKind::Struct, fields)
+          }
+          _ => (NodeKind::Leaf, Vec::new()),
+        };
+        variants.push(VariantReg {
+          name: v.name.to_string(),
+          kind,
+          fields,
+        });
+      }
+      reg.enums.insert(e.name.to_string(), variants);
+    }
+  }
+}
+
+/// Move all entries whose path starts with `old` prefix to `new` prefix.
+fn remap_children(table: &mut SymbolTable, old: &str, new: &str) {
+  let old_prefix = format!("{old}.");
+  let children: Vec<(String, PathEntry)> = table
+    .iter()
+    .filter(|(p, _)| p.starts_with(&old_prefix))
+    .map(|(p, e)| (p.clone(), e.clone()))
+    .collect();
+  for (p, mut e) in children {
+    table.remove(&p);
+    let new_path = format!("{new}{}", &p[old.len()..]);
+    e.path = new_path.clone();
+    table.insert(new_path, e);
+  }
+}
+
+/// Remove a path and all its descendants from the table.
+fn remove_subtree(table: &mut SymbolTable, path: &str) {
+  let prefix = format!("{path}.");
+  let keys: Vec<String> = table
+    .keys()
+    .filter(|p| *p == path || p.starts_with(&prefix))
+    .cloned()
+    .collect();
+  for k in keys {
+    table.remove(&k);
+  }
+}
+
+/// Known type conversions (stringly-typed whitelist).
+fn is_convertible(from: &str, to: &str) -> bool {
+  const NUMERIC: &[&str] = &["i32", "i64", "u32", "u64", "f32", "f64", "usize", "isize"];
+  if from == to {
+    return true;
+  }
+  if NUMERIC.contains(&from) && NUMERIC.contains(&to) {
+    return true;
+  }
+  if from == "String" && NUMERIC.contains(&to) {
+    return true;
+  }
+  matches!((from, to), ("bool", "String") | ("String", "bool"))
+}
+
+// ---------------------------------------------------------------------------
+// Codegen
+// ---------------------------------------------------------------------------
+
+/// Detect whether the user already manages derives on a declaration via
+/// `#[structstruck::each[...]]`, the deprecated `#[strikethrough[...]]`, or a
+/// plain `#[derive(...)]`. If so we must NOT inject our own `each` (two `each`s
+/// would both apply their derives -> duplicate `derive` impls).
+fn has_user_each(schema_tokens: &TS2) -> bool {
+  fn scan(ts: &TS2) -> bool {
+    let toks: Vec<TokenTree> = ts.clone().into_iter().collect();
+    for w in toks.windows(4) {
+      if let (TokenTree::Ident(i), TokenTree::Punct(a), TokenTree::Punct(b), TokenTree::Ident(e)) =
+        (&w[0], &w[1], &w[2], &w[3])
+        && i == "structstruck"
+        && a.as_char() == ':'
+        && b.as_char() == ':'
+        && (e == "each" || e == "strikethrough")
+      {
+        return true;
+      }
+    }
+    for tt in &toks {
+      match tt {
+        TokenTree::Ident(i) if i == "strikethrough" || i == "each" || i == "derive" => return true,
+        TokenTree::Group(g) if scan(&g.stream()) => return true,
+        _ => {}
+      }
+    }
+    false
+  }
+  scan(schema_tokens)
+}
+
+/// Inject `#[structstruck::each[derive(...)]]` before every top-level
+/// `struct`/`enum` keyword in the raw schema tokens, so structstruck applies
+/// serde derives to all generated types. Skipped if the user manages derives
+/// themselves via `structstruck::each`.
+fn inject_each(schema_tokens: TS2) -> TS2 {
+  let toks: Vec<TokenTree> = schema_tokens.into_iter().collect();
+  let inject = !has_user_each(&toks.clone().into_iter().collect::<TS2>());
+  let each = each_attr();
+  let mut out = TS2::new();
+  let mut depth = 0u32;
+  let mut i = 0usize;
+  while i < toks.len() {
+    match &toks[i] {
+      TokenTree::Group(_) => {
+        depth += 1;
+        out.extend([toks[i].clone()]);
+        depth -= 1;
+        i += 1;
+      }
+      TokenTree::Punct(p) if depth == 0 && p.as_char() == '#' => {
+        // `#[aux]` is a DSL marker, not a Rust attribute: drop it so it
+        // isn't forwarded to structstruck (Rust would reject the unknown attr).
+        if i + 1 < toks.len() && is_aux_attr(&toks[i + 1]) {
+          i += 2;
+          continue;
+        }
+        out.extend([toks[i].clone()]);
+        i += 1;
+      }
+      TokenTree::Ident(id) => {
+        let s = id.to_string();
+        if inject && depth == 0 && (s == "struct" || s == "enum") {
+          out.extend(each.clone());
+        }
+        out.extend([TokenTree::Ident(id.clone())]);
+        i += 1;
+      }
+      other => {
+        out.extend([other.clone()]);
+        i += 1;
+      }
+    }
+  }
+  out
+}
+
+/// Split the raw schema tokens into per-top-level-declaration token streams.
+///
+/// `structstruck::strike!` only processes the FIRST top-level declaration
+/// (`lib.rs` calls `recurse_through_definition` once), so each top-level
+/// `struct`/`enum` (with its leading attributes/visibility) must go through its
+/// own `strike!` call.
+///
+/// A declaration runs from a top-level `struct`/`enum` keyword (plus its
+/// leading preamble: `#[aux]`, `pub`, ...) through its `{ ... }` body. Anything
+/// after the body is the preamble of the NEXT declaration.
+fn split_top_levels(schema_tokens: &TS2) -> Vec<TS2> {
+  let toks: Vec<TokenTree> = schema_tokens.clone().into_iter().collect();
+  let mut decls: Vec<TS2> = Vec::new();
+  let mut pending: Vec<TokenTree> = Vec::new();
+  let mut cur: Vec<TokenTree> = Vec::new();
+  let mut in_decl = false;
+  let mut i = 0usize;
+  while i < toks.len() {
+    let tt = &toks[i];
+    if !in_decl {
+      if let TokenTree::Ident(id) = tt {
+        if id == "struct" || id == "enum" {
+          if !cur.is_empty() {
+            decls.push(cur.drain(..).collect());
+          }
+          cur.append(&mut pending);
+          cur.push(tt.clone());
+          in_decl = true;
+          i += 1;
+          continue;
+        }
+      }
+      pending.push(tt.clone());
+    } else {
+      cur.push(tt.clone());
+      // The `{ ... }` body closes the declaration; afterwards the stream
+      // belongs to the next declaration's preamble.
+      if matches!(tt, TokenTree::Group(g) if g.delimiter() == proc_macro2::Delimiter::Brace) {
+        in_decl = false;
+      }
+    }
+    i += 1;
+  }
+  if !cur.is_empty() {
+    decls.push(cur.into_iter().collect());
+  }
+  decls
+}
+
+/// The serde derive `each` attribute we inject for generated types.
+fn each_attr() -> TS2 {
+  quote!(
+      #[structstruck::each[derive(::serde::Serialize, ::serde::Deserialize, Clone, Debug)]]
+  )
+}
+
+/// `#[aux]` appears as a bracket group whose first token is `aux`.
+fn is_aux_attr(tt: &TokenTree) -> bool {
+  let TokenTree::Group(g) = tt else {
+    return false;
+  };
+  if g.delimiter() != proc_macro2::Delimiter::Bracket {
+    return false;
+  }
+  matches!(
+      g.stream().into_iter().next(),
+      Some(TokenTree::Ident(i)) if i == "aux"
+  )
+}
+
+fn op_to_tokens(op: &Op, convert_fields: &[ConvertField]) -> TS2 {
+  match op {
+    // Model-level ops translate to runtime ops (schema change = runtime change).
+    Op::AddModel { .. } => {
+      // No runtime effect: the model's fields are introduced via
+      // `convert` ops with defaults.
+      quote! {}
+    }
+    Op::RemoveModel { name } => {
+      quote! { ::sjmcl_migration::Op::Remove { path: #name.into() } }
+    }
+    Op::RenameModel { from, to } => {
+      quote! { ::sjmcl_migration::Op::Rename { from: #from.into(), to: #to.into() } }
+    }
+    Op::Rename { from, to } => {
+      quote! { ::sjmcl_migration::Op::Rename { from: #from.into(), to: #to.into() } }
+    }
+    Op::Move { from, to } => {
+      quote! { ::sjmcl_migration::Op::Move { from: #from.into(), to: #to.into() } }
+    }
+    Op::Convert {
+      path,
+      from_ty,
+      to_ty,
+      default,
+      f,
+    } => {
+      let from_ty_ts = from_ty
+        .as_ref()
+        .map(|t| quote! { Some(#t.into()) })
+        .unwrap_or(quote! { None });
+      let to_ty_ts = to_ty
+        .as_ref()
+        .map(|t| quote! { Some(#t.into()) })
+        .unwrap_or(quote! { None });
+      let default_ts = default
+        .as_ref()
+        .map(|v| quote! { Some(::serde_json::json!(#v)) })
+        .unwrap_or(quote! { None });
+      // Helper resolution: explicit `=> fn` wins; otherwise fall back to
+      // the model-level `convert_field` registration for this path.
+      let f_ts = f
+        .as_ref()
+        .map(|fn_path| quote! { Some(#fn_path) })
+        .or_else(|| {
+          convert_fields.iter().find(|cf| cf.path == *path).map(|cf| {
+            let fn_path = &cf.f;
+            quote! { Some(#fn_path) }
+          })
+        })
+        .unwrap_or(quote! { None });
+      quote! {
+          ::sjmcl_migration::Op::Convert {
+              path: #path.into(),
+              from_ty: #from_ty_ts,
+              to_ty: #to_ty_ts,
+              default: #default_ts,
+              f: #f_ts,
+          }
+      }
+    }
+    Op::Remove { path } => {
+      quote! { ::sjmcl_migration::Op::Remove { path: #path.into() } }
+    }
+  }
+}
+
+fn codegen(
+  final_schema_tokens: &TS2,
+  migrations: &[Migration],
+  root_ident: &Ident,
+  max_version: Version,
+  convert_fields: &[ConvertField],
+) -> TS2 {
+  // `strike!` only processes the first top-level declaration, so each top-level
+  // struct/enum (root + every `#[aux]`) gets its own `strike!` call.
+  let baseline_strikes: Vec<TS2> = split_top_levels(final_schema_tokens)
+    .into_iter()
+    .map(|decl| {
+      let injected = inject_each(decl);
+      quote! {
+          ::structstruck::strike! { #injected }
+      }
+    })
+    .collect();
+
+  // Models introduced via `add_model` are also generated (their attributes
+  // apply to the real type).
+  let added_strikes: Vec<TS2> = migrations
+    .iter()
+    .flat_map(|m| m.ops.iter())
+    .filter_map(|op| match op {
+      Op::AddModel { raw, .. } => Some(raw.clone()),
+      _ => None,
+    })
+    .map(|raw| {
+      let injected = inject_each(raw);
+      quote! {
+          ::structstruck::strike! { #injected }
+      }
+    })
+    .collect();
+
+  let mig_descs: Vec<_> = migrations
+    .iter()
+    .map(|m| {
+      let from = m.from.to_tokens();
+      let to = m.to.to_tokens();
+      // Model-level ops may translate to no runtime op (AddModel); drop
+      // empty entries so `vec![...]` stays well-formed.
+      let ops: Vec<_> = m
+        .ops
+        .iter()
+        .map(|op| op_to_tokens(op, convert_fields))
+        .filter(|t| !t.is_empty())
+        .collect();
+      quote! {
+          ::sjmcl_migration::Migration {
+              from: #from,
+              to: #to,
+              ops: vec![ #(#ops,)* ],
+          }
+      }
+    })
+    .collect();
+
+  let max_version_ts = max_version.to_tokens();
+  quote! {
+      /// Real Rust types generated by structstruck from the schema block
+      /// (one `strike!` per top-level declaration), plus every `add_model`.
+      #(#baseline_strikes)*
+      #(#added_strikes)*
+
+      /// The settings root type (first declared struct).
+      pub type SettingsRoot = #root_ident;
+
+      /// Statically registered migration set (lazily built).
+      pub static MIGRATIONS: std::sync::LazyLock<Vec<::sjmcl_migration::Migration>> =
+          std::sync::LazyLock::new(|| vec![ #(#mig_descs,)* ]);
+
+      pub mod __migration_meta {
+          pub const MAX_VERSION: ::sjmcl_migration::Version = #max_version_ts;
+      }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+pub fn migrations_impl(input: TokenStream) -> TokenStream {
+  let input = parse_macro_input!(input as MigrationsInput);
+
+  let (schemas, migrations) = (input.schemas, input.migrations);
+
+  match validate(&schemas, &migrations) {
+    Ok(_) => {}
+    Err(errors) => {
+      let errs: Vec<_> = errors.into_iter().map(|e| e.to_compile_error()).collect();
+      return quote! { #(#errs)* }.into();
+    }
+  }
+
+  // The highest declared version is the final schema (used to generate types).
+  let final_block = schemas
+    .iter()
+    .max_by_key(|s| s.version)
+    .expect("at least one schema block");
+  let root_ident = final_block
+    .roots
+    .iter()
+    .find_map(|i| match i {
+      ItemDef::Struct(s) => Some(s.name.clone()),
+      ItemDef::Enum(_) => None,
+    })
+    .unwrap_or_else(|| Ident::new("SettingsRoot", Span::call_site()));
+  let max_version = migrations.iter().map(|m| m.to).max().unwrap_or(Version {
+    major: 1,
+    minor: 0,
+    patch: 0,
+  });
+
+  let output = codegen(
+    &final_block.raw_tokens,
+    &migrations,
+    &root_ident,
+    max_version,
+    &final_block.convert_fields,
+  );
+  output.into()
+}

--- a/src-tauri/crates/sjmcl-migration/Cargo.toml
+++ b/src-tauri/crates/sjmcl-migration/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "sjmcl-migration"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true

--- a/src-tauri/crates/sjmcl-migration/src/lib.rs
+++ b/src-tauri/crates/sjmcl-migration/src/lib.rs
@@ -1,0 +1,395 @@
+//! Runtime data model + migration engine for the migration DSL.
+//!
+//! The `migrations!` proc macro expands to `Migration`/`Op` static data that
+//! the engine in this crate executes against `serde_json::Value` documents.
+
+use serde_json::{Map, Value};
+
+/// A three-part version `major.minor.patch`, ordered lexicographically.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Version {
+  pub major: u32,
+  pub minor: u32,
+  pub patch: u32,
+}
+
+impl Version {
+  pub fn new(major: u32, minor: u32, patch: u32) -> Self {
+    Version {
+      major,
+      minor,
+      patch,
+    }
+  }
+
+  /// Parse a `"major.minor.patch"` string (any or all trailing parts optional).
+  pub fn parse(s: &str) -> Result<Self, MigrationError> {
+    let mut parts = s.split('.');
+    let major = parts
+      .next()
+      .ok_or_else(|| MigrationError::MissingVersion("empty version string".into()))?
+      .parse::<u32>()
+      .map_err(|_| MigrationError::MissingVersion(format!("invalid version `{s}`")))?;
+    let minor = parts
+      .next()
+      .map(|p| p.parse::<u32>())
+      .transpose()
+      .map_err(|_| MigrationError::MissingVersion(format!("invalid version `{s}`")))?
+      .unwrap_or(0);
+    let patch = parts
+      .next()
+      .map(|p| p.parse::<u32>())
+      .transpose()
+      .map_err(|_| MigrationError::MissingVersion(format!("invalid version `{s}`")))?
+      .unwrap_or(0);
+    if parts.next().is_some() {
+      return Err(MigrationError::MissingVersion(format!(
+        "version `{s}` has more than three parts"
+      )));
+    }
+    Ok(Version {
+      major,
+      minor,
+      patch,
+    })
+  }
+}
+
+impl std::fmt::Display for Version {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+  }
+}
+
+/// A single migration step from `from` to `to` (adjacent versions).
+pub struct Migration {
+  pub from: Version,
+  pub to: Version,
+  pub ops: Vec<Op>,
+}
+
+/// A declarative operation applied during a migration.
+pub enum Op {
+  Rename {
+    from: String,
+    to: String,
+  },
+  Move {
+    from: String,
+    to: String,
+  },
+  /// Convert the value at `path`.
+  ///
+  /// - `default: Some(v)` — fill `v` when the path is missing
+  /// - `f: Some(fn)` — invoke the helper on the existing value
+  /// - otherwise — built-in whitelist conversion (`convert_value`)
+  Convert {
+    path: String,
+    from_ty: Option<String>,
+    to_ty: Option<String>,
+    default: Option<Value>,
+    f: Option<fn(&Value) -> Result<Value, MigrationError>>,
+  },
+  Remove {
+    path: String,
+  },
+}
+
+/// Errors produced while applying a migration to a document.
+#[derive(Debug)]
+pub enum MigrationError {
+  MissingVersion(String),
+  NoPath(Version, Version),
+  MissingPath(String),
+  TypeMismatch(String),
+  Json(serde_json::Error),
+}
+
+impl std::fmt::Display for MigrationError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      MigrationError::MissingVersion(m) => {
+        write!(f, "cannot read version from document: {m}")
+      }
+      MigrationError::NoPath(c, t) => write!(
+        f,
+        "no migration path from version {c} to target version {t}"
+      ),
+      MigrationError::MissingPath(p) => {
+        write!(f, "path `{p}` does not exist in the document")
+      }
+      MigrationError::TypeMismatch(t) => write!(f, "path has wrong type: {t}"),
+      MigrationError::Json(e) => write!(f, "JSON error: {e}"),
+    }
+  }
+}
+
+impl std::error::Error for MigrationError {
+  fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+    match self {
+      MigrationError::Json(e) => Some(e),
+      _ => None,
+    }
+  }
+}
+
+impl From<serde_json::Error> for MigrationError {
+  fn from(e: serde_json::Error) -> Self {
+    MigrationError::Json(e)
+  }
+}
+
+/// Run all forward migrations needed to bring `doc` from its current version
+/// (read from `version_key`) up to `target_version` (or the highest registered
+/// `to` if `None`).
+///
+/// Documents written before versioning was introduced have no `version_key`;
+/// those fall back to the chain-start version (the first migration's `from`)
+/// so the declared migration steps still apply.
+pub fn migrate(
+  doc: &mut Value,
+  migrations: &[Migration],
+  target: Option<Version>,
+  version_key: &str,
+) -> Result<(), MigrationError> {
+  let fallback = migrations.first().map(|m| m.from);
+  let current = read_version(doc, fallback, version_key)?;
+  let target = target.unwrap_or_else(|| migrations.iter().map(|m| m.to).max().unwrap_or(current));
+  if target < current {
+    return Err(MigrationError::NoPath(current, target));
+  }
+  if target == current {
+    return Ok(());
+  }
+
+  // Walk the chain from `current` towards `target` in ascending order.
+  let mut cursor = current;
+  while cursor < target {
+    let step = migrations
+      .iter()
+      .find(|m| m.from == cursor)
+      .ok_or(MigrationError::NoPath(cursor, target))?;
+    apply_migration(doc, step, version_key)?;
+    cursor = step.to;
+  }
+  Ok(())
+}
+
+fn read_version(
+  doc: &Value,
+  fallback: Option<Version>,
+  key: &str,
+) -> Result<Version, MigrationError> {
+  match doc.get(key) {
+    Some(Value::String(s)) => Version::parse(s),
+    Some(Value::Number(n)) => n
+      .as_u64()
+      .map(|v| Version {
+        major: v as u32,
+        minor: 0,
+        patch: 0,
+      })
+      .ok_or_else(|| MigrationError::MissingVersion("version is not a positive integer".into())),
+    _ => fallback.ok_or_else(|| MigrationError::MissingVersion(format!("missing `{key}` key"))),
+  }
+}
+
+fn apply_migration(
+  doc: &mut Value,
+  m: &Migration,
+  version_key: &str,
+) -> Result<(), MigrationError> {
+  for op in &m.ops {
+    apply_op(doc, op)?;
+  }
+  if let Some(obj) = doc.as_object_mut() {
+    obj.insert(version_key.to_string(), Value::String(m.to.to_string()));
+  } else {
+    return Err(MigrationError::MissingVersion(
+      "root is not an object".into(),
+    ));
+  }
+  Ok(())
+}
+
+fn apply_op(doc: &mut Value, op: &Op) -> Result<(), MigrationError> {
+  match op {
+    Op::Rename { from, to } => {
+      let (from_parent, from_key) = split_path(from);
+      let Some(value) = take_optional(doc, from_parent, from_key)? else {
+        return Ok(());
+      };
+      set_at(doc, to, value)?;
+      Ok(())
+    }
+    Op::Move { from, to } => {
+      let (from_parent, from_key) = split_path(from);
+      let Some(value) = take_optional(doc, from_parent, from_key)? else {
+        return Ok(());
+      };
+      set_at(doc, to, value)?;
+      Ok(())
+    }
+    Op::Convert {
+      path,
+      to_ty,
+      default,
+      f,
+      ..
+    } => {
+      let Ok(value) = get_at(doc, path) else {
+        // Missing path: fill the default when declared, otherwise no-op.
+        if let Some(v) = default {
+          set_at(doc, path, v.clone())?;
+        }
+        return Ok(());
+      };
+      let converted = match f {
+        Some(f) => f(value)?,
+        None => match to_ty {
+          Some(tt) => convert_value(value, tt)?,
+          None => value.clone(),
+        },
+      };
+      set_at(doc, path, converted)?;
+      Ok(())
+    }
+    Op::Remove { path } => {
+      let (parent, key) = split_path(path);
+      let obj = get_at_mut(doc, parent)?
+        .as_object_mut()
+        .ok_or_else(|| MigrationError::TypeMismatch(parent.to_string()))?;
+      obj.remove(key);
+      Ok(())
+    }
+  }
+}
+
+/// Take a value at `parent.key` if present; `None` if the key (or parent) is
+/// absent. Lenient, so migrations can reference optional fields/enum variants
+/// that may not be present in a given document.
+fn take_optional(
+  doc: &mut Value,
+  parent: &str,
+  key: &str,
+) -> Result<Option<Value>, MigrationError> {
+  let Ok(parent_val) = get_at_mut(doc, parent) else {
+    return Ok(None);
+  };
+  let Some(obj) = parent_val.as_object_mut() else {
+    return Ok(None);
+  };
+  Ok(obj.remove(key))
+}
+
+fn convert_value(value: &Value, to_ty: &str) -> Result<Value, MigrationError> {
+  use serde_json::Number;
+  match to_ty {
+    "u64" | "u32" | "usize" => {
+      let n = value
+        .as_u64()
+        .or_else(|| value.as_str().and_then(|s| s.parse().ok()))
+        .ok_or(MigrationError::TypeMismatch("numeric".into()))?;
+      Ok(Value::Number(Number::from(n)))
+    }
+    "i64" | "i32" | "isize" => {
+      let n = value
+        .as_i64()
+        .or_else(|| value.as_str().and_then(|s| s.parse().ok()))
+        .ok_or(MigrationError::TypeMismatch("numeric".into()))?;
+      Ok(Value::Number(Number::from(n)))
+    }
+    "f64" | "f32" => {
+      let n = value
+        .as_f64()
+        .or_else(|| value.as_str().and_then(|s| s.parse().ok()))
+        .ok_or(MigrationError::TypeMismatch("float".into()))?;
+      Number::from_f64(n)
+        .map(Value::Number)
+        .ok_or(MigrationError::TypeMismatch("float".into()))
+    }
+    "String" => {
+      let s = match value {
+        Value::String(s) => s.clone(),
+        Value::Number(n) => n.to_string(),
+        Value::Bool(b) => b.to_string(),
+        _ => return Err(MigrationError::TypeMismatch("string convertible".into())),
+      };
+      Ok(Value::String(s))
+    }
+    "bool" => {
+      let b = value
+        .as_bool()
+        .or_else(|| {
+          value.as_str().and_then(|s| match s {
+            "true" => Some(true),
+            "false" => Some(false),
+            _ => None,
+          })
+        })
+        .ok_or(MigrationError::TypeMismatch("bool".into()))?;
+      Ok(Value::Bool(b))
+    }
+    _ => {
+      // Unknown target type: try serde_json number passthrough.
+      Ok(value.clone())
+    }
+  }
+}
+
+/// Split "a.b.c" into parent path ("a.b") and final key ("c").
+fn split_path(path: &str) -> (&str, &str) {
+  match path.rfind('.') {
+    Some(idx) => (&path[..idx], &path[idx + 1..]),
+    None => ("", path),
+  }
+}
+
+/// Navigate to the value at `path` (dotted). Empty path returns root.
+fn get_at<'a>(doc: &'a Value, path: &str) -> Result<&'a Value, MigrationError> {
+  if path.is_empty() {
+    return Ok(doc);
+  }
+  let mut cur = doc;
+  for seg in path.split('.') {
+    cur = cur
+      .get(seg)
+      .ok_or_else(|| MigrationError::MissingPath(path.to_string()))?;
+  }
+  Ok(cur)
+}
+
+/// Mutably navigate to the value at `path`. Empty path returns root.
+fn get_at_mut<'a>(doc: &'a mut Value, path: &str) -> Result<&'a mut Value, MigrationError> {
+  if path.is_empty() {
+    return Ok(doc);
+  }
+  let mut cur = doc;
+  for seg in path.split('.') {
+    cur = cur
+      .get_mut(seg)
+      .ok_or_else(|| MigrationError::MissingPath(path.to_string()))?;
+  }
+  Ok(cur)
+}
+
+/// Set `value` at `path`, creating intermediate objects as needed.
+fn set_at(doc: &mut Value, path: &str, value: Value) -> Result<(), MigrationError> {
+  if path.is_empty() {
+    *doc = value;
+    return Ok(());
+  }
+  let segs: Vec<&str> = path.split('.').collect();
+  let obj = doc
+    .as_object_mut()
+    .ok_or(MigrationError::TypeMismatch("root object".into()))?;
+  let mut cur = obj;
+  for seg in &segs[..segs.len() - 1] {
+    let entry = cur.entry(*seg).or_insert_with(|| Value::Object(Map::new()));
+    cur = entry
+      .as_object_mut()
+      .ok_or_else(|| MigrationError::TypeMismatch(seg.to_string()))?;
+  }
+  cur.insert((*segs[segs.len() - 1]).to_string(), value);
+  Ok(())
+}

--- a/src-tauri/src/account/helpers/authlib_injector/models.rs
+++ b/src-tauri/src/account/helpers/authlib_injector/models.rs
@@ -14,7 +14,7 @@ pub struct MinecraftProfile {
 }
 
 structstruck::strike! {
-  #[strikethrough[derive(serde::Deserialize, serde::Serialize)]]
+  #[structstruck::each[derive(serde::Deserialize, serde::Serialize)]]
   pub struct TextureInfo {
     pub textures: HashMap<String, pub struct {
       pub url: String,

--- a/src-tauri/src/account/helpers/microsoft/models.rs
+++ b/src-tauri/src/account/helpers/microsoft/models.rs
@@ -21,7 +21,7 @@ pub struct TextureEntry {
 }
 
 structstruck::strike! {
-#[strikethrough[derive(Deserialize)]]
+#[structstruck::each[derive(Deserialize)]]
   pub struct XstsResponse {
     #[serde(rename = "Token")]
     pub token: String,

--- a/src-tauri/src/account/models.rs
+++ b/src-tauri/src/account/models.rs
@@ -233,8 +233,8 @@ pub struct OAuthErrorResponse {
 }
 
 structstruck::strike! {
-  #[strikethrough[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize, Default)]]
-  #[strikethrough[serde(rename_all = "camelCase", deny_unknown_fields)]]
+  #[structstruck::each[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize, Default)]]
+  #[structstruck::each[serde(rename_all = "camelCase", deny_unknown_fields)]]
   pub struct AuthServer {
     pub name: String,
     pub auth_url: String,

--- a/src-tauri/src/extension/models.rs
+++ b/src-tauri/src/extension/models.rs
@@ -6,8 +6,8 @@ use strum_macros::Display;
 use crate::utils::image::ImageWrapper;
 
 structstruck::strike! {
-  #[strikethrough[derive(Debug, Clone, Serialize, Deserialize)]]
-  #[strikethrough[serde(rename_all = "camelCase")]]
+  #[structstruck::each[derive(Debug, Clone, Serialize, Deserialize)]]
+  #[structstruck::each[serde(rename_all = "camelCase")]]
   pub struct ExtensionMetadata {
     pub identifier: String,
     pub name: String,

--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -51,9 +51,9 @@ use crate::instance::helpers::server::{
 };
 use crate::instance::helpers::world::{load_level_data_from_nbt, load_world_info_from_dir};
 use crate::instance::models::misc::{
-  Instance, InstanceError, InstanceSubdirType, InstanceSummary, LocalModInfo, ModLoader,
-  ModLoaderStatus, ModLoaderType, ModpackFileList, OptiFine, ResourcePackInfo, SchematicInfo,
-  ScreenshotInfo, ShaderPackInfo,
+  __migration_meta, Instance, InstanceError, InstanceSubdirType, InstanceSummary, LocalModInfo,
+  ModLoader, ModLoaderStatus, ModLoaderType, ModpackFileList, OptiFine, ResourcePackInfo,
+  SchematicInfo, ScreenshotInfo, ShaderPackInfo,
 };
 use crate::instance::models::world::base::WorldInfo;
 use crate::instance::models::world::level::LevelData;
@@ -1077,6 +1077,7 @@ pub async fn create_instance(
 
   // Create instance config
   let instance = Instance {
+    config_version: __migration_meta::MAX_VERSION.to_string(),
     id: format!("{}:{}", directory.name, name.clone()),
     name: name.clone(),
     version: game.id.clone(),

--- a/src-tauri/src/instance/helpers/loader/forge.rs
+++ b/src-tauri/src/instance/helpers/loader/forge.rs
@@ -497,8 +497,8 @@ pub struct InstallProfile {
 }
 
 structstruck::strike! {
-#[strikethrough[derive(Debug, Serialize, Deserialize, Default)]]
-#[strikethrough[serde(rename_all = "camelCase", default)]]
+#[structstruck::each[derive(Debug, Serialize, Deserialize, Default)]]
+#[structstruck::each[serde(rename_all = "camelCase", default)]]
 pub struct LegacyInstallProfile {
   pub install: struct {
     pub path: String,

--- a/src-tauri/src/instance/helpers/modpack/curseforge.rs
+++ b/src-tauri/src/instance/helpers/modpack/curseforge.rs
@@ -34,8 +34,8 @@ pub struct CurseForgeFiles {
 }
 
 structstruck::strike! {
-#[strikethrough[derive(Deserialize, Serialize, Debug, Clone)]]
-#[strikethrough[serde(rename_all = "camelCase")]]
+#[structstruck::each[derive(Deserialize, Serialize, Debug, Clone)]]
+#[structstruck::each[serde(rename_all = "camelCase")]]
   pub struct CurseForgeManifest {
     pub name: String,
     pub version: Option<String>,
@@ -50,8 +50,8 @@ structstruck::strike! {
 }
 
 structstruck::strike! {
-#[strikethrough[derive(Deserialize, Serialize, Debug, Clone)]]
-#[strikethrough[serde(rename_all = "camelCase")]]
+#[structstruck::each[derive(Deserialize, Serialize, Debug, Clone)]]
+#[structstruck::each[serde(rename_all = "camelCase")]]
   pub struct CurseForgeFileManifest {
     pub data: struct {
       pub download_url: Option<String>,

--- a/src-tauri/src/instance/helpers/modpack/modrinth.rs
+++ b/src-tauri/src/instance/helpers/modpack/modrinth.rs
@@ -27,9 +27,9 @@ use crate::tasks::PTaskParam;
 use crate::tasks::download::DownloadParam;
 
 structstruck::strike! {
-#[strikethrough[serialize_skip_none]]
-#[strikethrough[derive(Deserialize, Serialize, Debug, Clone)]]
-#[strikethrough[serde(rename_all = "camelCase")]]
+#[structstruck::each[serialize_skip_none]]
+#[structstruck::each[derive(Deserialize, Serialize, Debug, Clone)]]
+#[structstruck::each[serde(rename_all = "camelCase")]]
 pub struct ModrinthFile {
   pub path: String,
   pub hashes: struct ModrinthFileHashes {

--- a/src-tauri/src/instance/helpers/modpack/multimc.rs
+++ b/src-tauri/src/instance/helpers/modpack/multimc.rs
@@ -38,8 +38,8 @@ pub struct MultiMcComponent {
 }
 
 structstruck::strike! {
-#[strikethrough[derive(Deserialize, Serialize, Debug, Clone)]]
-#[strikethrough[serde(rename_all = "camelCase")]]
+#[structstruck::each[derive(Deserialize, Serialize, Debug, Clone)]]
+#[structstruck::each[serde(rename_all = "camelCase")]]
   pub struct MultiMcManifest {
     pub components: Vec<MultiMcComponent>,
     pub format_version: u64,

--- a/src-tauri/src/instance/models/misc.rs
+++ b/src-tauri/src/instance/models/misc.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
-use sjmcl_types::storage::{load_json_async, save_json_async};
+use serde_json::Value;
+use sjmcl_migration::migrate;
+use sjmcl_types::storage::save_json_async;
+use smart_default::SmartDefault;
 use std::cmp::{Ord, Ordering, PartialOrd};
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -26,16 +29,73 @@ pub enum InstanceSubdirType {
   ShaderPacks,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Deserialize, Serialize, Default, Display)]
-pub enum ModLoaderType {
-  #[default]
-  Unknown,
-  Fabric,
-  Forge,
-  LegacyForge,
-  NeoForge,
-  LiteLoader,
-  Quilt,
+sjmcl_macros::migrations! {
+  schema v1.2.0 {
+    #[structstruck::each[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize, SmartDefault)]]
+    #[structstruck::each[serde(rename_all = "camelCase", default)]]
+    pub struct Instance {
+      // Config format version (the `version` field is the Minecraft version).
+      #[default(_code = "__migration_meta::MAX_VERSION.to_string()")]
+      pub config_version: String,
+      pub id: String,
+      pub name: String,
+      pub description: String,
+      pub tag: Option<String>,
+      pub icon_src: String,
+      pub starred: bool,
+      pub play_time: u128,
+      pub version: String,
+      pub version_path: PathBuf,
+      pub mod_loader: struct {
+        pub status: ModLoaderStatus,
+        pub loader_type: ModLoaderType,
+        pub version: String,
+        pub branch: Option<String>, // Optional branch name for mod loaders like Forge
+      },
+      pub optifine: Option<OptiFine>,
+      // if true, use the spec_game_config, else use the global game config
+      pub use_spec_game_config: bool,
+      // if use_spec_game_config is false, this field is ignored
+      pub spec_game_config: Option<GameConfig>,
+      pub modpack_version: Option<String>,
+    }
+    #[aux]
+    #[derive(Debug, PartialEq, Eq, Clone, Copy, Deserialize, Serialize, Default, Display)]
+    pub enum ModLoaderType {
+      #[default]
+      Unknown,
+      Fabric,
+      Forge,
+      LegacyForge,
+      NeoForge,
+      LiteLoader,
+      Quilt,
+    }
+    #[aux]
+    #[derive(Debug, PartialEq, Eq, Deserialize, Clone, Serialize, Default)]
+    pub enum ModLoaderStatus {
+      NotDownloaded, // mod loader's library has not been downloaded
+      DownloadFailed, /* mod loader's library download process failed (including processor installation failed)
+                      Only when SJMCL restart, it will try to re-download library while making no changes to client info JSON (is_retry = true),
+                      and do following steps */
+      Downloading, // mod loader's library download process is ongoing
+      Installing,  // mod loader's library has been downloaded, and installation processors are working
+      #[default]
+      Installed,
+    }
+    #[aux]
+    #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize, Default)]
+    #[serde(rename_all = "camelCase")]
+    pub struct OptiFine {
+      pub filename: String,
+      pub version: String,
+      pub status: ModLoaderStatus,
+    }
+  }
+  // Legacy instance configs (written before format versioning) carry no
+  // `configVersion` key and fall back to the chain-start version (v1.0.0).
+  v1.0.0 -> v1.1.0 {}
+  v1.1.0 -> v1.2.0 {}
 }
 
 impl FromStr for ModLoaderType {
@@ -68,46 +128,6 @@ impl ModLoaderType {
   }
 }
 
-#[derive(Debug, PartialEq, Eq, Deserialize, Clone, Serialize, Default)]
-pub enum ModLoaderStatus {
-  NotDownloaded, // mod loader's library has not been downloaded
-  DownloadFailed, /* mod loader's library download process failed (including processor installation failed)
-                  Only when SJMCL restart, it will try to re-download library while making no changes to client info JSON (is_retry = true),
-                  and do following steps */
-  Downloading, // mod loader's library download process is ongoing
-  Installing,  // mod loader's library has been downloaded, and installation processors are working
-  #[default]
-  Installed,
-}
-
-structstruck::strike! {
-  #[strikethrough[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize, Default)]]
-  #[strikethrough[serde(rename_all = "camelCase", default)]]
-  pub struct Instance {
-    pub id: String,
-    pub name: String,
-    pub description: String,
-    pub tag: Option<String>,
-    pub icon_src: String,
-    pub starred: bool,
-    pub play_time: u128,
-    pub version: String,
-    pub version_path: PathBuf,
-    pub mod_loader: struct {
-      pub status: ModLoaderStatus,
-      pub loader_type: ModLoaderType,
-      pub version: String,
-      pub branch: Option<String>, // Optional branch name for mod loaders like Forge
-    },
-    pub optifine: Option<OptiFine>,
-    // if true, use the spec_game_config, else use the global game config
-    pub use_spec_game_config: bool,
-    // if use_spec_game_config is false, this field is ignored
-    pub spec_game_config: Option<GameConfig>,
-    pub modpack_version: Option<String>,
-  }
-}
-
 impl Instance {
   pub fn get_json_cfg_path(&self) -> PathBuf {
     self.version_path.join(INSTANCE_CFG_FILE_NAME)
@@ -117,7 +137,12 @@ impl Instance {
   where
     Self: Sized + serde::de::DeserializeOwned + Send,
   {
-    load_json_async::<Self>(&self.get_json_cfg_path()).await
+    let json_string = tokio::fs::read_to_string(self.get_json_cfg_path()).await?;
+    let mut value: Value = serde_json::from_str(&json_string)?;
+    // Config files written before 1.1.0 carry no `configVersion` key; migrate()
+    // falls back to the chain-start version and applies the declared steps.
+    migrate(&mut value, &MIGRATIONS, None, "configVersion").map_err(std::io::Error::other)?;
+    serde_json::from_value(value).map_err(std::io::Error::other)
   }
 
   pub async fn save_json_cfg(&self) -> Result<(), std::io::Error> {
@@ -286,14 +311,6 @@ pub enum InstanceError {
   LoaderInstallerNotFound,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct OptiFine {
-  pub filename: String,
-  pub version: String,
-  pub status: ModLoaderStatus,
-}
-
 impl std::error::Error for InstanceError {}
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -301,4 +318,39 @@ impl std::error::Error for InstanceError {}
 pub struct ModpackFileList {
   pub all: Vec<String>,
   pub unchecked: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn migrate_fills_config_version_for_legacy_instance() {
+    // A pre-1.1.0 instance config has no `configVersion` key; migrate() falls
+    // back to the chain-start version and stamps the current version. The
+    // Minecraft `version` key must be left untouched.
+    let mut doc: Value = serde_json::json!({
+      "id": "test:instance",
+      "version": "26.3-snapshot-9",
+    });
+    migrate(&mut doc, &MIGRATIONS, None, "configVersion").unwrap();
+    assert_eq!(doc["configVersion"], "1.1.0");
+    assert_eq!(doc["version"], "26.3-snapshot-9");
+  }
+
+  #[test]
+  fn migrate_keeps_current_config_version_unchanged() {
+    let mut doc: Value = serde_json::json!({
+      "configVersion": "1.1.0",
+      "version": "1.20.1",
+    });
+    migrate(&mut doc, &MIGRATIONS, None, "configVersion").unwrap();
+    assert_eq!(doc["configVersion"], "1.1.0");
+    assert_eq!(doc["version"], "1.20.1");
+  }
+
+  #[test]
+  fn default_config_version_is_max_version() {
+    assert_eq!(Instance::default().config_version, "1.1.0");
+  }
 }

--- a/src-tauri/src/launcher_config/migrations.rs
+++ b/src-tauri/src/launcher_config/migrations.rs
@@ -1,70 +1,51 @@
-use serde::Deserialize;
-use serde::de::Deserializer;
 use serde_json::Value;
-
-use crate::launcher_config::models::AppearanceBackgroundConfig;
+use serde_json::json;
+use sjmcl_migration::MigrationError;
 
 // Migrate old built-in wallpaper choices to the new default preset.
 const LEGACY_BUILT_IN_BACKGROUNDS: &[&str] = &["%built-in:Jokull", "%built-in:GNLXC"];
 
-#[derive(Deserialize, Default)]
-#[serde(rename_all = "camelCase", default)]
-struct BackgroundPayload {
-  choice: String,
-  random_custom: bool,
-  auto_darken: bool,
-}
+/// Migration helper: convert a legacy `appearance.background` object.
+///
+/// The built-in wallpaper set changed in 1.2.0; old presets are remapped to the
+/// new default preset and `auto_darken` is reset. Invoked by the migration
+/// chain when restoring configs written before 1.2.0.
+pub fn migrate_background(value: &Value) -> Result<Value, MigrationError> {
+  let mut obj = value
+    .as_object()
+    .cloned()
+    .ok_or_else(|| MigrationError::TypeMismatch("background object".into()))?;
 
-pub fn deserialize_background<'de, D>(
-  deserializer: D,
-) -> Result<AppearanceBackgroundConfig, D::Error>
-where
-  D: Deserializer<'de>,
-{
-  let mut payload = BackgroundPayload::deserialize(deserializer)?;
-
-  if LEGACY_BUILT_IN_BACKGROUNDS.contains(&payload.choice.as_str()) {
-    payload.choice = "%built-in:Florwyn".to_string();
-    payload.auto_darken = false;
+  let choice = obj
+    .get("choice")
+    .and_then(|v| v.as_str())
+    .unwrap_or_default();
+  if LEGACY_BUILT_IN_BACKGROUNDS.contains(&choice) {
+    obj.insert("choice".to_string(), json!("%built-in:Florwyn"));
+    obj.insert("autoDarken".to_string(), json!(false));
   }
 
-  Ok(AppearanceBackgroundConfig {
-    choice: payload.choice,
-    random_custom: payload.random_custom,
-    auto_darken: payload.auto_darken,
-  })
+  Ok(Value::Object(obj))
 }
 
-// Deserializing discover sources from old and new formats.
-// Migrated from Vec<String> to Vec<(String, bool)> with default enabled=true
-pub fn deserialize_discover_sources<'de, D>(
-  deserializer: D,
-) -> Result<Vec<(String, bool)>, D::Error>
-where
-  D: Deserializer<'de>,
-{
-  let value = match Value::deserialize(deserializer) {
-    Ok(value) => value,
-    Err(_) => return Ok(Vec::default()),
+/// Migration helper: convert old `discoverSourceEndpoints` formats.
+///
+/// Migrated from `Vec<String>` to `Vec<(String, bool)>` with default
+/// enabled=true. Invoked by the migration chain when restoring configs written
+/// before 1.2.0.
+pub fn migrate_discover_sources(value: &Value) -> Result<Value, MigrationError> {
+  let Some(items) = value.as_array() else {
+    return Ok(Value::Array(Vec::new()));
   };
 
-  let items = match value.as_array() {
-    Some(items) => items,
-    None => return Ok(Vec::default()),
-  };
-
-  Ok(
+  Ok(Value::Array(
     items
       .iter()
       .filter_map(|item| match item {
-        Value::String(url) => Some((url.to_string(), true)),
-        Value::Array(tuple) if tuple.len() == 2 => {
-          let url = tuple.first()?.as_str()?;
-          let enabled = tuple.get(1)?.as_bool()?;
-          Some((url.to_string(), enabled))
-        }
+        Value::String(url) => Some(json!([url, true])),
+        Value::Array(tuple) if tuple.len() == 2 => Some(Value::Array(tuple.clone())),
         _ => None,
       })
       .collect(),
-  )
+  ))
 }

--- a/src-tauri/src/launcher_config/models.rs
+++ b/src-tauri/src/launcher_config/models.rs
@@ -1,117 +1,20 @@
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use sjmcl_macros::Partial;
+use sjmcl_migration::migrate;
 use sjmcl_types::partial::PartialUpdate;
 use sjmcl_types::storage::Storage;
 use smart_default::SmartDefault;
+use std::fs;
 use std::path::PathBuf;
 use strum_macros::{Display, EnumString};
 use tauri::{AppHandle, Emitter};
 
 use crate::launcher_config::constants::{CONFIG_PARTIAL_UPDATE_EVENT, LAUNCHER_CFG_FILE_NAME};
-use crate::launcher_config::migrations::{deserialize_background, deserialize_discover_sources};
 use crate::utils::string::snake_to_camel_case;
 use crate::utils::sys_info;
 use crate::{APP_DATA_DIR, EXE_DIR, IS_PORTABLE};
-
-// Info about the latest release version fetched from remote, shown to the user to update.
-#[derive(Debug, Serialize, Deserialize, Default)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct VersionMetaInfo {
-  pub version: String,
-  pub file_name: String,
-  pub release_notes: String,
-  pub published_at: String,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct MemoryInfo {
-  pub total: u64,
-  pub used: u64,
-  pub suggested_max_alloc: u64,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, Default)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
-pub struct JavaInfo {
-  pub name: String, // JDK/JRE + full version
-  pub exec_path: String,
-  pub vendor: String,
-  pub major_version: i32, // major version + LTS flag
-  pub is_lts: bool,
-  pub is_user_added: bool,
-}
-
-// https://github.com/HMCL-dev/HMCL/blob/d9e3816b8edf9e7275e4349d4fc67a5ef2e3c6cf/HMCLCore/src/main/java/org/jackhuang/hmcl/game/ProcessPriority.java#L20
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
-#[serde(rename_all = "camelCase")]
-pub enum ProcessPriority {
-  Low,
-  AboveNormal,
-  BelowNormal,
-  High,
-  #[serde(other)]
-  Normal,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
-#[serde(rename_all = "camelCase")]
-pub enum FileValidatePolicy {
-  Disable,
-  Full,
-  #[serde(other)]
-  Normal,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
-#[serde(rename_all = "camelCase")]
-pub enum LauncherVisiablity {
-  StartHidden,
-  RunningHidden,
-  Always,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
-#[serde(rename_all = "lowercase")]
-pub enum GarbageCollector {
-  G1gc,
-  Zgc,
-  Shenandoah,
-  Parallel,
-  Serial,
-  #[serde(other)]
-  Auto,
-}
-
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
-#[serde(rename_all = "lowercase")]
-pub enum GraphicsApi {
-  Opengl,
-  Vulkan,
-  #[serde(other)]
-  Default,
-}
-
-// see java.net.proxy
-// https://github.com/HMCL-dev/HMCL/blob/d9e3816b8edf9e7275e4349d4fc67a5ef2e3c6cf/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java#L114
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
-#[serde(rename_all = "camelCase")]
-pub enum ProxyType {
-  Socks,
-  #[serde(other)]
-  Http,
-}
-
-#[derive(Partial, Debug, PartialEq, Eq, Clone, Deserialize, Serialize, SmartDefault)]
-#[serde(default)]
-#[serde(rename_all = "camelCase")]
-pub struct ProxyConfig {
-  pub enabled: bool,
-  #[default(ProxyType::Http)]
-  pub selected_type: ProxyType,
-  pub host: String,
-  pub port: usize,
-}
 
 // Partial Derive is used for these structs and we can use it for key value storage.
 // And partially update some fields for better performance and hygiene.
@@ -122,85 +25,374 @@ pub struct ProxyConfig {
 // assert_eq!(result_game, Ok(()));
 // assert!(config.access("114514").is_err())
 //
-structstruck::strike! {
-  #[strikethrough[derive(Partial, Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]]
-  #[strikethrough[serde(rename_all = "camelCase")]]
-  #[strikethrough[derive(SmartDefault)]]
-  #[strikethrough[serde(default)]]
-  pub struct GameConfig {
-    pub game_java: struct GameJava {
-      #[default = true]
-      pub auto: bool,
-      pub exec_path: String,
-    },
-    pub game_window: struct {
-      pub resolution: struct {
-        #[default = 854]
-        pub width: u32,
-        #[default = 480]
-        pub height: u32,
-        pub fullscreen: bool,
-      },
-      pub custom_title: String,
-      pub custom_info: String,
-    },
-    pub performance: struct {
-      #[default = true]
-      pub auto_mem_allocation: bool,
-      #[default = 1024]
-      pub max_mem_allocation: u32,
-      #[default(ProcessPriority::Normal)]
-      pub process_priority: ProcessPriority,
-    },
-    pub game_server: struct {
-      pub auto_join: bool,
-      pub server_url: String,
-    },
-    #[default = true]
-    pub version_isolation: bool,
-    #[default(LauncherVisiablity::Always)]
-    pub launcher_visibility: LauncherVisiablity,
-    pub display_game_log: bool,
-    pub advanced_options: struct {
-      pub enabled: bool,
-    },
-    pub advanced: struct {
-      pub graphics: struct {
-        #[default(GraphicsApi::Default)]
-        pub api: GraphicsApi,
-        #[default = "default"]
-        pub renderer: String,
-      },
-      pub custom_commands: struct {
-        pub minecraft_argument: String,
-        pub precall_command: String,
-        pub wrapper_launcher: String,
-        pub post_exit_command: String,
-      },
-      pub proxy: ProxyConfig,
-      pub jvm: struct {
-        #[default(GarbageCollector::Auto)]
-        pub garbage_collector: GarbageCollector,
-        pub java_permanent_generation_space: u32,
-        pub environment_variable: String,
-        pub args: String,
-      },
-      pub workaround: struct GameWorkaroundConfig {
-        pub no_jvm_args: bool,
-        #[default(FileValidatePolicy::Normal)]
-        pub game_file_validate_policy: FileValidatePolicy,
-        pub dont_check_jvm_validity: bool,
-        pub dont_patch_natives: bool,
+sjmcl_macros::migrations! {
+  // Pre-1.2.0 config files carry no `version` key and fall back to the
+  // chain-start version (v1.0.0) when migrated. The legacy field conversions
+  // (old built-in backgrounds, old discover source format) are applied by the
+  // customized migration helpers in the final step that restores v1.2.0.
+  schema v1.2.0 {
+    #[structstruck::each[derive(Partial, Debug, PartialEq, Eq, Clone, Deserialize, Serialize, SmartDefault)]]
+    #[structstruck::each[serde(rename_all = "camelCase", default)]]
+    pub struct LauncherConfig {
+      #[default(_code = "__migration_meta::MAX_VERSION.to_string()")]
+      pub version: String,
+      pub basic_info: struct {
+        #[default = "dev"]
+        pub launcher_version: String,
+        pub platform: String,
+        pub arch: String,
+        pub os_type: String,
+        pub platform_version: String,
+        pub exe_sha256: String,
+        pub is_portable: bool,
         #[default = true]
-        pub use_lwjgl_unsafe_agent: bool,
-        pub use_custom_authlib_injector: struct {
-          pub enabled: bool,
-          pub path: String,
-        },
-        pub use_native_glfw: bool,
-        pub use_native_openal: bool,
+        pub is_exe_path_available: bool,
+        #[default = false]
+        pub is_china_mainland_ip: bool,
+        #[default = false]
+        pub allow_full_login_feature: bool,
+        // Build metadata, sourced from compile-time constants injected by build.rs.
+        // Filled by setup_with_app; not meant to be edited by the user.
+        #[default(BuildType::Dev)]
+        pub build_type: BuildType,
+        pub build_commit_sha: String,
       },
+      // mocked: false when invoked from the backend, true when the frontend placeholder data is used during loading.
+      pub mocked: bool,
+      pub run_count: usize,
+      #[default = true]
+      pub last_run_exited_normally: bool,
+      pub appearance: struct AppearanceConfig {
+        pub theme: struct {
+          #[default = "blue"]
+          pub primary_color: String,
+          #[default = "light"]
+          pub color_mode: String,
+          pub use_liquid_glass_design: bool,
+          #[default = "adaptive"]
+          pub head_nav_style: String,
+        },
+        pub font: struct {
+          #[default = "%built-in"]
+          pub font_family: String,
+          #[default = "%built-in"]
+          pub log_font_family: String,
+          #[default = 100]
+          pub font_size: usize, // as percent
+        },
+        #[serde(default)]
+        pub background: struct AppearanceBackgroundConfig {
+          #[default = "%built-in:Florwyn"]
+          pub choice: String,
+          pub random_custom: bool,
+          pub auto_darken: bool,
+        },
+        pub accessibility: struct {
+          pub invert_colors: bool,
+          pub enhance_contrast: bool,
+        }
+      },
+      pub download: struct DownloadConfig {
+        pub source: struct {
+          #[default = "auto"]
+          pub strategy: String,
+        },
+        pub transmission: struct {
+          #[default = true]
+          pub auto_concurrent: bool,
+          #[default = 64]
+          pub concurrent_count: usize,
+          #[default = false]
+          pub enable_speed_limit: bool,
+          #[default = 1024]
+          pub speed_limit_value: usize,
+        },
+        pub cache: struct {
+          pub directory: PathBuf,
+        },
+        pub proxy: ProxyConfig,
+      },
+      pub general: struct GeneralConfig {
+        pub general: struct {
+          #[default(sys_info::get_mapped_locale())]
+          pub language: String,
+        },
+        pub functionality: struct {
+          #[default = "on"]
+          pub discover_page: String,
+          #[default = "instance"]
+          pub instances_nav_type: String,
+          #[default = true]
+          pub launch_page_quick_switch: bool,
+          #[default = true]
+          pub auto_download_java: bool,
+          #[default = true]
+          pub resource_translation: bool, // only available in zh-Hans
+          #[default = true]
+          pub translated_filename_prefix: bool, // only available in zh-Hans
+          #[default = true]
+          pub skip_first_screen_options: bool,
+        },
+        pub advanced: struct GeneralConfigAdvanced {
+          #[default = true]
+          pub auto_purge_launcher_logs: bool,
+        }
+      },
+      pub intelligence: struct IntelligenceConfig {
+        pub mcp_server: struct {
+          pub launcher: struct LauncherMcpServerConfig{
+            #[default = true]
+            pub enabled: bool,
+            #[default = 18970]
+            pub port: u16,
+          },
+        }
+      },
+      pub extension: struct ExtensionConfig {
+        pub enabled: Vec<String>,
+        #[serde(default)]
+        pub home_widget_state: Vec<(String, u32, bool)>,  // widget_key, width, collapsed
+      },
+      pub global_game_config: GameConfig,
+      pub local_game_directories: Vec<GameDirectory>,
+      #[serde(default)]
+      #[default(_code="vec![(\"https://mc.sjtu.cn/api-sjmcl/article\".to_string(), true),
+      (\"https://mc.sjtu.cn/api-sjmcl/article/mua\".to_string(), true)]")]
+      pub discover_source_endpoints: Vec<(String, bool)>,
+      pub extra_java_paths: Vec<String>,
+      pub suppressed_dialogs: Vec<String>,
+      pub states: struct States {
+        pub shared: struct {
+          pub selected_player_id: String,
+          pub selected_instance_id: String,
+        },
+        pub accounts_page: struct {
+          #[default = "grid"]
+          pub view_type: String
+        },
+        pub all_instances_page: struct {
+          #[default = "versionAsc"]
+          pub sort_by: String,
+          #[default = "list"]
+          pub view_type: String
+        },
+        pub game_version_selector: struct {
+          #[default(_code="vec![\"release\".to_string()]")]
+          pub game_types: Vec<String>
+        },
+        pub instance_mods_page: struct {
+          #[default([true, true])]
+          pub accordion_states: [bool; 2],
+        },
+        pub instance_resource_packs_page: struct {
+          #[default([true, true])]
+          pub accordion_states: [bool; 2],
+        },
+        pub instance_worlds_page: struct {
+          #[default([true, true])]
+          pub accordion_states: [bool; 2],
+        },
+        pub instance_shader_packs_page: struct {
+          #[default([true, true])]
+          pub accordion_states: [bool; 2],
+        },
+      }
     }
+    #[structstruck::each[derive(Partial, Debug, PartialEq, Eq, Clone, Deserialize, Serialize, SmartDefault)]]
+    #[structstruck::each[serde(rename_all = "camelCase", default)]]
+    pub struct GameConfig {
+      pub game_java: struct GameJava {
+        #[default = true]
+        pub auto: bool,
+        pub exec_path: String,
+      },
+      pub game_window: struct {
+        pub resolution: struct {
+          #[default = 854]
+          pub width: u32,
+          #[default = 480]
+          pub height: u32,
+          pub fullscreen: bool,
+        },
+        pub custom_title: String,
+        pub custom_info: String,
+      },
+      pub performance: struct {
+        #[default = true]
+        pub auto_mem_allocation: bool,
+        #[default = 1024]
+        pub max_mem_allocation: u32,
+        #[default(ProcessPriority::Normal)]
+        pub process_priority: ProcessPriority,
+      },
+      pub game_server: struct {
+        pub auto_join: bool,
+        pub server_url: String,
+      },
+      #[default = true]
+      pub version_isolation: bool,
+      #[default(LauncherVisiablity::Always)]
+      pub launcher_visibility: LauncherVisiablity,
+      pub display_game_log: bool,
+      pub advanced_options: struct {
+        pub enabled: bool,
+      },
+      pub advanced: struct {
+        pub graphics: struct {
+          #[default(GraphicsApi::Default)]
+          pub api: GraphicsApi,
+          #[default = "default"]
+          pub renderer: String,
+        },
+        pub custom_commands: struct {
+          pub minecraft_argument: String,
+          pub precall_command: String,
+          pub wrapper_launcher: String,
+          pub post_exit_command: String,
+        },
+        pub proxy: ProxyConfig,
+        pub jvm: struct {
+          #[default(GarbageCollector::Auto)]
+          pub garbage_collector: GarbageCollector,
+          pub java_permanent_generation_space: u32,
+          pub environment_variable: String,
+          pub args: String,
+        },
+        pub workaround: struct GameWorkaroundConfig {
+          pub no_jvm_args: bool,
+          #[default(FileValidatePolicy::Normal)]
+          pub game_file_validate_policy: FileValidatePolicy,
+          pub dont_check_jvm_validity: bool,
+          pub dont_patch_natives: bool,
+          #[default = true]
+          pub use_lwjgl_unsafe_agent: bool,
+          pub use_custom_authlib_injector: struct {
+            pub enabled: bool,
+            pub path: String,
+          },
+          pub use_native_glfw: bool,
+          pub use_native_openal: bool,
+        },
+      }
+    }
+  // Auxiliary types: generated as real Rust types and referenceable as field
+  // types, but not part of the migration symbol table.
+  #[aux]
+  #[derive(Debug, Serialize, Deserialize, Default)]
+  #[serde(rename_all = "camelCase", deny_unknown_fields)]
+  pub struct VersionMetaInfo {
+    pub version: String,
+    pub file_name: String,
+    pub release_notes: String,
+    pub published_at: String,
+  }
+
+  #[aux]
+  #[derive(Debug, Serialize)]
+  #[serde(rename_all = "camelCase", deny_unknown_fields)]
+  pub struct MemoryInfo {
+    pub total: u64,
+    pub used: u64,
+    pub suggested_max_alloc: u64,
+  }
+
+  #[aux]
+  #[derive(Debug, Serialize, Deserialize, Clone, Default)]
+  #[serde(rename_all = "camelCase", deny_unknown_fields)]
+  pub struct JavaInfo {
+    pub name: String, // JDK/JRE + full version
+    pub exec_path: String,
+    pub vendor: String,
+    pub major_version: i32, // major version + LTS flag
+    pub is_lts: bool,
+    pub is_user_added: bool,
+  }
+
+  // https://github.com/HMCL-dev/HMCL/blob/d9e3816b8edf9e7275e4349d4fc67a5ef2e3c6cf/HMCLCore/src/main/java/org/jackhuang/hmcl/game/ProcessPriority.java#L20
+  #[aux]
+  #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+  #[serde(rename_all = "camelCase")]
+  pub enum ProcessPriority {
+    Low,
+    AboveNormal,
+    BelowNormal,
+    High,
+    #[serde(other)]
+    Normal,
+  }
+
+  #[aux]
+  #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+  #[serde(rename_all = "camelCase")]
+  pub enum FileValidatePolicy {
+    Disable,
+    Full,
+    #[serde(other)]
+    Normal,
+  }
+
+  #[aux]
+  #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+  #[serde(rename_all = "camelCase")]
+  pub enum LauncherVisiablity {
+    StartHidden,
+    RunningHidden,
+    Always,
+  }
+
+  #[aux]
+  #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+  #[serde(rename_all = "lowercase")]
+  pub enum GarbageCollector {
+    G1gc,
+    Zgc,
+    Shenandoah,
+    Parallel,
+    Serial,
+    #[serde(other)]
+    Auto,
+  }
+
+  #[aux]
+  #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+  #[serde(rename_all = "lowercase")]
+  pub enum GraphicsApi {
+    Opengl,
+    Vulkan,
+    #[serde(other)]
+    Default,
+  }
+
+  // see java.net.proxy
+  // https://github.com/HMCL-dev/HMCL/blob/d9e3816b8edf9e7275e4349d4fc67a5ef2e3c6cf/HMCLCore/src/main/java/org/jackhuang/hmcl/launch/DefaultLauncher.java#L114
+  #[aux]
+  #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+  #[serde(rename_all = "camelCase")]
+  pub enum ProxyType {
+    Socks,
+    #[serde(other)]
+    Http,
+  }
+
+  #[aux]
+  #[derive(Partial, Debug, PartialEq, Eq, Clone, Deserialize, Serialize, SmartDefault)]
+  #[serde(default)]
+  #[serde(rename_all = "camelCase")]
+  pub struct ProxyConfig {
+    pub enabled: bool,
+    #[default(ProxyType::Http)]
+    pub selected_type: ProxyType,
+    pub host: String,
+    pub port: usize,
+  }
+  }
+  // Pre-1.2.0 configs carry no `version` key and fall back to the chain start
+  // (v1.0.0) during migration. The legacy field conversions are applied by the
+  // customized migration helpers below when restoring v1.2.0.
+  v1.0.0 -> v1.1.0 {}
+  v1.1.0 -> v1.2.0 {
+    convert "appearance.background" from AppearanceBackgroundConfig to AppearanceBackgroundConfig => crate::launcher_config::migrations::migrate_background;
+    convert "discoverSourceEndpoints" from Vec<String> to Vec<(String, bool)> => crate::launcher_config::migrations::migrate_discover_sources;
   }
 }
 
@@ -224,182 +416,6 @@ pub enum BuildType {
   Nightly,
   Beta,
   Release,
-}
-
-structstruck::strike! {
-  #[strikethrough[derive(Partial, Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]]
-  #[strikethrough[serde(rename_all = "camelCase")]]
-  #[strikethrough[derive(SmartDefault)]]
-  #[strikethrough[serde(default)]]
-  pub struct LauncherConfig {
-    pub basic_info: struct {
-      #[default = "dev"]
-      pub launcher_version: String,
-      pub platform: String,
-      pub arch: String,
-      pub os_type: String,
-      pub platform_version: String,
-      pub exe_sha256: String,
-      pub is_portable: bool,
-      #[default = true]
-      pub is_exe_path_available: bool,
-      #[default = false]
-      pub is_china_mainland_ip: bool,
-      #[default = false]
-      pub allow_full_login_feature: bool,
-      // Build metadata, sourced from compile-time constants injected by build.rs.
-      // Filled by setup_with_app; not meant to be edited by the user.
-      #[default(BuildType::Dev)]
-      pub build_type: BuildType,
-      pub build_commit_sha: String,
-    },
-    // mocked: false when invoked from the backend, true when the frontend placeholder data is used during loading.
-    pub mocked: bool,
-    pub run_count: usize,
-    #[default = true]
-    pub last_run_exited_normally: bool,
-    pub appearance: struct AppearanceConfig {
-      pub theme: struct {
-        #[default = "blue"]
-        pub primary_color: String,
-        #[default = "light"]
-        pub color_mode: String,
-        pub use_liquid_glass_design: bool,
-        #[default = "adaptive"]
-        pub head_nav_style: String,
-      },
-      pub font: struct {
-        #[default = "%built-in"]
-        pub font_family: String,
-        #[default = "%built-in"]
-        pub log_font_family: String,
-        #[default = 100]
-        pub font_size: usize, // as percent
-      },
-      #[serde(
-        default,
-        deserialize_with = "deserialize_background"
-      )]
-      pub background: struct AppearanceBackgroundConfig {
-        #[default = "%built-in:Florwyn"]
-        pub choice: String,
-        pub random_custom: bool,
-        pub auto_darken: bool,
-      },
-      pub accessibility: struct {
-        pub invert_colors: bool,
-        pub enhance_contrast: bool,
-      }
-    },
-    pub download: struct DownloadConfig {
-      pub source: struct {
-        #[default = "auto"]
-        pub strategy: String,
-      },
-      pub transmission: struct {
-        #[default = true]
-        pub auto_concurrent: bool,
-        #[default = 64]
-        pub concurrent_count: usize,
-        #[default = false]
-        pub enable_speed_limit: bool,
-        #[default = 1024]
-        pub speed_limit_value: usize,
-      },
-      pub cache: struct {
-        pub directory: PathBuf,
-      },
-      pub proxy: ProxyConfig,
-    },
-    pub general: struct GeneralConfig {
-      pub general: struct {
-        #[default(sys_info::get_mapped_locale())]
-        pub language: String,
-      },
-      pub functionality: struct {
-        #[default = "on"]
-        pub discover_page: String,
-        #[default = "instance"]
-        pub instances_nav_type: String,
-        #[default = true]
-        pub launch_page_quick_switch: bool,
-        #[default = true]
-        pub auto_download_java: bool,
-        #[default = true]
-        pub resource_translation: bool, // only available in zh-Hans
-        #[default = true]
-        pub translated_filename_prefix: bool, // only available in zh-Hans
-        #[default = true]
-        pub skip_first_screen_options: bool,
-      },
-      pub advanced: struct GeneralConfigAdvanced {
-        #[default = true]
-        pub auto_purge_launcher_logs: bool,
-      }
-    },
-    pub intelligence: struct IntelligenceConfig {
-      pub mcp_server: struct {
-        pub launcher: struct LauncherMcpServerConfig{
-          #[default = true]
-          pub enabled: bool,
-          #[default = 18970]
-          pub port: u16,
-        },
-      }
-    },
-    pub extension: struct ExtensionConfig {
-      pub enabled: Vec<String>,
-      #[serde(default)]
-      pub home_widget_state: Vec<(String, u32, bool)>,  // widget_key, width, collapsed
-    },
-    pub global_game_config: GameConfig,
-    pub local_game_directories: Vec<GameDirectory>,
-    #[serde(
-      default,
-      deserialize_with = "deserialize_discover_sources"
-    )]
-    #[default(_code="vec![(\"https://mc.sjtu.cn/api-sjmcl/article\".to_string(), true),
-    (\"https://mc.sjtu.cn/api-sjmcl/article/mua\".to_string(), true)]")]
-    pub discover_source_endpoints: Vec<(String, bool)>,
-    pub extra_java_paths: Vec<String>,
-    pub suppressed_dialogs: Vec<String>,
-    pub states: struct States {
-      pub shared: struct {
-        pub selected_player_id: String,
-        pub selected_instance_id: String,
-      },
-      pub accounts_page: struct {
-        #[default = "grid"]
-        pub view_type: String
-      },
-      pub all_instances_page: struct {
-        #[default = "versionAsc"]
-        pub sort_by: String,
-        #[default = "list"]
-        pub view_type: String
-      },
-      pub game_version_selector: struct {
-        #[default(_code="vec![\"release\".to_string()]")]
-        pub game_types: Vec<String>
-      },
-      pub instance_mods_page: struct {
-        #[default([true, true])]
-        pub accordion_states: [bool; 2],
-      },
-      pub instance_resource_packs_page: struct {
-        #[default([true, true])]
-        pub accordion_states: [bool; 2],
-      },
-      pub instance_worlds_page: struct {
-        #[default([true, true])]
-        pub accordion_states: [bool; 2],
-      },
-      pub instance_shader_packs_page: struct {
-        #[default([true, true])]
-        pub accordion_states: [bool; 2],
-      },
-    }
-  }
 }
 
 impl LauncherConfig {
@@ -435,6 +451,18 @@ impl Storage for LauncherConfig {
       APP_DATA_DIR.get().unwrap().join(LAUNCHER_CFG_FILE_NAME)
     }
   }
+
+  fn load() -> Result<Self, std::io::Error>
+  where
+    Self: Sized + DeserializeOwned,
+  {
+    let json_string = fs::read_to_string(Self::file_path())?;
+    let mut value: Value = serde_json::from_str(&json_string)?;
+    // Config files written before 1.2.0 carry no `version` key; migrate() falls
+    // back to the chain-start version and applies the declared steps.
+    migrate(&mut value, &MIGRATIONS, None, "version").map_err(std::io::Error::other)?;
+    serde_json::from_value(value).map_err(std::io::Error::other)
+  }
 }
 
 #[derive(Debug, Display)]
@@ -452,3 +480,69 @@ pub enum LauncherConfigError {
 }
 
 impl std::error::Error for LauncherConfigError {}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn migration_chain_covers_pre_1_2_0_versions() {
+    assert_eq!(MIGRATIONS.len(), 2);
+    assert_eq!((MIGRATIONS[0].from.major, MIGRATIONS[0].from.minor), (1, 0));
+    assert_eq!((MIGRATIONS[1].to.major, MIGRATIONS[1].to.minor), (1, 2));
+    assert_eq!(__migration_meta::MAX_VERSION.major, 1);
+    assert_eq!(__migration_meta::MAX_VERSION.minor, 2);
+  }
+
+  #[test]
+  fn migrate_fills_version_for_legacy_config() {
+    // A pre-1.2.0 config has no `version` key; migrate() falls back to the
+    // chain-start version and stamps the current version onto the document.
+    let mut doc: Value = serde_json::json!({
+      "mocked": true,
+    });
+    migrate(&mut doc, &MIGRATIONS, None, "version").unwrap();
+    assert_eq!(doc["version"], "1.2.0");
+  }
+
+  #[test]
+  fn migrate_keeps_current_version_unchanged() {
+    let mut doc: Value = serde_json::json!({
+      "version": "1.2.0",
+      "mocked": true,
+    });
+    migrate(&mut doc, &MIGRATIONS, None, "version").unwrap();
+    assert_eq!(doc["version"], "1.2.0");
+  }
+
+  #[test]
+  fn migrate_applies_legacy_field_conversions() {
+    // A pre-1.2.0 config with legacy built-in backgrounds and old
+    // discover source string format; the custom ops restore them to 1.2.0.
+    let mut doc: Value = serde_json::json!({
+      "appearance": {
+        "background": {
+          "choice": "%built-in:Jokull",
+          "randomCustom": true,
+          "autoDarken": true,
+        }
+      },
+      "discoverSourceEndpoints": [
+        "https://mc.sjtu.cn/api-sjmcl/article",
+        "https://mc.sjtu.cn/api-sjmcl/article/mua",
+      ],
+    });
+    migrate(&mut doc, &MIGRATIONS, None, "version").unwrap();
+
+    assert_eq!(doc["version"], "1.2.0");
+    assert_eq!(
+      doc["appearance"]["background"]["choice"],
+      "%built-in:Florwyn"
+    );
+    assert_eq!(doc["appearance"]["background"]["autoDarken"], false);
+    assert_eq!(
+      doc["discoverSourceEndpoints"][0],
+      serde_json::json!(["https://mc.sjtu.cn/api-sjmcl/article", true,])
+    );
+  }
+}

--- a/src-tauri/src/resource/helpers/curseforge/misc.rs
+++ b/src-tauri/src/resource/helpers/curseforge/misc.rs
@@ -85,8 +85,8 @@ pub fn get_curseforge_api(
 }
 
 structstruck::strike! {
-#[strikethrough[derive(Deserialize, Serialize, Debug, Clone)]]
-#[strikethrough[serde(rename_all = "camelCase")]]
+#[structstruck::each[derive(Deserialize, Serialize, Debug, Clone)]]
+#[structstruck::each[serde(rename_all = "camelCase")]]
   pub struct CurseForgeProject {
     pub id: i32,
     pub class_id: Option<i32>,
@@ -125,8 +125,8 @@ pub struct CurseForgeSearchRes {
 }
 
 structstruck::strike! {
-#[strikethrough[derive(Deserialize, Serialize, Debug, Clone)]]
-#[strikethrough[serde(rename_all = "camelCase")]]
+#[structstruck::each[derive(Deserialize, Serialize, Debug, Clone)]]
+#[structstruck::each[serde(rename_all = "camelCase")]]
   pub struct CurseForgeFileInfo {
     pub id: i32,
     pub mod_id: i32,
@@ -155,8 +155,8 @@ pub struct CurseForgeVersionPackSearchRes {
 }
 
 structstruck::strike! {
-#[strikethrough[derive(Deserialize, Serialize, Debug, Clone)]]
-#[strikethrough[serde(rename_all = "camelCase")]]
+#[structstruck::each[derive(Deserialize, Serialize, Debug, Clone)]]
+#[structstruck::each[serde(rename_all = "camelCase")]]
   pub struct CurseForgeFingerprintRes {
     pub data: pub struct {
       pub exact_matches: Vec<pub struct {

--- a/src-tauri/src/resource/helpers/modrinth/misc.rs
+++ b/src-tauri/src/resource/helpers/modrinth/misc.rs
@@ -98,7 +98,7 @@ pub struct ModrinthSearchRes {
 }
 
 structstruck::strike! {
-#[strikethrough[derive(Deserialize, Debug)]]
+#[structstruck::each[derive(Deserialize, Debug)]]
   pub struct ModrinthFileInfo {
     pub url: String,
     pub filename: String,
@@ -111,7 +111,7 @@ structstruck::strike! {
 }
 
 structstruck::strike! {
-#[strikethrough[derive(Deserialize, Debug)]]
+#[structstruck::each[derive(Deserialize, Debug)]]
   pub struct ModrinthVersionPack {
     pub project_id: String,
     pub dependencies: Vec<pub struct {

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -75,6 +75,7 @@ export interface GameDirectory {
 }
 
 export interface LauncherConfig {
+  version: string;
   basicInfo: {
     launcherVersion: string;
     platform: string;
@@ -268,6 +269,7 @@ export const defaultGameConfig: GameConfig = {
 };
 
 export const defaultConfig: LauncherConfig = {
+  version: "1.2.0",
   basicInfo: {
     launcherVersion: "dev",
     platform: "",


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature

### Related Issues

Resolve #1915 

### Description

完善schema 迁移dsl系统

## Summary by Sourcery

Introduce a versioned schema migration system and apply it to launcher and instance configuration models.

New Features:
- Add a migrations DSL for declaring versioned schemas and generating migration metadata and model types.
- Support runtime JSON migrations for renaming, moving, removing, converting, and defaulting fields, including custom conversion helpers.
- Migrate launcher and instance configuration data to versioned formats, including legacy background and discover-source conversions.

Bug Fixes:
- Preserve and restore legacy configuration data while introducing explicit configuration versioning.

Enhancements:
- Replace legacy structstruck attribute syntax with the current structstruck::each form across generated models.
- Validate migration chains, schema paths, type conversions, model evolution, and circular type references at compile time.

Build:
- Add the sjmcl-migration workspace crate and update proc-macro dependencies.

Tests:
- Add coverage for migration chains, legacy configuration upgrades, custom field conversions, and current-version handling.