### PR TITLE
feat: 支持安装 1.2~1.5 版本 Forge

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,15 +1,15 @@
-use comfy_table::{ContentArrangement, Table, presets::UTF8_FULL_CONDENSED};
+use comfy_table::{presets::UTF8_FULL_CONDENSED, ContentArrangement, Table};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
-use rmcp::ServiceExt;
 use rmcp::model::{CallToolRequestParams, Tool};
 use rmcp::service::{RoleClient, RunningService};
 use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::ServiceExt;
 use serde_json::{Map, Value};
 use std::env;
 use std::ffi::OsString;
 use std::io::{self, IsTerminal};
 use std::process::Command;
-use tokio::time::{Instant, sleep};
+use tokio::time::{sleep, Instant};
 
 type LauncherClient = RunningService<RoleClient, ()>;
 
@@ -21,7 +21,8 @@ const EXPECTED_SERVER_NAME: &str = "sjmcl-mcp";
 const MCP_SERVER_HOST: &str = "127.0.0.1";
 const MCP_SERVER_PATH: &str = "/mcp";
 const RUN_SJMCL_DEEPLINK: &str = "sjmcl://run-silently";
-const ENABLE_MCP_HINT: &str = "Please enable Launcher MCP Server in SJMCL - Intelligence to use the CLI.\nIf your MCP server uses a port other than the default 18970, run the CLI with `-p <port>`.";
+const ENABLE_MCP_HINT: &str =
+  "Please enable Launcher MCP Server in SJMCL - Intelligence to use the CLI.\nIf your MCP server uses a port other than the default 18970, run the CLI with `-p <port>`.";
 
 #[derive(Clone)]
 struct CliOptions {
@@ -60,20 +61,20 @@ async fn run() -> Result<(), String> {
   match invocation.command {
     CliCommand::Help => {
       let (tools, hint) =
-        match with_spinner(async { connect_launcher(&invocation.options).await }).await {
-          Ok(client) => {
-            let tools = with_spinner(async {
-              client
-                .list_all_tools()
-                .await
-                .map_err(service_error_to_string)
-            })
-            .await?;
-            let _ = client.cancel().await;
-            (Some(tools), None)
-          }
-          Err(err) => (None, Some(err)),
-        };
+          match with_spinner(async { connect_launcher(&invocation.options).await }).await {
+            Ok(client) => {
+              let tools = with_spinner(async {
+                client
+                    .list_all_tools()
+                    .await
+                    .map_err(service_error_to_string)
+              })
+                  .await?;
+              let _ = client.cancel().await;
+              (Some(tools), None)
+            }
+            Err(err) => (None, Some(err)),
+          };
 
       print_help(tools.as_deref(), hint.as_deref());
       Ok(())
@@ -82,11 +83,11 @@ async fn run() -> Result<(), String> {
       let client = with_spinner(async { connect_launcher(&invocation.options).await }).await?;
       let result = with_spinner(async {
         client
-          .call_tool(CallToolRequestParams::new(name.clone()).with_arguments(arguments))
-          .await
-          .map_err(service_error_to_string)
+            .call_tool(CallToolRequestParams::new(name.clone()).with_arguments(arguments))
+            .await
+            .map_err(service_error_to_string)
       })
-      .await?;
+          .await?;
       let _ = client.cancel().await;
 
       print_call_result(&result);
@@ -103,7 +104,7 @@ async fn run() -> Result<(), String> {
 impl CliInvocation {
   fn parse<I>(args: I) -> Result<Self, String>
   where
-    I: IntoIterator<Item = OsString>,
+      I: IntoIterator<Item = OsString>,
   {
     let mut args = args.into_iter();
     let _bin = args.next();
@@ -122,8 +123,8 @@ impl CliInvocation {
         }
         "-p" | "--port" => {
           let value = args
-            .next()
-            .ok_or_else(|| "missing value for --port".to_string())?;
+              .next()
+              .ok_or_else(|| "missing value for --port".to_string())?;
           options.port = parse_u16_option("--port", &os_string_to_string(value)?)?;
         }
         _ if arg.starts_with("-p=") => {
@@ -136,8 +137,8 @@ impl CliInvocation {
           rest.push(arg);
           rest.extend(
             args
-              .map(os_string_to_string)
-              .collect::<Result<Vec<_>, _>>()?,
+                .map(os_string_to_string)
+                .collect::<Result<Vec<_>, _>>()?,
           );
           break;
         }
@@ -188,13 +189,13 @@ async fn try_connect(port: u16) -> Result<LauncherClient, String> {
   let endpoint = mcp_endpoint(port);
   let transport = StreamableHttpClientTransport::from_uri(endpoint.clone());
   let client = ()
-    .serve(transport)
-    .await
-    .map_err(|err| format!("failed to initialize MCP client for {endpoint}: {err}"))?;
+      .serve(transport)
+      .await
+      .map_err(|err| format!("failed to initialize MCP client for {endpoint}: {err}"))?;
 
   let server_info = client
-    .peer_info()
-    .ok_or_else(|| format!("server at {endpoint} did not provide MCP server info"))?;
+      .peer_info()
+      .ok_or_else(|| format!("server at {endpoint} did not provide MCP server info"))?;
 
   if server_info.server_info.name != EXPECTED_SERVER_NAME {
     let actual_name = server_info.server_info.name.clone();
@@ -243,40 +244,40 @@ fn print_tool_list(tools: &[Tool]) {
 
 fn summarize_input_schema(tool: &Tool) -> String {
   let required = tool
-    .input_schema
-    .get("required")
-    .and_then(Value::as_array)
-    .map(|items| {
-      items
-        .iter()
-        .filter_map(Value::as_str)
-        .map(ToString::to_string)
-        .collect::<Vec<_>>()
-    })
-    .unwrap_or_default();
+      .input_schema
+      .get("required")
+      .and_then(Value::as_array)
+      .map(|items| {
+        items
+            .iter()
+            .filter_map(Value::as_str)
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+      })
+      .unwrap_or_default();
 
   let properties = tool
-    .input_schema
-    .get("properties")
-    .and_then(Value::as_object)
-    .map(|props| props.keys().cloned().collect::<Vec<_>>())
-    .unwrap_or_default();
+      .input_schema
+      .get("properties")
+      .and_then(Value::as_object)
+      .map(|props| props.keys().cloned().collect::<Vec<_>>())
+      .unwrap_or_default();
 
   if properties.is_empty() {
     return String::new();
   }
 
   properties
-    .into_iter()
-    .map(|name| {
-      if required.contains(&name) {
-        format!("<{name}>")
-      } else {
-        format!("[{name}]")
-      }
-    })
-    .collect::<Vec<_>>()
-    .join(" ")
+      .into_iter()
+      .map(|name| {
+        if required.contains(&name) {
+          format!("<{name}>")
+        } else {
+          format!("[{name}]")
+        }
+      })
+      .collect::<Vec<_>>()
+      .join(" ")
 }
 
 fn print_call_result(result: &rmcp::model::CallToolResult) {
@@ -312,11 +313,11 @@ fn parse_tool_arguments(args: &[String]) -> Result<Map<String, Value>, String> {
   }
 
   let value: Value = serde_json::from_str(&args[0])
-    .map_err(|err| format!("failed to parse tool arguments JSON: {err}"))?;
+      .map_err(|err| format!("failed to parse tool arguments JSON: {err}"))?;
   value
-    .as_object()
-    .cloned()
-    .ok_or_else(|| "tool arguments must be a JSON object".to_string())
+      .as_object()
+      .cloned()
+      .ok_or_else(|| "tool arguments must be a JSON object".to_string())
 }
 
 fn run_sjmcl_deeplink() -> Result<(), String> {
@@ -342,18 +343,18 @@ fn run_sjmcl_deeplink() -> Result<(), String> {
   };
 
   command
-    .status()
-    .map_err(|err| format!("failed to open deeplink `{RUN_SJMCL_DEEPLINK}`: {err}"))
-    .and_then(|status| {
-      if status.success() {
-        Ok(())
-      } else {
-        Err(format!(
-          "deeplink launcher exited with status {} for `{RUN_SJMCL_DEEPLINK}`",
-          status
-        ))
-      }
-    })
+      .status()
+      .map_err(|err| format!("failed to open deeplink `{RUN_SJMCL_DEEPLINK}`: {err}"))
+      .and_then(|status| {
+        if status.success() {
+          Ok(())
+        } else {
+          Err(format!(
+            "deeplink launcher exited with status {} for `{RUN_SJMCL_DEEPLINK}`",
+            status
+          ))
+        }
+      })
 }
 
 fn mcp_endpoint(port: u16) -> String {
@@ -362,10 +363,10 @@ fn mcp_endpoint(port: u16) -> String {
 
 fn parse_u16_option(flag: &str, value: &str) -> Result<u16, String> {
   value
-    .parse::<u16>()
-    .ok()
-    .filter(|port| *port > 0)
-    .ok_or_else(|| format!("invalid value for {flag}: `{value}`"))
+      .parse::<u16>()
+      .ok()
+      .filter(|port| *port > 0)
+      .ok_or_else(|| format!("invalid value for {flag}: `{value}`"))
 }
 
 fn service_error_to_string(err: rmcp::service::ServiceError) -> String {
@@ -374,7 +375,7 @@ fn service_error_to_string(err: rmcp::service::ServiceError) -> String {
 
 async fn with_spinner<F, T>(future: F) -> T
 where
-  F: std::future::Future<Output = T>,
+    F: std::future::Future<Output = T>,
 {
   if !io::stderr().is_terminal() {
     return future.await;
@@ -384,8 +385,8 @@ where
   spinner.set_draw_target(ProgressDrawTarget::stderr());
   spinner.set_style(
     ProgressStyle::with_template("{spinner}")
-      .unwrap()
-      .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
+        .unwrap()
+        .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
   );
   spinner.enable_steady_tick(std::time::Duration::from_millis(80));
 
@@ -396,6 +397,6 @@ where
 
 fn os_string_to_string(value: OsString) -> Result<String, String> {
   value
-    .into_string()
-    .map_err(|_| "non-UTF-8 CLI arguments are not supported".to_string())
+      .into_string()
+      .map_err(|_| "non-UTF-8 CLI arguments are not supported".to_string())
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,7 +22,7 @@ const MCP_SERVER_HOST: &str = "127.0.0.1";
 const MCP_SERVER_PATH: &str = "/mcp";
 const RUN_SJMCL_DEEPLINK: &str = "sjmcl://run-silently";
 const ENABLE_MCP_HINT: &str =
-  "Please enable Launcher MCP Server in SJMCL - Intelligence to use the CLI.\nIf your MCP server uses a port other than the default 18970, run the CLI with `-p <port>`.";
+"Please enable Launcher MCP Server in SJMCL - Intelligence to use the CLI.\nIf your MCP server uses a port other than the default 18970, run the CLI with `-p <port>`.";
 
 #[derive(Clone)]
 struct CliOptions {
@@ -61,20 +61,20 @@ async fn run() -> Result<(), String> {
   match invocation.command {
     CliCommand::Help => {
       let (tools, hint) =
-          match with_spinner(async { connect_launcher(&invocation.options).await }).await {
-            Ok(client) => {
-              let tools = with_spinner(async {
-                client
-                    .list_all_tools()
-                    .await
-                    .map_err(service_error_to_string)
-              })
-                  .await?;
-              let _ = client.cancel().await;
-              (Some(tools), None)
-            }
-            Err(err) => (None, Some(err)),
-          };
+      match with_spinner(async { connect_launcher(&invocation.options).await }).await {
+        Ok(client) => {
+          let tools = with_spinner(async {
+            client
+            .list_all_tools()
+            .await
+            .map_err(service_error_to_string)
+          })
+          .await?;
+          let _ = client.cancel().await;
+          (Some(tools), None)
+        }
+        Err(err) => (None, Some(err)),
+      };
 
       print_help(tools.as_deref(), hint.as_deref());
       Ok(())
@@ -83,11 +83,11 @@ async fn run() -> Result<(), String> {
       let client = with_spinner(async { connect_launcher(&invocation.options).await }).await?;
       let result = with_spinner(async {
         client
-            .call_tool(CallToolRequestParams::new(name.clone()).with_arguments(arguments))
-            .await
-            .map_err(service_error_to_string)
+        .call_tool(CallToolRequestParams::new(name.clone()).with_arguments(arguments))
+        .await
+        .map_err(service_error_to_string)
       })
-          .await?;
+      .await?;
       let _ = client.cancel().await;
 
       print_call_result(&result);
@@ -104,7 +104,7 @@ async fn run() -> Result<(), String> {
 impl CliInvocation {
   fn parse<I>(args: I) -> Result<Self, String>
   where
-      I: IntoIterator<Item = OsString>,
+  I: IntoIterator<Item = OsString>,
   {
     let mut args = args.into_iter();
     let _bin = args.next();
@@ -123,8 +123,8 @@ impl CliInvocation {
         }
         "-p" | "--port" => {
           let value = args
-              .next()
-              .ok_or_else(|| "missing value for --port".to_string())?;
+          .next()
+          .ok_or_else(|| "missing value for --port".to_string())?;
           options.port = parse_u16_option("--port", &os_string_to_string(value)?)?;
         }
         _ if arg.starts_with("-p=") => {
@@ -137,8 +137,8 @@ impl CliInvocation {
           rest.push(arg);
           rest.extend(
             args
-                .map(os_string_to_string)
-                .collect::<Result<Vec<_>, _>>()?,
+            .map(os_string_to_string)
+            .collect::<Result<Vec<_>, _>>()?,
           );
           break;
         }
@@ -154,10 +154,10 @@ impl CliInvocation {
 
     Ok(Self {
       options,
-      command: CliCommand::Call {
-        name: rest[0].clone(),
-        arguments: parse_tool_arguments(&rest[1..])?,
-      },
+       command: CliCommand::Call {
+         name: rest[0].clone(),
+       arguments: parse_tool_arguments(&rest[1..])?,
+       },
     })
   }
 }
@@ -189,13 +189,13 @@ async fn try_connect(port: u16) -> Result<LauncherClient, String> {
   let endpoint = mcp_endpoint(port);
   let transport = StreamableHttpClientTransport::from_uri(endpoint.clone());
   let client = ()
-      .serve(transport)
-      .await
-      .map_err(|err| format!("failed to initialize MCP client for {endpoint}: {err}"))?;
+  .serve(transport)
+  .await
+  .map_err(|err| format!("failed to initialize MCP client for {endpoint}: {err}"))?;
 
   let server_info = client
-      .peer_info()
-      .ok_or_else(|| format!("server at {endpoint} did not provide MCP server info"))?;
+  .peer_info()
+  .ok_or_else(|| format!("server at {endpoint} did not provide MCP server info"))?;
 
   if server_info.server_info.name != EXPECTED_SERVER_NAME {
     let actual_name = server_info.server_info.name.clone();
@@ -244,40 +244,40 @@ fn print_tool_list(tools: &[Tool]) {
 
 fn summarize_input_schema(tool: &Tool) -> String {
   let required = tool
-      .input_schema
-      .get("required")
-      .and_then(Value::as_array)
-      .map(|items| {
-        items
-            .iter()
-            .filter_map(Value::as_str)
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-      })
-      .unwrap_or_default();
+  .input_schema
+  .get("required")
+  .and_then(Value::as_array)
+  .map(|items| {
+    items
+    .iter()
+    .filter_map(Value::as_str)
+    .map(ToString::to_string)
+    .collect::<Vec<_>>()
+  })
+  .unwrap_or_default();
 
   let properties = tool
-      .input_schema
-      .get("properties")
-      .and_then(Value::as_object)
-      .map(|props| props.keys().cloned().collect::<Vec<_>>())
-      .unwrap_or_default();
+  .input_schema
+  .get("properties")
+  .and_then(Value::as_object)
+  .map(|props| props.keys().cloned().collect::<Vec<_>>())
+  .unwrap_or_default();
 
   if properties.is_empty() {
     return String::new();
   }
 
   properties
-      .into_iter()
-      .map(|name| {
-        if required.contains(&name) {
-          format!("<{name}>")
-        } else {
-          format!("[{name}]")
-        }
-      })
-      .collect::<Vec<_>>()
-      .join(" ")
+  .into_iter()
+  .map(|name| {
+    if required.contains(&name) {
+      format!("<{name}>")
+    } else {
+      format!("[{name}]")
+    }
+  })
+  .collect::<Vec<_>>()
+  .join(" ")
 }
 
 fn print_call_result(result: &rmcp::model::CallToolResult) {
@@ -313,11 +313,11 @@ fn parse_tool_arguments(args: &[String]) -> Result<Map<String, Value>, String> {
   }
 
   let value: Value = serde_json::from_str(&args[0])
-      .map_err(|err| format!("failed to parse tool arguments JSON: {err}"))?;
+  .map_err(|err| format!("failed to parse tool arguments JSON: {err}"))?;
   value
-      .as_object()
-      .cloned()
-      .ok_or_else(|| "tool arguments must be a JSON object".to_string())
+  .as_object()
+  .cloned()
+  .ok_or_else(|| "tool arguments must be a JSON object".to_string())
 }
 
 fn run_sjmcl_deeplink() -> Result<(), String> {
@@ -343,18 +343,18 @@ fn run_sjmcl_deeplink() -> Result<(), String> {
   };
 
   command
-      .status()
-      .map_err(|err| format!("failed to open deeplink `{RUN_SJMCL_DEEPLINK}`: {err}"))
-      .and_then(|status| {
-        if status.success() {
-          Ok(())
-        } else {
-          Err(format!(
-            "deeplink launcher exited with status {} for `{RUN_SJMCL_DEEPLINK}`",
-            status
-          ))
-        }
-      })
+  .status()
+  .map_err(|err| format!("failed to open deeplink `{RUN_SJMCL_DEEPLINK}`: {err}"))
+  .and_then(|status| {
+    if status.success() {
+      Ok(())
+    } else {
+      Err(format!(
+        "deeplink launcher exited with status {} for `{RUN_SJMCL_DEEPLINK}`",
+        status
+      ))
+    }
+  })
 }
 
 fn mcp_endpoint(port: u16) -> String {
@@ -363,10 +363,10 @@ fn mcp_endpoint(port: u16) -> String {
 
 fn parse_u16_option(flag: &str, value: &str) -> Result<u16, String> {
   value
-      .parse::<u16>()
-      .ok()
-      .filter(|port| *port > 0)
-      .ok_or_else(|| format!("invalid value for {flag}: `{value}`"))
+  .parse::<u16>()
+  .ok()
+  .filter(|port| *port > 0)
+  .ok_or_else(|| format!("invalid value for {flag}: `{value}`"))
 }
 
 fn service_error_to_string(err: rmcp::service::ServiceError) -> String {
@@ -375,7 +375,7 @@ fn service_error_to_string(err: rmcp::service::ServiceError) -> String {
 
 async fn with_spinner<F, T>(future: F) -> T
 where
-    F: std::future::Future<Output = T>,
+F: std::future::Future<Output = T>,
 {
   if !io::stderr().is_terminal() {
     return future.await;
@@ -385,8 +385,8 @@ where
   spinner.set_draw_target(ProgressDrawTarget::stderr());
   spinner.set_style(
     ProgressStyle::with_template("{spinner}")
-        .unwrap()
-        .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
+    .unwrap()
+    .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
   );
   spinner.enable_steady_tick(std::time::Duration::from_millis(80));
 
@@ -397,6 +397,6 @@ where
 
 fn os_string_to_string(value: OsString) -> Result<String, String> {
   value
-      .into_string()
-      .map_err(|_| "non-UTF-8 CLI arguments are not supported".to_string())
+  .into_string()
+  .map_err(|_| "non-UTF-8 CLI arguments are not supported".to_string())
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,7 +22,7 @@ const MCP_SERVER_HOST: &str = "127.0.0.1";
 const MCP_SERVER_PATH: &str = "/mcp";
 const RUN_SJMCL_DEEPLINK: &str = "sjmcl://run-silently";
 const ENABLE_MCP_HINT: &str =
-"Please enable Launcher MCP Server in SJMCL - Intelligence to use the CLI.\nIf your MCP server uses a port other than the default 18970, run the CLI with `-p <port>`.";
+  "Please enable Launcher MCP Server in SJMCL - Intelligence to use the CLI.\nIf your MCP server uses a port other than the default 18970, run the CLI with `-p <port>`.";
 
 #[derive(Clone)]
 struct CliOptions {
@@ -61,20 +61,20 @@ async fn run() -> Result<(), String> {
   match invocation.command {
     CliCommand::Help => {
       let (tools, hint) =
-      match with_spinner(async { connect_launcher(&invocation.options).await }).await {
-        Ok(client) => {
-          let tools = with_spinner(async {
-            client
-            .list_all_tools()
-            .await
-            .map_err(service_error_to_string)
-          })
-          .await?;
-          let _ = client.cancel().await;
-          (Some(tools), None)
-        }
-        Err(err) => (None, Some(err)),
-      };
+        match with_spinner(async { connect_launcher(&invocation.options).await }).await {
+          Ok(client) => {
+            let tools = with_spinner(async {
+              client
+                .list_all_tools()
+                .await
+                .map_err(service_error_to_string)
+            })
+            .await?;
+            let _ = client.cancel().await;
+            (Some(tools), None)
+          }
+          Err(err) => (None, Some(err)),
+        };
 
       print_help(tools.as_deref(), hint.as_deref());
       Ok(())
@@ -83,9 +83,9 @@ async fn run() -> Result<(), String> {
       let client = with_spinner(async { connect_launcher(&invocation.options).await }).await?;
       let result = with_spinner(async {
         client
-        .call_tool(CallToolRequestParams::new(name.clone()).with_arguments(arguments))
-        .await
-        .map_err(service_error_to_string)
+          .call_tool(CallToolRequestParams::new(name.clone()).with_arguments(arguments))
+          .await
+          .map_err(service_error_to_string)
       })
       .await?;
       let _ = client.cancel().await;
@@ -104,7 +104,7 @@ async fn run() -> Result<(), String> {
 impl CliInvocation {
   fn parse<I>(args: I) -> Result<Self, String>
   where
-  I: IntoIterator<Item = OsString>,
+    I: IntoIterator<Item = OsString>,
   {
     let mut args = args.into_iter();
     let _bin = args.next();
@@ -123,8 +123,8 @@ impl CliInvocation {
         }
         "-p" | "--port" => {
           let value = args
-          .next()
-          .ok_or_else(|| "missing value for --port".to_string())?;
+            .next()
+            .ok_or_else(|| "missing value for --port".to_string())?;
           options.port = parse_u16_option("--port", &os_string_to_string(value)?)?;
         }
         _ if arg.starts_with("-p=") => {
@@ -137,8 +137,8 @@ impl CliInvocation {
           rest.push(arg);
           rest.extend(
             args
-            .map(os_string_to_string)
-            .collect::<Result<Vec<_>, _>>()?,
+              .map(os_string_to_string)
+              .collect::<Result<Vec<_>, _>>()?,
           );
           break;
         }
@@ -154,10 +154,10 @@ impl CliInvocation {
 
     Ok(Self {
       options,
-       command: CliCommand::Call {
-         name: rest[0].clone(),
-       arguments: parse_tool_arguments(&rest[1..])?,
-       },
+      command: CliCommand::Call {
+        name: rest[0].clone(),
+        arguments: parse_tool_arguments(&rest[1..])?,
+      },
     })
   }
 }
@@ -189,13 +189,13 @@ async fn try_connect(port: u16) -> Result<LauncherClient, String> {
   let endpoint = mcp_endpoint(port);
   let transport = StreamableHttpClientTransport::from_uri(endpoint.clone());
   let client = ()
-  .serve(transport)
-  .await
-  .map_err(|err| format!("failed to initialize MCP client for {endpoint}: {err}"))?;
+    .serve(transport)
+    .await
+    .map_err(|err| format!("failed to initialize MCP client for {endpoint}: {err}"))?;
 
   let server_info = client
-  .peer_info()
-  .ok_or_else(|| format!("server at {endpoint} did not provide MCP server info"))?;
+    .peer_info()
+    .ok_or_else(|| format!("server at {endpoint} did not provide MCP server info"))?;
 
   if server_info.server_info.name != EXPECTED_SERVER_NAME {
     let actual_name = server_info.server_info.name.clone();
@@ -244,40 +244,40 @@ fn print_tool_list(tools: &[Tool]) {
 
 fn summarize_input_schema(tool: &Tool) -> String {
   let required = tool
-  .input_schema
-  .get("required")
-  .and_then(Value::as_array)
-  .map(|items| {
-    items
-    .iter()
-    .filter_map(Value::as_str)
-    .map(ToString::to_string)
-    .collect::<Vec<_>>()
-  })
-  .unwrap_or_default();
+    .input_schema
+    .get("required")
+    .and_then(Value::as_array)
+    .map(|items| {
+      items
+        .iter()
+        .filter_map(Value::as_str)
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+    })
+    .unwrap_or_default();
 
   let properties = tool
-  .input_schema
-  .get("properties")
-  .and_then(Value::as_object)
-  .map(|props| props.keys().cloned().collect::<Vec<_>>())
-  .unwrap_or_default();
+    .input_schema
+    .get("properties")
+    .and_then(Value::as_object)
+    .map(|props| props.keys().cloned().collect::<Vec<_>>())
+    .unwrap_or_default();
 
   if properties.is_empty() {
     return String::new();
   }
 
   properties
-  .into_iter()
-  .map(|name| {
-    if required.contains(&name) {
-      format!("<{name}>")
-    } else {
-      format!("[{name}]")
-    }
-  })
-  .collect::<Vec<_>>()
-  .join(" ")
+    .into_iter()
+    .map(|name| {
+      if required.contains(&name) {
+        format!("<{name}>")
+      } else {
+        format!("[{name}]")
+      }
+    })
+    .collect::<Vec<_>>()
+    .join(" ")
 }
 
 fn print_call_result(result: &rmcp::model::CallToolResult) {
@@ -313,11 +313,11 @@ fn parse_tool_arguments(args: &[String]) -> Result<Map<String, Value>, String> {
   }
 
   let value: Value = serde_json::from_str(&args[0])
-  .map_err(|err| format!("failed to parse tool arguments JSON: {err}"))?;
+    .map_err(|err| format!("failed to parse tool arguments JSON: {err}"))?;
   value
-  .as_object()
-  .cloned()
-  .ok_or_else(|| "tool arguments must be a JSON object".to_string())
+    .as_object()
+    .cloned()
+    .ok_or_else(|| "tool arguments must be a JSON object".to_string())
 }
 
 fn run_sjmcl_deeplink() -> Result<(), String> {
@@ -343,18 +343,18 @@ fn run_sjmcl_deeplink() -> Result<(), String> {
   };
 
   command
-  .status()
-  .map_err(|err| format!("failed to open deeplink `{RUN_SJMCL_DEEPLINK}`: {err}"))
-  .and_then(|status| {
-    if status.success() {
-      Ok(())
-    } else {
-      Err(format!(
-        "deeplink launcher exited with status {} for `{RUN_SJMCL_DEEPLINK}`",
-        status
-      ))
-    }
-  })
+    .status()
+    .map_err(|err| format!("failed to open deeplink `{RUN_SJMCL_DEEPLINK}`: {err}"))
+    .and_then(|status| {
+      if status.success() {
+        Ok(())
+      } else {
+        Err(format!(
+          "deeplink launcher exited with status {} for `{RUN_SJMCL_DEEPLINK}`",
+          status
+        ))
+      }
+    })
 }
 
 fn mcp_endpoint(port: u16) -> String {
@@ -363,10 +363,10 @@ fn mcp_endpoint(port: u16) -> String {
 
 fn parse_u16_option(flag: &str, value: &str) -> Result<u16, String> {
   value
-  .parse::<u16>()
-  .ok()
-  .filter(|port| *port > 0)
-  .ok_or_else(|| format!("invalid value for {flag}: `{value}`"))
+    .parse::<u16>()
+    .ok()
+    .filter(|port| *port > 0)
+    .ok_or_else(|| format!("invalid value for {flag}: `{value}`"))
 }
 
 fn service_error_to_string(err: rmcp::service::ServiceError) -> String {
@@ -375,7 +375,7 @@ fn service_error_to_string(err: rmcp::service::ServiceError) -> String {
 
 async fn with_spinner<F, T>(future: F) -> T
 where
-F: std::future::Future<Output = T>,
+  F: std::future::Future<Output = T>,
 {
   if !io::stderr().is_terminal() {
     return future.await;
@@ -385,8 +385,8 @@ F: std::future::Future<Output = T>,
   spinner.set_draw_target(ProgressDrawTarget::stderr());
   spinner.set_style(
     ProgressStyle::with_template("{spinner}")
-    .unwrap()
-    .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
+      .unwrap()
+      .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
   );
   spinner.enable_steady_tick(std::time::Duration::from_millis(80));
 
@@ -397,6 +397,6 @@ F: std::future::Future<Output = T>,
 
 fn os_string_to_string(value: OsString) -> Result<String, String> {
   value
-  .into_string()
-  .map_err(|_| "non-UTF-8 CLI arguments are not supported".to_string())
+    .into_string()
+    .map_err(|_| "non-UTF-8 CLI arguments are not supported".to_string())
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,15 +1,15 @@
-use comfy_table::{presets::UTF8_FULL_CONDENSED, ContentArrangement, Table};
+use comfy_table::{ContentArrangement, Table, presets::UTF8_FULL_CONDENSED};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+use rmcp::ServiceExt;
 use rmcp::model::{CallToolRequestParams, Tool};
 use rmcp::service::{RoleClient, RunningService};
 use rmcp::transport::StreamableHttpClientTransport;
-use rmcp::ServiceExt;
 use serde_json::{Map, Value};
 use std::env;
 use std::ffi::OsString;
 use std::io::{self, IsTerminal};
 use std::process::Command;
-use tokio::time::{sleep, Instant};
+use tokio::time::{Instant, sleep};
 
 type LauncherClient = RunningService<RoleClient, ()>;
 
@@ -21,8 +21,7 @@ const EXPECTED_SERVER_NAME: &str = "sjmcl-mcp";
 const MCP_SERVER_HOST: &str = "127.0.0.1";
 const MCP_SERVER_PATH: &str = "/mcp";
 const RUN_SJMCL_DEEPLINK: &str = "sjmcl://run-silently";
-const ENABLE_MCP_HINT: &str =
-  "Please enable Launcher MCP Server in SJMCL - Intelligence to use the CLI.\nIf your MCP server uses a port other than the default 18970, run the CLI with `-p <port>`.";
+const ENABLE_MCP_HINT: &str = "Please enable Launcher MCP Server in SJMCL - Intelligence to use the CLI.\nIf your MCP server uses a port other than the default 18970, run the CLI with `-p <port>`.";
 
 #[derive(Clone)]
 struct CliOptions {

--- a/src-tauri/assets/game/fmllibs.json
+++ b/src-tauri/assets/game/fmllibs.json
@@ -1,0 +1,112 @@
+{
+  "1.3.x": [
+    {
+      "filename": "argo-2.25.jar",
+      "checksum": "bb672829fde76cb163004752b86b0484bd0a7f4b"
+    },
+    {
+      "filename": "guava-12.0.1.jar",
+      "checksum": "b8e78b9af7bf45900e14c6f958486b6ca682195f"
+    },
+    {
+      "filename": "asm-all-4.0.jar",
+      "checksum": "98308890597acb64047f7e896638e0d98753ae82"
+    }
+  ],
+  "1.4.x": [
+    {
+      "filename": "argo-2.25.jar",
+      "checksum": "bb672829fde76cb163004752b86b0484bd0a7f4b"
+    },
+    {
+      "filename": "guava-12.0.1.jar",
+      "checksum": "b8e78b9af7bf45900e14c6f958486b6ca682195f"
+    },
+    {
+      "filename": "asm-all-4.0.jar",
+      "checksum": "98308890597acb64047f7e896638e0d98753ae82"
+    },
+    {
+      "filename": "bcprov-jdk15on-147.jar",
+      "checksum": "b6f5d9926b0afbde9f4dbe3db88c5247be7794bb"
+    }
+  ],
+  "1.5": [
+    {
+      "filename": "argo-small-3.2.jar",
+      "checksum": "58912ea2858d168c50781f956fa5b59f0f7c6b51"
+    },
+    {
+      "filename": "guava-14.0-rc3.jar",
+      "checksum": "931ae21fa8014c3ce686aaa621eae565fefb1a6a"
+    },
+    {
+      "filename": "asm-all-4.1.jar",
+      "checksum": "054986e962b88d8660ae4566475658469595ef58"
+    },
+    {
+      "filename": "bcprov-jdk15on-148.jar",
+      "checksum": "960dea7c9181ba0b17e8bab0c06a43f0a5f04e65"
+    },
+    {
+      "filename": "deobfuscation_data_1.5.zip",
+      "checksum": "5f7c142d53776f16304c0bbe10542014abad6af8"
+    },
+    {
+      "filename": "scala-library.jar",
+      "checksum": "458d046151ad179c85429ed7420ffb1eaf6ddf85"
+    }
+  ],
+  "1.5.1": [
+    {
+      "filename": "argo-small-3.2.jar",
+      "checksum": "58912ea2858d168c50781f956fa5b59f0f7c6b51"
+    },
+    {
+      "filename": "guava-14.0-rc3.jar",
+      "checksum": "931ae21fa8014c3ce686aaa621eae565fefb1a6a"
+    },
+    {
+      "filename": "asm-all-4.1.jar",
+      "checksum": "054986e962b88d8660ae4566475658469595ef58"
+    },
+    {
+      "filename": "bcprov-jdk15on-148.jar",
+      "checksum": "960dea7c9181ba0b17e8bab0c06a43f0a5f04e65"
+    },
+    {
+      "filename": "deobfuscation_data_1.5.1.zip",
+      "checksum": "22e221a0d89516c1f721d6cab056a7e37471d0a6"
+    },
+    {
+      "filename": "scala-library.jar",
+      "checksum": "458d046151ad179c85429ed7420ffb1eaf6ddf85"
+    }
+  ],
+  "1.5.2": [
+    {
+      "filename": "argo-small-3.2.jar",
+      "checksum": "58912ea2858d168c50781f956fa5b59f0f7c6b51"
+    },
+    {
+      "filename": "guava-14.0-rc3.jar",
+      "checksum": "931ae21fa8014c3ce686aaa621eae565fefb1a6a"
+    },
+    {
+      "filename": "asm-all-4.1.jar",
+      "checksum": "054986e962b88d8660ae4566475658469595ef58"
+    },
+    {
+      "filename": "bcprov-jdk15on-148.jar",
+      "checksum": "960dea7c9181ba0b17e8bab0c06a43f0a5f04e65"
+    },
+    {
+      "filename": "deobfuscation_data_1.5.2.zip",
+      "checksum": "446e55cd986582c70fcf12cb27bc00114c5adfd9"
+    },
+    {
+      "filename": "scala-library.jar",
+      "checksum": "458d046151ad179c85429ed7420ffb1eaf6ddf85"
+    }
+  ]
+}

--- a/src-tauri/src/instance/helpers/loader/common.rs
+++ b/src-tauri/src/instance/helpers/loader/common.rs
@@ -1,3 +1,4 @@
+use semver::Version;
 use sjmcl_types::error::SJMCLResult;
 use std::fs::File;
 use std::io::Read;
@@ -12,6 +13,7 @@ use crate::instance::helpers::loader::fabric::install_fabric_loader;
 use crate::instance::helpers::loader::forge::{InstallProfile, install_forge_loader};
 use crate::instance::helpers::loader::neoforge::install_neoforge_loader;
 use crate::instance::helpers::loader::quilt::install_quilt_loader;
+use crate::instance::helpers::loader::universal_forge::install_universal_forge_loader;
 use crate::instance::helpers::misc::get_instance_game_config;
 use crate::instance::models::misc::{Instance, InstanceError, ModLoader, ModLoaderType};
 use crate::launch::helpers::file_validator::merge_library_lists;
@@ -74,7 +76,12 @@ pub async fn install_mod_loader(
       .await
     }
     ModLoaderType::Forge => {
-      install_forge_loader(priority, game_version, loader, lib_dir.clone(), task_params).await
+      if Version::parse(game_version)?.lt(&Version::new(1, 6, 0)) {
+        install_universal_forge_loader(priority, game_version, loader, lib_dir.clone(), task_params)
+          .await
+      } else {
+        install_forge_loader(priority, game_version, loader, lib_dir.clone(), task_params).await
+      }
     }
     ModLoaderType::Cleanroom => {
       install_cleanroom_loader(priority, loader, lib_dir.clone(), task_params).await

--- a/src-tauri/src/instance/helpers/loader/mod.rs
+++ b/src-tauri/src/instance/helpers/loader/mod.rs
@@ -5,3 +5,4 @@ pub mod forge;
 pub mod neoforge;
 pub mod optifine;
 pub mod quilt;
+pub mod universal_forge;

--- a/src-tauri/src/instance/helpers/loader/universal_forge.rs
+++ b/src-tauri/src/instance/helpers/loader/universal_forge.rs
@@ -1,0 +1,235 @@
+use crate::instance::helpers::client_json::{
+  LibrariesValue, McClientInfo, reset_fields_from_patches,
+};
+use crate::instance::helpers::misc::get_instance_subdir_paths;
+use crate::instance::models::misc::{Instance, InstanceError, InstanceSubdirType, ModLoader};
+use crate::launch::helpers::file_validator::convert_library_name_to_path;
+use crate::resource::helpers::misc::get_download_api;
+use crate::resource::models::{ResourceType, SourceType};
+use crate::tasks::PTaskParam;
+use crate::tasks::commands::schedule_progressive_task_group;
+use crate::tasks::download::DownloadParam;
+use crate::utils::fs::get_app_resource_filepath;
+use reqwest_middleware::reqwest::redirect::Policy;
+use reqwest_middleware::reqwest::{Client, Error, StatusCode};
+use serde::Deserialize;
+use sjmcl_types::error::{SJMCLError, SJMCLResult};
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use tauri::AppHandle;
+use url::Url;
+
+async fn fetch_bmcl_forge_universal_url(
+  root: Url,
+  game_version: &str,
+  loader_ver: &str,
+) -> Result<String, Error> {
+  let client = Client::builder().redirect(Policy::limited(5)).build()?;
+
+  let response = client
+    .get(root.clone())
+    .query(&[
+      ("mcversion", game_version),
+      ("version", loader_ver),
+      ("category", "client"),
+      ("format", "zip"),
+    ])
+    .send()
+    .await?;
+
+  if response.status() == StatusCode::NOT_FOUND {
+    let response = client
+      .get(root)
+      .query(&[
+        ("mcversion", game_version),
+        ("version", loader_ver),
+        ("category", "universal"),
+        ("format", "zip"),
+      ])
+      .send()
+      .await?;
+    Ok(response.url().to_string())
+  } else {
+    Ok(response.url().to_string())
+  }
+}
+
+pub async fn install_universal_forge_loader(
+  priority: &[SourceType],
+  game_version: &str,
+  loader: &ModLoader,
+  lib_dir: PathBuf,
+  task_params: &mut Vec<PTaskParam>,
+) -> SJMCLResult<()> {
+  let loader_ver = &loader.version;
+
+  let mut universal_url_opt: Option<Url> = None;
+  for source_type in priority.iter() {
+    if let Ok(root) = get_download_api(*source_type, ResourceType::ForgeInstall) {
+      let url_res: SJMCLResult<Url> = match source_type {
+        SourceType::Official => {
+          let full_ver = vec![game_version, loader_ver.as_str()]
+            .into_iter()
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>()
+            .join("-");
+
+          let client = Client::builder()
+            .redirect(Policy::limited(5))
+            .build()
+            .map_err(|e| SJMCLError(e.to_string()))?;
+
+          let response = client
+            .get(root.join(&format!("{full_ver}/forge-{full_ver}-client.zip"))?)
+            .send()
+            .await
+            .map_err(|e| SJMCLError(e.to_string()))?;
+
+          let status = response.status();
+          if status == StatusCode::NOT_FOUND {
+            Ok(root.join(&format!("{full_ver}/forge-{full_ver}-universal.zip"))?)
+          } else {
+            Ok(root.join(&format!("{full_ver}/forge-{full_ver}-client.zip"))?)
+          }
+        }
+        SourceType::BMCLAPIMirror => {
+          let s = fetch_bmcl_forge_universal_url(root, game_version, loader_ver)
+            .await
+            .map_err(|e| SJMCLError(e.to_string()))?;
+          Ok(Url::parse(&s)?)
+        }
+      };
+      if let Ok(url) = url_res {
+        universal_url_opt = Some(url);
+        break;
+      }
+    }
+  }
+
+  let universal_url = universal_url_opt
+    .ok_or_else(|| SJMCLError("failed to resolve Forge universal URL".to_string()))?;
+
+  let universal_coord = format!("net.minecraftforge:forge:{}", loader.version);
+  let universal_rel = convert_library_name_to_path(&universal_coord, None)?;
+  let universal_path = lib_dir.join(&universal_rel);
+
+  task_params.push(PTaskParam::Download(DownloadParam {
+    src: universal_url,
+    dest: universal_path.clone(),
+    filename: None,
+    sha1: None,
+  }));
+
+  Ok(())
+}
+
+pub async fn download_universal_forge_libraries(
+  app: &AppHandle,
+  priority: &[SourceType],
+  instance: &Instance,
+  client_info: &mut McClientInfo,
+) -> SJMCLResult<()> {
+  let subdirs = get_instance_subdir_paths(
+    app,
+    instance,
+    &[&InstanceSubdirType::Root, &InstanceSubdirType::Libraries],
+  )
+  .ok_or(InstanceError::InvalidSourcePath)?;
+
+  let [root_dir, lib_dir] = subdirs.as_slice() else {
+    return Err(InstanceError::InvalidSourcePath.into());
+  };
+
+  let version = instance.mod_loader.version.clone();
+  let universal_coord = format!("net.minecraftforge:forge:{version}");
+  let universal_rel = convert_library_name_to_path(&universal_coord, None)?;
+  let universal_path = lib_dir.join(&universal_rel);
+
+  if !universal_path.exists() {
+    return Err(InstanceError::LoaderInstallerNotFound.into());
+  }
+
+  client_info.patches.push(McClientInfo {
+    id: "forge".to_string(),
+    version: Some(version.clone()),
+    priority: Some(30000),
+    libraries: vec![LibrariesValue {
+      name: universal_coord.clone(),
+      downloads: Default::default(),
+      natives: Default::default(),
+      extract: Default::default(),
+      rules: Default::default(),
+    }],
+    ..Default::default()
+  });
+
+  let mut task_params = vec![];
+
+  let path = get_app_resource_filepath(app, "assets/game/fmllibs.json")?;
+  let txt =
+    fs::read_to_string(&path).map_err(|e| SJMCLError(format!("read fmllibs.json failed: {e}")))?;
+  let map: HashMap<String, Vec<FMLLib>> = serde_json::from_str(&txt)
+    .map_err(|e| SJMCLError(format!("parse fmllibs.json failed: {e}")))?;
+
+  let forge_version = &instance.mod_loader.version;
+
+  let mut libs: &Vec<FMLLib> = &vec![];
+  if forge_version.starts_with("4.") {
+    libs = map.get("1.3.x").unwrap();
+  } else if forge_version.starts_with("6.") || forge_version.starts_with("5.") {
+    libs = map.get("1.4.x").unwrap();
+  } else if forge_version.starts_with("7.7.0.5") {
+    libs = map.get("1.5").unwrap();
+  } else if forge_version.starts_with("7.7.0.6")
+    || forge_version.starts_with("7.7.1.")
+    || forge_version.starts_with("7.7.2.")
+  {
+    libs = map.get("1.5.1").unwrap();
+  } else if forge_version.starts_with("7.8.") {
+    libs = map.get("1.5.2").unwrap();
+  }
+
+  for lib in libs {
+    task_params.push(PTaskParam::Download(DownloadParam {
+      src: Url::parse(
+        format!("https://files.prismlauncher.org/fmllibs/{}", lib.filename).as_str(),
+      )?,
+      dest: root_dir.join("libs").join(&lib.filename),
+      filename: None,
+      sha1: lib.checksum.clone(),
+    }));
+
+    task_params.push(PTaskParam::Download(DownloadParam {
+      src: Url::parse(
+        format!("https://files.prismlauncher.org/fmllibs/{}", lib.filename).as_str(),
+      )?,
+      dest: lib_dir.join("..").join("libs").join(&lib.filename),
+      filename: None,
+      sha1: lib.checksum.clone(),
+    }));
+  }
+
+  let mut seen = std::collections::HashSet::new();
+  task_params.retain(|param| match param {
+    PTaskParam::Download(dp) => seen.insert(dp.dest.clone()),
+  });
+
+  schedule_progressive_task_group(
+    app.clone(),
+    format!("forge-libraries?{}", instance.id),
+    task_params,
+    true,
+  )
+  .await?;
+
+  reset_fields_from_patches(client_info);
+
+  Ok(())
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct FMLLib {
+  pub filename: String,
+  pub checksum: Option<String>,
+}

--- a/src-tauri/src/instance/helpers/misc.rs
+++ b/src-tauri/src/instance/helpers/misc.rs
@@ -1,4 +1,5 @@
 use sanitize_filename;
+use semver::Version;
 use serde_json::Value;
 use sjmcl_types::error::SJMCLResult;
 use sjmcl_types::storage::load_json_async;
@@ -16,6 +17,7 @@ use crate::instance::helpers::loader::cleanroom::download_cleanroom_libraries;
 use crate::instance::helpers::loader::forge::download_forge_libraries;
 use crate::instance::helpers::loader::neoforge::download_neoforge_libraries;
 use crate::instance::helpers::loader::optifine::download_optifine_libraries;
+use crate::instance::helpers::loader::universal_forge::download_universal_forge_libraries;
 use crate::instance::models::misc::{
   Instance, InstanceError, InstanceSubdirType, ModLoader, ModLoaderStatus, ModLoaderType, OptiFine,
 };
@@ -174,8 +176,19 @@ async fn refresh_instance(
         ModLoaderStatus::NotDownloaded => {
           match cfg_read.mod_loader.loader_type {
             ModLoaderType::Forge => {
-              cfg_read.mod_loader.status = ModLoaderStatus::Downloading;
-              download_forge_libraries(app, &priority_list, &cfg_read, &mut client_data).await?;
+              if Version::parse(&*cfg_read.version)?.lt(&Version::new(1, 6, 0)) {
+                download_universal_forge_libraries(
+                  app,
+                  &priority_list,
+                  &cfg_read,
+                  &mut client_data,
+                )
+                .await?;
+                cfg_read.mod_loader.status = ModLoaderStatus::Installed;
+              } else {
+                cfg_read.mod_loader.status = ModLoaderStatus::Downloading;
+                download_forge_libraries(app, &priority_list, &cfg_read, &mut client_data).await?;
+              }
             }
             ModLoaderType::Cleanroom => {
               cfg_read.mod_loader.status = ModLoaderStatus::Downloading;
@@ -197,8 +210,15 @@ async fn refresh_instance(
         }
         ModLoaderStatus::DownloadFailed => match cfg_read.mod_loader.loader_type {
           ModLoaderType::Forge => {
-            cfg_read.mod_loader.status = ModLoaderStatus::Downloading;
-            download_forge_libraries(app, &priority_list, &cfg_read, &mut client_data).await
+            if Version::parse(&*cfg_read.version)?.lt(&Version::new(1, 6, 0)) {
+              download_universal_forge_libraries(app, &priority_list, &cfg_read, &mut client_data)
+                .await?;
+              cfg_read.mod_loader.status = ModLoaderStatus::Installed;
+              Ok(())
+            } else {
+              cfg_read.mod_loader.status = ModLoaderStatus::Downloading;
+              download_forge_libraries(app, &priority_list, &cfg_read, &mut client_data).await
+            }
           }
           ModLoaderType::Cleanroom => {
             cfg_read.mod_loader.status = ModLoaderStatus::Downloading;


### PR DESCRIPTION
<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [x] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [ ] Code formatting and commit messages align with the project's conventions.
- [ ] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [x] 🐞 Bug fix

### Related Issues

closes #1954

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Support installation of legacy Forge versions below Minecraft 1.6.

New Features:
- Add support for installing Forge versions for Minecraft 1.2 through 1.5 using universal Forge packages and version-specific legacy libraries.

Bug Fixes:
- Correct legacy Forge library installation and instance status handling so supported pre-1.6 versions can complete installation successfully.