### PR TITLE
fix(instance): preserve resource pack cache when world retrieval fails

### DIFF
--- a/src/contexts/instance.tsx
+++ b/src/contexts/instance.tsx
@@ -297,7 +297,7 @@ export const InstanceContextProvider: React.FC<{
         description: response.details,
         status: "error",
       });
-      setResourcePacks([]);
+      setWorlds([]);
       return [];
     }
   }, [setWorlds, toast]);


### PR DESCRIPTION
### Checklist

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🐞 Bug fix

### Related Issues

close #1936

### Description

Fix the world-list error path so it clears the world state instead of the cached resource-pack state.

When world retrieval fails, existing resource packs now remain unchanged while the world list is reset and the error toast is displayed.

### Additional Context

Validated the failure path with an isolated callback test. TypeScript checking, ESLint, and the production frontend build also pass locally.

## Summary by Sourcery

Preserve resource-pack cache when world retrieval fails.

Bug Fixes:
- Preserve cached resource packs when world retrieval fails by resetting only the world state while still displaying the error notification.

Tests:
- Add isolated callback coverage for the world-retrieval failure path.
