### PR TITLE
fix(instance): support Quilt metadata without optional mappings

### DIFF
--- a/src-tauri/src/instance/helpers/loader/quilt.rs
+++ b/src-tauri/src/instance/helpers/loader/quilt.rs
@@ -24,6 +24,23 @@ fn resolve_maven_root<'a>(coord: &str, quilt_root: &'a str) -> &'a str {
   }
 }
 
+fn get_quilt_library_paths(meta: &serde_json::Value) -> SJMCLResult<Vec<&str>> {
+  let loader_path = meta["loader"]["maven"]
+    .as_str()
+    .ok_or(SJMCLError("meta missing loader maven".to_string()))?;
+
+  Ok(
+    [
+      Some(loader_path),
+      meta["intermediary"]["maven"].as_str(),
+      meta["hashed"]["maven"].as_str(),
+    ]
+    .into_iter()
+    .flatten()
+    .collect(),
+  )
+}
+
 pub async fn install_quilt_loader(
   app: AppHandle,
   priority: &[SourceType],
@@ -63,15 +80,7 @@ pub async fn install_quilt_loader(
   let meta = meta.ok_or(SJMCLError("failed to fetch Quilt loader meta".to_string()))?;
   let quilt_maven = quilt_maven.ok_or(SJMCLError("failed to get Quilt Maven URL".to_string()))?;
 
-  let loader_path = meta["loader"]["maven"]
-    .as_str()
-    .ok_or(SJMCLError("meta missing loader maven".to_string()))?;
-  let int_path = meta["intermediary"]["maven"]
-    .as_str()
-    .ok_or(SJMCLError("meta missing intermediary maven".to_string()))?;
-  let hashed_path = meta["hashed"]["maven"]
-    .as_str()
-    .ok_or(SJMCLError("meta missing hashed maven".to_string()))?;
+  let library_paths = get_quilt_library_paths(&meta)?;
 
   let main_class = meta["launcherMeta"]["mainClass"]["client"]
     .as_str()
@@ -85,7 +94,7 @@ pub async fn install_quilt_loader(
     ..Default::default()
   };
 
-  for path in &[loader_path, int_path, hashed_path] {
+  for path in &library_paths {
     add_library_entry(&mut client_info.libraries, path, None)?;
     add_library_entry(&mut new_patch.libraries, path, None)?;
   }
@@ -140,7 +149,7 @@ pub async fn install_quilt_loader(
   }
   client_info.patches.push(new_patch);
 
-  for path in &[loader_path, int_path, hashed_path] {
+  for path in &library_paths {
     let rel: String = convert_library_name_to_path(path, None)?;
     let root_url = resolve_maven_root(path, quilt_maven.as_str());
     let full_url = Url::parse(root_url)?.join(&rel)?;

--- a/src-tauri/src/resource/helpers/loader_meta/quilt.rs
+++ b/src-tauri/src/resource/helpers/loader_meta/quilt.rs
@@ -1,6 +1,5 @@
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use sjmcl_types::error::SJMCLResult;
 use tauri::{AppHandle, Manager};
 use tauri_plugin_http::reqwest;
@@ -13,7 +12,6 @@ use crate::resource::models::{ModLoaderResourceInfo, ResourceError, ResourceType
 #[serde(rename_all = "camelCase")]
 struct QuiltMetaItem {
   pub loader: QuiltLoaderInfo,
-  pub intermediary: Value,
 }
 
 #[derive(Serialize, Deserialize, Default)]


### PR DESCRIPTION
### Checklist

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🐞 Bug fix

### Related Issues

close #1937

### Description

Allow Quilt loader metadata to omit the `intermediary` and `hashed` Maven coordinates while keeping the loader coordinate required.

Only coordinates present in the metadata are now added to the version patch and download tasks. Legacy metadata containing all three coordinates remains supported.

### Additional Context

Validated against current official Quilt metadata for Minecraft 26.1 and legacy metadata for 1.20.1, including independently missing optional fields. The updated production helper was validated with a temporary external harness, and no test code is included in this PR. Rust formatting and all GitHub CI checks pass for the amended commit.

## Summary by Sourcery

Allow Quilt loader installation to handle metadata with missing optional Maven mappings.

Bug Fixes:
- Support Quilt loader metadata that omits optional intermediary and hashed Maven coordinates while continuing to require the loader coordinate.

Enhancements:
- Use only the Maven coordinates present in Quilt metadata when creating version patches and download entries, while retaining compatibility with legacy metadata.