### PR TITLE
feat: 支持修改验证服务器名称

### DIFF
--- a/src-tauri/src/account/commands.rs
+++ b/src-tauri/src/account/commands.rs
@@ -580,6 +580,7 @@ pub fn rename_auth_server(app: AppHandle, url: String, target: String) -> SJMCLR
     .auth_servers
     .iter_mut()
     .find(|server| server.auth_url == url)
+    .ok_or(AccountError::NotFound)?
     .map(|server| server.server_name = Some(target));
 
   account_state.save()?;

--- a/src-tauri/src/account/commands.rs
+++ b/src-tauri/src/account/commands.rs
@@ -1,3 +1,4 @@
+use serde_json::json;
 use sjmcl_types::error::SJMCLResult;
 use sjmcl_types::storage::Storage;
 use std::path::Path;
@@ -561,6 +562,25 @@ pub fn delete_auth_server(app: AppHandle, url: String) -> SJMCLResult<()> {
       .unwrap_or_default(),
     )?;
   }
+
+  account_state.save()?;
+  config_state.save()?;
+  Ok(())
+}
+
+#[tauri::command]
+pub fn rename_auth_server(app: AppHandle, url: String, target: String) -> SJMCLResult<()> {
+  let account_binding = app.state::<Mutex<AccountInfo>>();
+  let mut account_state = account_binding.lock()?;
+
+  let config_binding = app.state::<Mutex<LauncherConfig>>();
+  let mut config_state = config_binding.lock()?;
+
+  account_state
+    .auth_servers
+    .iter_mut()
+    .find(|server| server.auth_url == url)
+    .map(|server| server.server_name = Some(target));
 
   account_state.save()?;
   config_state.save()?;

--- a/src-tauri/src/account/helpers/authlib_injector/info.rs
+++ b/src-tauri/src/account/helpers/authlib_injector/info.rs
@@ -39,6 +39,7 @@ pub async fn fetch_auth_server_info(
       }
 
       Ok(AuthServerInfo {
+        server_name: None,
         auth_url: auth_url.clone(),
         client_id,
         metadata: json,
@@ -85,7 +86,13 @@ pub async fn refresh_and_update_auth_servers(app: &AppHandle) -> SJMCLResult<()>
   let mut refreshed_auth_server_info_list =
     futures::future::join_all(cloned_account_state.auth_servers.iter().map(|info| async {
       if let Ok(refreshed_info) = fetch_auth_server_info(app, info.auth_url.clone()).await {
-        refreshed_info
+        if let Some(ref server_name) = info.server_name {
+          let mut named_info = refreshed_info.clone();
+          named_info.server_name = Some(server_name.clone());
+          named_info
+        } else {
+          refreshed_info
+        }
       } else {
         info.clone()
       }

--- a/src-tauri/src/account/models.rs
+++ b/src-tauri/src/account/models.rs
@@ -252,6 +252,7 @@ structstruck::strike! {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AuthServerInfo {
   pub auth_url: String,
+  pub server_name: Option<String>,
   pub client_id: Option<String>,
   pub metadata: Value,
   pub timestamp: u64,
@@ -260,10 +261,12 @@ pub struct AuthServerInfo {
 impl From<AuthServerInfo> for AuthServer {
   fn from(info: AuthServerInfo) -> Self {
     AuthServer {
-      name: info.metadata["meta"]["serverName"]
-        .as_str()
-        .unwrap_or_default()
-        .to_string(),
+      name: info.server_name.unwrap_or(
+        info.metadata["meta"]["serverName"]
+          .as_str()
+          .unwrap_or_default()
+          .to_string(),
+      ),
       auth_url: info.auth_url,
       homepage_url: info.metadata["meta"]["links"]["homepage"]
         .as_str()
@@ -302,6 +305,7 @@ impl Default for AccountInfo {
       auth_servers: PRESET_AUTH_SERVERS
         .iter()
         .map(|url| AuthServerInfo {
+          server_name: Some("".to_string()),
           auth_url: url.to_string(),
           client_id: None,
           metadata: Value::Null,

--- a/src-tauri/src/account/models.rs
+++ b/src-tauri/src/account/models.rs
@@ -305,7 +305,7 @@ impl Default for AccountInfo {
       auth_servers: PRESET_AUTH_SERVERS
         .iter()
         .map(|url| AuthServerInfo {
-          server_name: Some("".to_string()),
+          server_name: None,
           auth_url: url.to_string(),
           client_id: None,
           metadata: Value::Null,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -123,6 +123,7 @@ pub async fn run() {
         account::commands::fetch_auth_server,
         account::commands::add_auth_server,
         account::commands::delete_auth_server,
+        account::commands::rename_auth_server,
         account::commands::retrieve_other_launcher_account_info,
         account::commands::import_external_account_info,
         instance::commands::retrieve_instance_list,

--- a/src/components/modals/add-auth-server-modal.tsx
+++ b/src/components/modals/add-auth-server-modal.tsx
@@ -100,6 +100,11 @@ const AddAuthServerModal: React.FC<AddAuthServerModalProps> = ({
     setIsLoading(true);
     // save the server info to the storage
     AccountService.addAuthServer(trimmedServerUrl)
+      .then(async (response) => {
+        if (response.status !== "error")
+          await AccountService.renameAuthServer(trimmedServerUrl, serverName);
+        return Promise.resolve(response);
+      })
       .then((response) => {
         if (response.status === "success") {
           getAuthServerList(true);
@@ -172,10 +177,14 @@ const AddAuthServerModal: React.FC<AddAuthServerModalProps> = ({
           ) : (
             <VStack spacing={3.5} align="flex-start">
               <HStack spacing={2}>
-                <Text fontWeight={500}>
+                <Text fontWeight={500} whiteSpace="nowrap">
                   {t("AddAuthServerModal.page2.name")}
                 </Text>
-                <Text>{serverName}</Text>
+                <Input
+                  value={serverName}
+                  onChange={(e) => setServerName(e.target.value)}
+                  isRequired
+                />
               </HStack>
               <HStack spacing={2}>
                 <Text fontWeight={500}>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -81,7 +81,14 @@
       "add3rdPartyServer": "Add auth server",
       "sourceHomepage": "View Homepage",
       "deleteServer": "Delete Auth Server",
-      "importFromOtherLaunchers": "Import"
+      "importFromOtherLaunchers": "Import",
+      "rename": "Rename"
+    },
+    "renameServer": {
+      "title": "Rename Authentication Server",
+      "label": "New Authentication Server Name",
+      "error": "Failed to rename authentication server",
+      "success": "Successfully renamed authentication server"
     },
     "playerTypeList": {
       "all": "All Source"

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -81,7 +81,14 @@
       "add3rdPartyServer": "添加认证服务器",
       "sourceHomepage": "访问主页",
       "deleteServer": "删除此服务器",
-      "importFromOtherLaunchers": "从其他启动器导入"
+      "importFromOtherLaunchers": "从其他启动器导入",
+      "rename": "重命名"
+    },
+    "renameServer": {
+      "title": "重命名认证服务器",
+      "label": "新认证服务器名称",
+      "error": "重命名认证服务器失败",
+      "success": "重命名认证服务器成功"
     },
     "playerTypeList": {
       "all": "全部来源"

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -81,7 +81,14 @@
       "add3rdPartyServer": "新增認證伺服器",
       "sourceHomepage": "訪問首頁",
       "deleteServer": "刪除此伺服器",
-      "importFromOtherLaunchers": "從其他啟動器匯入"
+      "importFromOtherLaunchers": "從其他啟動器匯入",
+      "rename": "重命名"
+    },
+    "renameServer": {
+      "title": "重命名認證伺服器",
+      "label": "新認證伺服器名稱",
+      "error": "重命名認證伺服器失敗",
+      "success": "重命名認證伺服器成功"
     },
     "playerTypeList": {
       "all": "全部來源"

--- a/src/pages/accounts.tsx
+++ b/src/pages/accounts.tsx
@@ -1,11 +1,21 @@
 import {
   Box,
   Button,
+  FormControl,
+  FormLabel,
   Grid,
   GridItem,
   HStack,
   Icon,
   IconButton,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
   Text,
   Tooltip,
   VStack,
@@ -13,7 +23,7 @@ import {
 } from "@chakra-ui/react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import router from "next/router";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   LuCirclePlus,
@@ -23,6 +33,7 @@ import {
   LuLayoutGrid,
   LuLayoutList,
   LuLink2Off,
+  LuPenLine,
   LuPlus,
   LuServer,
   LuServerOff,
@@ -56,6 +67,7 @@ const AccountsPage = () => {
   const [selectedPlayerType, setSelectedPlayerType] = useState<string>("all");
   const [playerList, setPlayerList] = useState<Player[]>([]);
   const [authServerList, setAuthServerList] = useState<AuthServer[]>([]);
+  const [editingServerName, setEditingServerName] = useState("");
 
   const {
     isOpen: isAddPlayerModalOpen,
@@ -67,6 +79,12 @@ const AccountsPage = () => {
     isOpen: isImportAccountInfoModalOpen,
     onOpen: onImportAccountInfoModalOpen,
     onClose: onImportAccountInfoModalClose,
+  } = useDisclosure();
+
+  const {
+    isOpen: isEditServerNameModalOpen,
+    onOpen: onEditServerNameModalOpen,
+    onClose: onEditServerNameModalClose,
   } = useDisclosure();
 
   useEffect(() => {
@@ -178,6 +196,38 @@ const AccountsPage = () => {
     closeSharedModal("generic-confirm");
   };
 
+  const handleOpenEditServerNameModal = () => {
+    const server = authServerList.find(
+      (server) => server.authUrl === selectedPlayerType
+    );
+    if (server) {
+      setEditingServerName(server.name);
+      onEditServerNameModalOpen();
+    }
+  };
+
+  const handleSaveServerName = () => {
+    AccountService.renameAuthServer(selectedPlayerType, editingServerName).then(
+      (response) => {
+        if (response.status === "success") {
+          getAuthServerList(true);
+          toast({
+            title: t("AccountsPage.renameServer.success"),
+            status: "success",
+          });
+        } else {
+          toast({
+            title: t("AccountsPage.renameServer.error"),
+            description: response.details,
+            status: "error",
+          });
+        }
+      }
+    );
+
+    onEditServerNameModalClose();
+  };
+
   return (
     <>
       <Grid templateColumns="1fr 3fr" gap={4} h="100%">
@@ -240,6 +290,20 @@ const AccountsPage = () => {
             }
             headExtra={
               <HStack spacing={2} alignItems="flex-start">
+                {!["all", "offline", "microsoft"].includes(
+                  selectedPlayerType
+                ) && (
+                  <Tooltip label={t("AccountsPage.button.rename")}>
+                    <IconButton
+                      aria-label="rename"
+                      size="xs"
+                      fontSize="sm"
+                      variant="ghost"
+                      icon={<LuPenLine />}
+                      onClick={handleOpenEditServerNameModal}
+                    />
+                  </Tooltip>
+                )}
                 {!["all", "offline", "microsoft"].includes(
                   selectedPlayerType
                 ) && (
@@ -329,6 +393,42 @@ const AccountsPage = () => {
           </Section>
         </GridItem>
       </Grid>
+
+      <Modal
+        isOpen={isEditServerNameModalOpen}
+        onClose={onEditServerNameModalClose}
+      >
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>{t("AccountsPage.renameServer.title")}</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody pb={6}>
+            <FormControl isRequired>
+              <FormLabel>{t("AccountsPage.renameServer.label")}</FormLabel>
+              <Input
+                value={editingServerName}
+                onChange={(e) => setEditingServerName(e.target.value)}
+                autoFocus
+              />
+            </FormControl>
+          </ModalBody>
+          <ModalFooter>
+            <Button variant="ghost" onClick={onEditServerNameModalClose}>
+              {t("General.cancel")}
+            </Button>
+            <Button
+              colorScheme={primaryColor}
+              type={"submit"}
+              mr={3}
+              onClick={handleSaveServerName}
+              isDisabled={!editingServerName.trim()}
+            >
+              {t("Editable.save")}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+
       <AddPlayerModal
         isOpen={isAddPlayerModalOpen}
         onClose={onAddPlayerModalClose}

--- a/src/services/account.ts
+++ b/src/services/account.ts
@@ -293,6 +293,20 @@ export class AccountService {
   }
 
   /**
+   * RENAME the authentication server by URL.
+   * @param {string} url - The URL of the authentication server to be renamed.
+   * @param {string} target - The target name.
+   * @returns {Promise<InvokeResponse<void>>}
+   */
+  @responseHandler("account")
+  static async renameAuthServer(
+    url: string,
+    target: string
+  ): Promise<InvokeResponse<void>> {
+    return await invoke("rename_auth_server", { url, target });
+  }
+
+  /**
    * RETRIEVE other launcher account info for importing (stage 1).
    * @param {ImportLauncherType} launcherType - The external launcher type (e.g., HMCL / MultiMC).
    * @returns {Promise<InvokeResponse<[Player[], AuthServer[]]>>} - The other launcher account info for user selection.


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature

### Related Issues

resolves #1827

### Description


### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Enable users to set and update custom names for authentication servers throughout the account management flow.

New Features:
- Allow authentication server names to be customized when adding a server and edited later from the accounts page.

Enhancements:
- Preserve user-defined authentication server names when refreshing server metadata while retaining metadata names as the default.