### PR TITLE
feat: 日志窗口提供「结束游戏进程」的功能  

### DIFF
--- a/src-tauri/src/launch/commands.rs
+++ b/src-tauri/src/launch/commands.rs
@@ -11,9 +11,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::path::BaseDirectory;
 use tauri::{AppHandle, Manager, State};
 
-#[cfg(target_os = "windows")]
-use std::os::windows::process::CommandExt;
-
 use crate::account::helpers::misc::get_selected_player_info;
 use crate::account::helpers::offline::yggdrasil_server::YggdrasilServer;
 use crate::account::helpers::{authlib_injector, microsoft};
@@ -45,6 +42,9 @@ use crate::utils::fs::create_zip_from_dirs;
 use crate::utils::logging::get_launcher_log_path;
 use crate::utils::shell::{execute_command_line, split_command_line};
 use crate::utils::window::create_webview_window;
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+use sysinfo::{Pid, System};
 
 #[cfg(target_os = "windows")]
 use crate::launch::helpers::file_validator::get_invalid_windows_mesa_loader_file;
@@ -456,6 +456,19 @@ pub fn retrieve_game_launching_state(
   let launching_queue = launching_queue_state.lock()?;
   if let Some(launching) = launching_queue.iter().find(|l| l.id == launching_id) {
     Ok(launching.clone())
+  } else {
+    Err(LaunchError::LaunchingStateNotFound.into())
+  }
+}
+
+#[tauri::command]
+pub fn terminate_game_process(
+  launching_queue_state: State<'_, Mutex<Vec<LaunchingState>>>,
+  launching_id: u64,
+) -> SJMCLResult<()> {
+  let launching_queue = launching_queue_state.lock()?;
+  if let Some(launching) = launching_queue.iter().find(|l| l.id == launching_id) {
+    kill_process(launching.pid)
   } else {
     Err(LaunchError::LaunchingStateNotFound.into())
   }

--- a/src-tauri/src/launch/commands.rs
+++ b/src-tauri/src/launch/commands.rs
@@ -11,6 +11,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::path::BaseDirectory;
 use tauri::{AppHandle, Manager, State};
 
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+
 use crate::account::helpers::misc::get_selected_player_info;
 use crate::account::helpers::offline::yggdrasil_server::YggdrasilServer;
 use crate::account::helpers::{authlib_injector, microsoft};
@@ -42,9 +45,6 @@ use crate::utils::fs::create_zip_from_dirs;
 use crate::utils::logging::get_launcher_log_path;
 use crate::utils::shell::{execute_command_line, split_command_line};
 use crate::utils::window::create_webview_window;
-#[cfg(target_os = "windows")]
-use std::os::windows::process::CommandExt;
-use sysinfo::{Pid, System};
 
 #[cfg(target_os = "windows")]
 use crate::launch::helpers::file_validator::get_invalid_windows_mesa_loader_file;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -168,6 +168,7 @@ pub async fn run() {
         launch::commands::open_game_log_window,
         launch::commands::retrieve_game_log,
         launch::commands::retrieve_game_launching_state,
+        launch::commands::terminate_game_process,
         launch::commands::export_game_crash_info,
         resource::commands::fetch_game_version_list,
         resource::commands::fetch_game_version_specific,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1106,7 +1106,8 @@
     "placeholder": "Filter by Text",
     "revealRawLog": "Reveal Raw Log File",
     "clearLogs": "Clear All Logs",
-    "scrollToBottom": "Scroll to Bottom"
+    "scrollToBottom": "Scroll to Bottom",
+    "terminate": "Terminate Game Process"
   },
   "GameVersionSelector": {
     "old_beta": "Beta",

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -1106,7 +1106,8 @@
     "placeholder": "输入关键词筛选",
     "revealRawLog": "显示原始日志文件",
     "clearLogs": "清除所有日志",
-    "scrollToBottom": "滚动到底部"
+    "scrollToBottom": "滚动到底部",
+    "terminate": "结束游戏进程"
   },
   "GameVersionSelector": {
     "old_beta": "远古版",

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -1106,7 +1106,8 @@
     "placeholder": "輸入關鍵字篩選",
     "revealRawLog": "顯示原始日誌檔案",
     "clearLogs": "清除所有日誌",
-    "scrollToBottom": "滾動到底部"
+    "scrollToBottom": "滾動到底部",
+    "terminate": "結束遊戲進程"
   },
   "GameVersionSelector": {
     "old_beta": "遠古版",

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -1107,7 +1107,7 @@
     "revealRawLog": "顯示原始日誌檔案",
     "clearLogs": "清除所有日誌",
     "scrollToBottom": "滾動到底部",
-    "terminate": "結束遊戲進程"
+    "terminate": "結束遊戲處理程式"
   },
   "GameVersionSelector": {
     "old_beta": "遠古版",

--- a/src/pages/standalone/game-log.tsx
+++ b/src/pages/standalone/game-log.tsx
@@ -14,7 +14,7 @@ import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import { MouseEvent, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { LuChevronsDown, LuFileInput, LuTrash } from "react-icons/lu";
+import { LuChevronsDown, LuFileInput, LuTrash, LuX } from "react-icons/lu";
 import {
   AutoSizer,
   CellMeasurer,
@@ -297,6 +297,11 @@ const GameLogPage: React.FC = () => {
 
   const clearLogs = () => setLogs([]);
 
+  const terminateGameProcess = () => {
+    if (launchingIdRef.current != null)
+      LaunchService.terminateGameProcess(launchingIdRef.current);
+  };
+
   const revealRawLogFile = async () => {
     if (!launchingIdRef.current) return;
 
@@ -388,6 +393,16 @@ const GameLogPage: React.FC = () => {
             {level} ({logCounts[level] || 0})
           </Button>
         ))}
+        <Tooltip label={t("GameLogPage.terminate")} placement="bottom">
+          <IconButton
+            icon={<LuX />}
+            aria-label={t("GameLogPage.terminate")}
+            variant="ghost"
+            size="sm"
+            colorScheme="gray"
+            onClick={terminateGameProcess}
+          />
+        </Tooltip>
         <Tooltip label={t("GameLogPage.revealRawLog")} placement="bottom">
           <IconButton
             icon={<LuFileInput />}

--- a/src/services/launch.ts
+++ b/src/services/launch.ts
@@ -107,6 +107,19 @@ export class LaunchService {
   }
 
   /**
+   * TERMAITE the game process.
+   * This command is usually called by the game error window when game process crashed.
+   * @param {number} launchingId The id of the launching state to retrieve.
+   * @returns {Promise<InvokeResponse<LaunchingState>>} The current game launching state.
+   */
+  @responseHandler("launch")
+  static async terminateGameProcess(
+    launchingId: number
+  ): Promise<InvokeResponse<void>> {
+    return await invoke("terminate_game_process", { launchingId });
+  }
+
+  /**
    * EXPORT the game crash info to a zip file and reveal it in the file explorer.
    * This command is usually called by the game error window when game process crashed.
    * @param {number} launchingId The id of the launching state to export.

--- a/src/services/launch.ts
+++ b/src/services/launch.ts
@@ -107,10 +107,10 @@ export class LaunchService {
   }
 
   /**
-   * TERMAITE the game process.
-   * This command is usually called by the game error window when game process crashed.
-   * @param {number} launchingId The id of the launching state to retrieve.
-   * @returns {Promise<InvokeResponse<LaunchingState>>} The current game launching state.
+   * TERMINATE the game process.
+   * This command is usually called by the game-log window to terminate a running game process.
+   * @param {number} launchingId The id of the launching state to terminate.
+   * @returns {Promise<InvokeResponse<void>>}
    */
   @responseHandler("launch")
   static async terminateGameProcess(


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature

### Related Issues

resolves #1697

### Description

<img width="377" height="138" alt="image" src="https://github.com/user-attachments/assets/f30319a5-1853-491f-9017-ce43edbd0983" />

### Additional Context

目前点击结束后会弹窗游戏非正常退出窗口，这个窗口有没有必要保留🤔

## Summary by Sourcery

New Features:
- Add a control in the game log window to terminate the associated running game process.