### PR TITLE
feat(mod-loader): support install Forge for minecraft <=1.5.1

### DIFF
--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -1093,6 +1093,7 @@ pub async fn create_instance(
       },
       version: mod_loader.version.clone(),
       branch: mod_loader.branch.clone(),
+      forge_artifact_type: mod_loader.forge_artifact_type,
     },
     optifine: optifine_info,
     description,
@@ -1485,6 +1486,7 @@ pub async fn change_mod_loader(
       ModLoaderStatus::NotDownloaded
     },
     branch: new_mod_loader.branch.clone(),
+    forge_artifact_type: new_mod_loader.forge_artifact_type,
   };
 
   instance.mod_loader = mod_loader.clone();
@@ -1563,6 +1565,7 @@ pub async fn remove_mod_loader(app: AppHandle, instance_id: String) -> SJMCLResu
     version: String::new(),
     status: ModLoaderStatus::Installed,
     branch: None,
+    forge_artifact_type: None,
   };
 
   save_json_async(&version_info, &json_path).await?;

--- a/src-tauri/src/instance/helpers/loader/forge.rs
+++ b/src-tauri/src/instance/helpers/loader/forge.rs
@@ -16,7 +16,9 @@ use crate::instance::helpers::client_json::{
 };
 use crate::instance::helpers::loader::common::add_library_entry;
 use crate::instance::helpers::misc::get_instance_subdir_paths;
-use crate::instance::models::misc::{Instance, InstanceError, InstanceSubdirType, ModLoader};
+use crate::instance::models::misc::{
+  ForgeArtifactType, Instance, InstanceError, InstanceSubdirType, ModLoader, ModLoaderStatus,
+};
 use crate::launch::helpers::file_validator::convert_library_name_to_path;
 use crate::resource::helpers::misc::{convert_url_to_target_source, get_download_api};
 use crate::resource::models::{ResourceType, SourceType};
@@ -24,11 +26,12 @@ use crate::tasks::PTaskParam;
 use crate::tasks::commands::schedule_progressive_task_group;
 use crate::tasks::download::DownloadParam;
 
