### PR TITLE
fix(instance): manage mods in supported loader subdirectories

### DIFF
--- a/src-tauri/src/instance/commands.rs
+++ b/src-tauri/src/instance/commands.rs
@@ -616,7 +616,34 @@ pub async fn retrieve_local_mod_list(
     .build()
     .unwrap();
 
-  let mod_paths = get_files_with_regex(&mods_dir, &valid_extensions).unwrap_or_default();
+  let supports_mod_subdirectories = matches!(
+    installed_loader_type,
+    Some(
+      ModLoaderType::Forge
+        | ModLoaderType::LegacyForge
+        | ModLoaderType::Cleanroom
+        | ModLoaderType::LiteLoader
+        | ModLoaderType::Quilt
+    )
+  );
+  let mod_paths = get_files_with_regex_recursive(
+    &mods_dir,
+    &valid_extensions,
+    Some(usize::from(supports_mod_subdirectories)),
+  )
+  .unwrap_or_default()
+  .into_iter()
+  .filter(|path| {
+    !path.strip_prefix(&mods_dir).is_ok_and(|relative| {
+      relative.components().next().is_some_and(|component| {
+        component
+          .as_os_str()
+          .to_string_lossy()
+          .eq_ignore_ascii_case(".connector")
+      })
+    })
+  })
+  .collect::<Vec<_>>();
   let mut tasks = Vec::new();
   let semaphore = Arc::new(Semaphore::new(
     std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get),

--- a/src-tauri/src/resource/commands.rs
+++ b/src-tauri/src/resource/commands.rs
@@ -1,4 +1,5 @@
 use sjmcl_types::error::SJMCLResult;
+use std::path::Path;
 use std::sync::Mutex;
 use tauri::{AppHandle, Manager, State};
 use tauri_plugin_http::reqwest;
@@ -198,12 +199,23 @@ pub async fn update_mods(
     None => return Ok(()),
   };
 
+  let updates = queries
+    .iter()
+    .map(|query| {
+      let old_file_path = Path::new(&query.old_file_path);
+      let target_dir = old_file_path
+        .parent()
+        .filter(|parent| parent.starts_with(&mods_dir))
+        .unwrap_or(&mods_dir);
+      (query, target_dir.join(&query.file_name))
+    })
+    .collect::<Vec<_>>();
+
   let mut download_tasks = Vec::new();
-  for query in &queries {
-    let file_path = mods_dir.join(&query.file_name);
+  for (query, file_path) in &updates {
     let download_param = DownloadParam {
       src: url::Url::parse(&query.url).map_err(|_| ResourceError::ParseError)?,
-      dest: file_path,
+      dest: file_path.clone(),
       filename: None,
       sha1: Some(query.sha1.clone()),
     };
@@ -212,13 +224,12 @@ pub async fn update_mods(
 
   schedule_progressive_task_group(app, "mod-update".to_string(), download_tasks, true).await?;
 
-  for query in &queries {
-    let old_file_path = &query.old_file_path;
-    let new_file_path = mods_dir.join(&query.file_name);
+  for (query, new_file_path) in updates {
+    let old_file_path = Path::new(&query.old_file_path);
 
-    if old_file_path != &new_file_path.to_string_lossy().to_string() {
-      let old_backup_path = format!("{}.old", old_file_path);
-      if let Err(e) = std::fs::rename(old_file_path, &old_backup_path) {
+    if old_file_path != new_file_path {
+      let old_backup_path = format!("{}.old", old_file_path.to_string_lossy());
+      if let Err(e) = std::fs::rename(old_file_path, old_backup_path) {
         log::error!("Failed to rename old mod file: {}", e);
         return Err(ResourceError::FileOperationError.into());
       }

--- a/src/components/modals/check-mod-update-modal.tsx
+++ b/src/components/modals/check-mod-update-modal.tsx
@@ -70,9 +70,9 @@ const CheckModUpdateModal: React.FC<CheckModUpdateModalProps> = ({
 
   const handleModToggle = (mod: ModUpdateRecord) => {
     setSelectedMods((prev) => {
-      const isSelected = prev.some((m) => m.name === mod.name);
+      const isSelected = prev.some((m) => m.oldFilePath === mod.oldFilePath);
       if (isSelected) {
-        return prev.filter((m) => m.name !== mod.name);
+        return prev.filter((m) => m.oldFilePath !== mod.oldFilePath);
       } else {
         return [...prev, mod];
       }
@@ -217,6 +217,7 @@ const CheckModUpdateModal: React.FC<CheckModUpdateModalProps> = ({
               mod,
               updateRecord: {
                 name: mod.name,
+                oldFilePath: mod.filePath,
                 curVersion: mod.version,
                 newVersion: latestFile.name,
                 source: isCurseForgeNewer
@@ -261,19 +262,22 @@ const CheckModUpdateModal: React.FC<CheckModUpdateModalProps> = ({
   const summaryId = summary?.id;
 
   const handleDownloadUpdatedMods = useCallback(
-    async (urlShaPairs: { url: string; sha1: string; fileName: string }[]) => {
+    async (
+      urlShaPairs: {
+        url: string;
+        sha1: string;
+        fileName: string;
+        oldFilePath: string;
+      }[]
+    ) => {
       let params: ModUpdateQuery[] = [];
       if (summaryId) {
         for (const pair of urlShaPairs) {
-          const { url, sha1, fileName } = pair;
-          const oldMod = modsToUpdate.find((mod) =>
-            updateList.some(
-              (update) =>
-                update.fileName === fileName && update.name === mod.name
-            )
+          const { url, sha1, fileName, oldFilePath } = pair;
+          const oldMod = modsToUpdate.find(
+            (mod) => mod.filePath === oldFilePath
           );
           if (oldMod) {
-            const oldFilePath = oldMod.filePath;
             const finalFileName =
               addPrefix && oldMod.translatedName
                 ? `[${oldMod.translatedName}] ${fileName}`
@@ -289,7 +293,7 @@ const CheckModUpdateModal: React.FC<CheckModUpdateModalProps> = ({
         ResourceService.updateMods(summaryId, params);
       }
     },
-    [summaryId, modsToUpdate, updateList, addPrefix]
+    [summaryId, modsToUpdate, addPrefix]
   );
 
   useEffect(() => {
@@ -411,7 +415,7 @@ const CheckModUpdateModal: React.FC<CheckModUpdateModalProps> = ({
                 <VStack spacing={0} align="stretch">
                   {updateList.map((mod, index) => (
                     <HStack
-                      key={mod.fileName} // unique
+                      key={mod.oldFilePath}
                       py={3}
                       px={4}
                       borderBottom={
@@ -424,7 +428,7 @@ const CheckModUpdateModal: React.FC<CheckModUpdateModalProps> = ({
                     >
                       <Checkbox
                         isChecked={selectedMods.some(
-                          (m) => m.name === mod.name
+                          (m) => m.oldFilePath === mod.oldFilePath
                         )}
                         onChange={() => handleModToggle(mod)}
                         colorScheme={primaryColor}
@@ -494,6 +498,7 @@ const CheckModUpdateModal: React.FC<CheckModUpdateModalProps> = ({
                       url: mod.downloadUrl,
                       sha1: mod.sha1,
                       fileName: mod.fileName,
+                      oldFilePath: mod.oldFilePath,
                     }))
                   );
                   modalProps.onClose?.();

--- a/src/models/resource.ts
+++ b/src/models/resource.ts
@@ -82,6 +82,7 @@ export interface OptiFineResourceInfo {
 
 export interface ModUpdateRecord {
   name: string;
+  oldFilePath: string;
   curVersion: string;
   newVersion: string;
   source: string;

--- a/src/pages/instances/details/[id]/mods.tsx
+++ b/src/pages/instances/details/[id]/mods.tsx
@@ -560,7 +560,7 @@ const InstanceModsPage = () => {
           <OptionItemGroup
             items={filteredMods.map((mod) => (
               <OptionItem
-                key={mod.fileName} // unique
+                key={mod.filePath}
                 childrenOnHover
                 title={
                   <Text


### PR DESCRIPTION
### Checklist

- [ ] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [x] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🐞 Bug fix

### Related Issues

- fix #1940

### Description

- Discover mods in subdirectories for Forge, LegacyForge, Cleanroom, LiteLoader, and Quilt instances.
- Preserve each mod subdirectory when installing updates.
- Use full file paths to distinguish mods with identical filenames in different directories.
- Ignore files under the `.connector` directory.

### Additional Context

Validated with Cargo checks, Rust formatting, ESLint, TypeScript type checking, and diff checks.

## Summary by Sourcery

Fix mod discovery and updates for instances that organize supported loader mods in subdirectories.

Bug Fixes:
- Discover mods in supported loader subdirectories while excluding files under `.connector`.
- Preserve each mod's existing subdirectory during updates and distinguish mods by their full paths, including in update selection and display.

Enhancements:
- Use full mod paths as stable identities throughout mod update workflows.