-async fn fetch_bmcl_forge_installer_url(
+async fn fetch_bmcl_forge_artifact_url(
   root: Url,
   game_version: &str,
   loader_ver: &str,
   branch: Option<&str>,
+  artifact_type: ForgeArtifactType,
 ) -> Result<String, Error> {
   let client = Client::builder().redirect(Policy::limited(5)).build()?;
 
@@ -38,14 +41,43 @@ async fn fetch_bmcl_forge_installer_url(
       ("mcversion", game_version),
       ("version", loader_ver),
       ("branch", branch.unwrap_or("")),
-      ("category", "installer"),
-      ("format", "jar"),
+      ("category", artifact_type.category()),
+      ("format", artifact_type.extension()),
     ])
     .send()
     .await?;
 
   let final_url = response.url().to_string();
   Ok(final_url)
+}
+
+fn get_forge_full_version(game_version: &str, loader: &ModLoader) -> String {
+  [
+    game_version,
+    &loader.version,
+    loader.branch.as_deref().unwrap_or_default(),
+  ]
+  .into_iter()
+  .filter(|part| !part.is_empty())
+  .collect::<Vec<_>>()
+  .join("-")
+}
+
+fn get_forge_artifact_coord(
+  game_version: &str,
+  loader: &ModLoader,
+  artifact_type: ForgeArtifactType,
+) -> String {
+  if artifact_type == ForgeArtifactType::Installer {
+    format!("net.minecraftforge:forge:{}-installer", loader.version)
+  } else {
+    format!(
+      "net.minecraftforge:forge:{}:{}@{}",
+      get_forge_full_version(game_version, loader),
+      artifact_type.category(),
+      artifact_type.extension()
+    )
+  }
 }
 
 pub async fn install_forge_loader(
@@ -56,52 +88,50 @@ pub async fn install_forge_loader(
   task_params: &mut Vec<PTaskParam>,
 ) -> SJMCLResult<()> {
   let loader_ver = &loader.version;
+  let artifact_type = loader.forge_artifact_type.unwrap_or_default();
+  let full_ver = get_forge_full_version(game_version, loader);
 
-  let mut installer_url_opt: Option<Url> = None;
+  let mut artifact_url_opt: Option<Url> = None;
   for source_type in priority.iter() {
     if let Ok(root) = get_download_api(*source_type, ResourceType::ForgeInstall) {
       let url_res: SJMCLResult<Url> = match source_type {
         SourceType::Official => {
-          let full_ver = vec![
-            game_version,
-            loader_ver,
-            loader.branch.as_ref().unwrap_or(&"".to_string()),
-          ]
-          .into_iter()
-          .filter(|s| !s.is_empty())
-          .collect::<Vec<_>>()
-          .join("-");
-          Ok(root.join(&format!("{full_ver}/forge-{full_ver}-installer.jar"))?)
+          let category = artifact_type.category();
+          let extension = artifact_type.extension();
+          Ok(root.join(&format!(
+            "{full_ver}/forge-{full_ver}-{category}.{extension}"
+          ))?)
         }
         SourceType::BMCLAPIMirror => {
-          let s = fetch_bmcl_forge_installer_url(
+          let s = fetch_bmcl_forge_artifact_url(
             root,
             game_version,
             loader_ver,
             loader.branch.as_deref(),
+            artifact_type,
           )
           .await?;
           Ok(Url::parse(&s)?)
         }
       };
       if let Ok(url) = url_res {
-        installer_url_opt = Some(url);
+        artifact_url_opt = Some(url);
         break;
       }
     }
   }
 
-  let installer_url = installer_url_opt.ok_or(SJMCLError(
-    "failed to resolve Forge installer URL".to_string(),
+  let artifact_url = artifact_url_opt.ok_or(SJMCLError(
+    "failed to resolve Forge artifact URL".to_string(),
   ))?;
 
-  let installer_coord = format!("net.minecraftforge:forge:{}-installer", loader.version);
-  let installer_rel = convert_library_name_to_path(&installer_coord, None)?;
-  let installer_path = lib_dir.join(&installer_rel);
+  let artifact_coord = get_forge_artifact_coord(game_version, loader, artifact_type);
+  let artifact_rel = convert_library_name_to_path(&artifact_coord, None)?;
+  let artifact_path = lib_dir.join(&artifact_rel);
 
   task_params.push(PTaskParam::Download(DownloadParam {
-    src: installer_url,
-    dest: installer_path.clone(),
+    src: artifact_url,
+    dest: artifact_path,
     filename: None,
     sha1: None,
   }));
@@ -112,7 +142,7 @@ pub async fn install_forge_loader(
 pub async fn download_forge_libraries(
   app: &AppHandle,
   priority: &[SourceType],
-  instance: &Instance,
+  instance: &mut Instance,
   client_info: &mut McClientInfo,
 ) -> SJMCLResult<()> {
   let subdirs = get_instance_subdir_paths(
@@ -126,12 +156,32 @@ pub async fn download_forge_libraries(
   };
   let mut task_params = vec![];
 
-  let installer_coord = format!(
-    "net.minecraftforge:forge:{}-installer",
-    instance.mod_loader.version
-  );
-  let installer_rel = convert_library_name_to_path(&installer_coord, None)?;
-  let installer_path = lib_dir.join(&installer_rel);
+  let artifact_type = instance.mod_loader.forge_artifact_type.unwrap_or_default();
+  let artifact_coord =
+    get_forge_artifact_coord(&instance.version, &instance.mod_loader, artifact_type);
+  let artifact_path = lib_dir.join(convert_library_name_to_path(&artifact_coord, None)?);
+  if !artifact_path.exists() {
+    return Err(InstanceError::LoaderInstallerNotFound.into());
+  }
+
+  if artifact_type != ForgeArtifactType::Installer {
+    client_info.patches.push(McClientInfo {
+      id: "forge".to_string(),
+      version: Some(instance.mod_loader.version.clone()),
+      priority: Some(30000),
+      inherits_from: Some(instance.version.clone()),
+      libraries: vec![LibrariesValue {
+        name: artifact_coord,
+        ..Default::default()
+      }],
+      ..Default::default()
+    });
+    reset_fields_from_patches(client_info);
+    instance.mod_loader.status = ModLoaderStatus::Installed;
+    return Ok(());
+  }
+
+  let installer_path = artifact_path;
   let bin_patch = lib_dir.join(convert_library_name_to_path(
     &format!(
       "net.minecraftforge:forge:{}:clientdata@lzma",
@@ -139,9 +189,6 @@ pub async fn download_forge_libraries(
     ),
     None,
   )?);
-  if !installer_path.exists() {
-    return Err(InstanceError::LoaderInstallerNotFound.into());
-  }
   let file = File::open(&installer_path)?;
   let mut archive = ZipArchive::new(file)?;
 

--- a/src-tauri/src/instance/helpers/misc.rs
+++ b/src-tauri/src/instance/helpers/misc.rs
@@ -175,7 +175,8 @@ async fn refresh_instance(
           match cfg_read.mod_loader.loader_type {
             ModLoaderType::Forge => {
               cfg_read.mod_loader.status = ModLoaderStatus::Downloading;
-              download_forge_libraries(app, &priority_list, &cfg_read, &mut client_data).await?;
+              download_forge_libraries(app, &priority_list, &mut cfg_read, &mut client_data)
+                .await?;
             }
             ModLoaderType::Cleanroom => {
               cfg_read.mod_loader.status = ModLoaderStatus::Downloading;
@@ -198,7 +199,7 @@ async fn refresh_instance(
         ModLoaderStatus::DownloadFailed => match cfg_read.mod_loader.loader_type {
           ModLoaderType::Forge => {
             cfg_read.mod_loader.status = ModLoaderStatus::Downloading;
-            download_forge_libraries(app, &priority_list, &cfg_read, &mut client_data).await
+            download_forge_libraries(app, &priority_list, &mut cfg_read, &mut client_data).await
           }
           ModLoaderType::Cleanroom => {
             cfg_read.mod_loader.status = ModLoaderStatus::Downloading;
@@ -313,6 +314,7 @@ async fn refresh_instance(
         version: loader_version.unwrap_or_default(),
         status: ModLoaderStatus::Installed,
         branch: None,
+        forge_artifact_type: None,
       }
     },
     optifine: if !optifine_installed {

--- a/src-tauri/src/instance/helpers/modpack/import.rs
+++ b/src-tauri/src/instance/helpers/modpack/import.rs
@@ -64,6 +64,7 @@ impl ModLoader {
     if let Some(version) = version_list.iter().find(|v| v.version == self.version) {
       return Ok(Self {
         branch: version.branch.clone(),
+        forge_artifact_type: version.forge_artifact_type,
         ..self.clone()
       });
     }

--- a/src-tauri/src/instance/models/misc.rs
+++ b/src-tauri/src/instance/models/misc.rs
@@ -71,6 +71,31 @@ impl ModLoaderType {
   }
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Deserialize, Serialize, Default)]
+pub enum ForgeArtifactType {
+  #[default]
+  Installer,
+  Universal,
+  Client,
+}
+
+impl ForgeArtifactType {
+  pub fn category(self) -> &'static str {
+    match self {
+      Self::Installer => "installer",
+      Self::Universal => "universal",
+      Self::Client => "client",
+    }
+  }
+
+  pub fn extension(self) -> &'static str {
+    match self {
+      Self::Installer => "jar",
+      Self::Universal | Self::Client => "zip",
+    }
+  }
+}
+
 #[derive(Debug, PartialEq, Eq, Deserialize, Clone, Serialize, Default)]
 pub enum ModLoaderStatus {
   NotDownloaded, // mod loader's library has not been downloaded
@@ -101,6 +126,7 @@ structstruck::strike! {
       pub loader_type: ModLoaderType,
       pub version: String,
       pub branch: Option<String>, // Optional branch name for mod loaders like Forge
+      pub forge_artifact_type: Option<ForgeArtifactType>,
     },
     pub optifine: Option<OptiFine>,
     // if true, use the spec_game_config, else use the global game config

--- a/src-tauri/src/intelligence/mcp_server/launcher/tools/instance.rs
+++ b/src-tauri/src/intelligence/mcp_server/launcher/tools/instance.rs
@@ -37,6 +37,7 @@ async fn resolve_mod_loader(
       description: String::new(),
       stable: None,
       branch: None,
+      forge_artifact_type: None,
     });
   }
 

--- a/src-tauri/src/resource/helpers/loader_meta/cleanroom.rs
+++ b/src-tauri/src/resource/helpers/loader_meta/cleanroom.rs
@@ -32,6 +32,7 @@ async fn get_cleanroom_meta_by_game_version_official(
                 description: info.created_at,
                 stable: None,
                 branch: None,
+                forge_artifact_type: None,
               })
               .collect(),
           )

--- a/src-tauri/src/resource/helpers/loader_meta/fabric.rs
+++ b/src-tauri/src/resource/helpers/loader_meta/fabric.rs
@@ -49,6 +49,7 @@ pub async fn get_fabric_meta_by_game_version(
                   // stable: info.loader.stable,
                   stable: None,
                   branch: None,
+                  forge_artifact_type: None,
                 })
                 .collect(),
             );

--- a/src-tauri/src/resource/helpers/loader_meta/forge.rs
+++ b/src-tauri/src/resource/helpers/loader_meta/forge.rs
@@ -4,7 +4,7 @@ use sjmcl_types::error::SJMCLResult;
 use tauri::{AppHandle, Manager};
 use tauri_plugin_http::reqwest;
 
-use crate::instance::models::misc::ModLoaderType;
+use crate::instance::models::misc::{ForgeArtifactType, ModLoaderType};
 use crate::resource::helpers::misc::get_download_api;
 use crate::resource::models::{ModLoaderResourceInfo, ResourceError, ResourceType, SourceType};
 
@@ -12,10 +12,30 @@ use crate::resource::models::{ModLoaderResourceInfo, ResourceError, ResourceType
 struct ForgeMetaItem {
   pub branch: Option<Value>,
   pub build: i64,
-  pub files: Vec<Value>,
+  pub files: Vec<ForgeMetaFile>,
   pub mcversion: String,
   pub modified: String,
   pub version: String,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+struct ForgeMetaFile {
+  category: String,
+  format: String,
+}
+
+fn select_forge_artifact(files: &[ForgeMetaFile]) -> Option<ForgeArtifactType> {
+  [
+    ForgeArtifactType::Installer,
+    ForgeArtifactType::Universal,
+    ForgeArtifactType::Client,
+  ]
+  .into_iter()
+  .find(|artifact| {
+    files
+      .iter()
+      .any(|file| file.category == artifact.category() && file.format == artifact.extension())
+  })
 }
 
 async fn get_forge_meta_by_game_version_bmcl(
@@ -34,13 +54,17 @@ async fn get_forge_meta_by_game_version_bmcl(
           Ok(
             manifest
               .into_iter()
-              .map(|info| ModLoaderResourceInfo {
-                loader_type: ModLoaderType::Forge,
-                version: info.version,
-                description: info.modified,
-                // stable: true,
-                stable: None,
-                branch: info.branch.and_then(|v| v.as_str().map(String::from)),
+              .filter_map(|info| {
+                let forge_artifact_type = select_forge_artifact(&info.files)?;
+                Some(ModLoaderResourceInfo {
+                  loader_type: ModLoaderType::Forge,
+                  version: info.version,
+                  description: info.modified,
+                  // stable: true,
+                  stable: None,
+                  branch: info.branch.and_then(|v| v.as_str().map(String::from)),
+                  forge_artifact_type: Some(forge_artifact_type),
+                })
               })
               .collect(),
           )

--- a/src-tauri/src/resource/helpers/loader_meta/neoforge.rs
+++ b/src-tauri/src/resource/helpers/loader_meta/neoforge.rs
@@ -90,6 +90,7 @@ async fn get_neoforge_meta_by_game_version_official(
                 .is_none_or(|v| !v.as_bool().unwrap_or(false)),
             ),
             branch: None,
+            forge_artifact_type: None,
           },
         ));
       }
@@ -190,6 +191,7 @@ async fn get_neoforge_meta_by_game_version_official(
               description: String::new(),
               stable: Some(stable),
               branch: None,
+              forge_artifact_type: None,
             },
           ));
         }
@@ -244,6 +246,7 @@ async fn get_neoforge_meta_by_game_version_bmcl(
                   description: String::new(),
                   stable: Some(stable),
                   branch: None,
+                  forge_artifact_type: None,
                 }
               })
               .collect(),

--- a/src-tauri/src/resource/helpers/loader_meta/quilt.rs
+++ b/src-tauri/src/resource/helpers/loader_meta/quilt.rs
@@ -64,6 +64,7 @@ pub async fn get_quilt_meta_by_game_version(
                     description: String::new(),
                     stable: Some(stable),
                     branch: None,
+                    forge_artifact_type: None,
                   }
                 })
                 .collect(),

--- a/src-tauri/src/resource/models.rs
+++ b/src-tauri/src/resource/models.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use strum_macros::{Display, EnumIter};
 
-use crate::instance::models::misc::ModLoaderType;
+use crate::instance::models::misc::{ForgeArtifactType, ModLoaderType};
 
 #[derive(Eq, Hash, PartialEq, Clone, Copy, Debug, EnumIter)]
 pub enum ResourceType {
@@ -187,6 +187,7 @@ pub struct ModLoaderResourceInfo {
   pub description: String,
   pub stable: Option<bool>,
   pub branch: Option<String>,
+  pub forge_artifact_type: Option<ForgeArtifactType>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize, Default)]

--- a/src/enums/instance.ts
+++ b/src/enums/instance.ts
@@ -22,4 +22,10 @@ export enum ModLoaderType {
   Quilt = "Quilt",
 }
 
+export enum ForgeArtifactType {
+  Installer = "Installer",
+  Universal = "Universal",
+  Client = "Client",
+}
+
 export type ExportModpackFormat = "Modrinth" | "MultiMC";

--- a/src/models/instance/misc.ts
+++ b/src/models/instance/misc.ts
@@ -1,4 +1,8 @@
-import { ExportModpackFormat, ModLoaderType } from "@/enums/instance";
+import {
+  ExportModpackFormat,
+  ForgeArtifactType,
+  ModLoaderType,
+} from "@/enums/instance";
 import { OtherResourceSource } from "@/enums/resource";
 
 export enum ModLoaderStatus {
@@ -14,6 +18,7 @@ export interface ModLoader {
   loaderType: ModLoaderType;
   version?: string;
   branch?: string;
+  forgeArtifactType?: ForgeArtifactType;
 }
 
 export interface OptiFine {

--- a/src/models/resource.ts
+++ b/src/models/resource.ts
@@ -1,4 +1,4 @@
-import { ModLoaderType } from "@/enums/instance";
+import { ForgeArtifactType, ModLoaderType } from "@/enums/instance";
 import {
   DependencyType,
   OtherResourceSource,
@@ -66,6 +66,7 @@ export interface ModLoaderResourceInfo {
   description: string;
   stable?: boolean;
   branch?: string;
+  forgeArtifactType?: ForgeArtifactType;
 }
 
 export const defaultModLoaderResourceInfo: ModLoaderResourceInfo = {


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

close #1954

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Support installation of legacy Forge releases by selecting and handling the appropriate Forge artifact type.

New Features:
- Support installing Forge versions that provide universal or client ZIP artifacts, including Minecraft versions up to 1.5.1.
- Expose Forge artifact type metadata across loader resources and instance models.

Bug Fixes:
- Resolve Forge downloads using the artifact type available for each version instead of assuming an installer JAR.

Enhancements:
- Integrate non-installer Forge artifacts into the generated Minecraft client configuration and installation lifecycle.