### PR TITLE
feat(frontend): support to save skin file to local in the view-skin m…

### DIFF
--- a/src/components/modals/view-skin-modal.tsx
+++ b/src/components/modals/view-skin-modal.tsx
@@ -49,6 +49,7 @@ const ViewSkinModal: React.FC<ViewSkinModalProps> = ({
               width={416} // calculated from model content size
               height={310}
               showControlBar
+              showSaveButton={Boolean(skin && !skin.preset)}
               isCapeVisible={isCapeVisible}
               onCapeVisibilityChange={setIsCapeVisible}
             />

--- a/src/components/skin-preview.tsx
+++ b/src/components/skin-preview.tsx
@@ -13,6 +13,7 @@ import {
   Tooltip,
   VStack,
 } from "@chakra-ui/react";
+import { save } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { BsPersonRaisedHand } from "react-icons/bs";
@@ -30,10 +31,14 @@ import {
   LuPlay,
   LuRefreshCw,
   LuRefreshCwOff,
+  LuSave,
 } from "react-icons/lu";
 import * as skinview3d from "skinview3d";
+import { CommonIconButton } from "@/components/common/common-icon-button";
 import { useLauncherConfig } from "@/contexts/config";
+import { useToast } from "@/contexts/toast";
 import { SkinModel } from "@/enums/account";
+import { UtilsService } from "@/services/utils";
 
 type AnimationType = "idle" | "walk" | "run" | "wave";
 type backgroundType = "none" | "black" | "panorama";
@@ -50,6 +55,7 @@ interface SkinPreviewProps extends Omit<BoxProps, "width" | "height"> {
   errorMessage?: string | null;
   onSkinError?: (msg: string | null) => void;
   showControlBar?: boolean;
+  showSaveButton?: boolean;
   skinModel?: SkinModel;
 }
 
@@ -65,10 +71,12 @@ const SkinPreview: React.FC<SkinPreviewProps> = ({
   errorMessage,
   onSkinError,
   showControlBar = true,
+  showSaveButton = false,
   skinModel,
   ...props
 }) => {
   const { t } = useTranslation();
+  const toast = useToast();
   const { config } = useLauncherConfig();
   const primaryColor = config.appearance.theme.primaryColor;
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -78,6 +86,32 @@ const SkinPreview: React.FC<SkinPreviewProps> = ({
   const [background, setBackground] = useState<backgroundType>(canvasBg);
   const [autoRotate, setAutoRotate] = useState(false);
   const [isPlaying, setIsPlaying] = useState(true);
+
+  const handleSaveSkin = async () => {
+    if (!skinSrc) return;
+
+    const savePath = await save({
+      defaultPath: "skin.png",
+      filters: [
+        {
+          name: t("General.dialog.filterName.image"),
+          extensions: ["png"],
+        },
+      ],
+    });
+    if (!savePath) return;
+
+    const response = await UtilsService.writeFile(
+      savePath,
+      skinSrc.replace(/^data:image\/png;base64,/, ""),
+      "base64"
+    );
+    toast({
+      title: t(`SkinPreview.toast.${response.status}`),
+      description: response.status === "error" ? response.details : undefined,
+      status: response.status,
+    });
+  };
 
   // animation
   const animationList = useMemo(
@@ -336,6 +370,13 @@ const SkinPreview: React.FC<SkinPreviewProps> = ({
               onChange={(e) => onCapeVisibilityChange?.(e.target.checked)}
               colorScheme={primaryColor}
             />
+            {showSaveButton && (
+              <CommonIconButton
+                icon={LuSave}
+                label={t("SkinPreview.button.saveToLocal")}
+                onClick={handleSaveSkin}
+              />
+            )}
           </HStack>
         </Flex>
       )}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3111,6 +3111,7 @@
       "wave": "Wave"
     },
     "button": {
+      "saveToLocal": "Save Locally",
       "enableRotation": "Enable Rotation",
       "disableRotation": "Disable Rotation",
       "play": "Play",
@@ -3118,6 +3119,10 @@
     },
     "error": {
       "loadSkin": "Failed to load skin"
+    },
+    "toast": {
+      "error": "Failed to save skin locally",
+      "success": "Skin saved locally"
     }
   },
   "SpotlightSearchModal": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -3111,6 +3111,7 @@
       "wave": "Saludar"
     },
     "button": {
+      "saveToLocal": "Guardar localmente",
       "enableRotation": "Habilitar Rotación",
       "disableRotation": "Deshabilitar Rotación",
       "play": "Reproducir",
@@ -3118,6 +3119,10 @@
     },
     "error": {
       "loadSkin": "Error al cargar la skin"
+    },
+    "toast": {
+      "error": "No se pudo guardar la skin localmente",
+      "success": "Skin guardada localmente"
     }
   },
   "SpotlightSearchModal": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -3111,6 +3111,7 @@
       "wave": "Saluer"
     },
     "button": {
+      "saveToLocal": "Enregistrer localement",
       "enableRotation": "Activer la rotation",
       "disableRotation": "Désactiver la rotation",
       "play": "Lire",
@@ -3118,6 +3119,10 @@
     },
     "error": {
       "loadSkin": "加载皮肤失败"
+    },
+    "toast": {
+      "error": "Échec de l’enregistrement local du skin",
+      "success": "Skin enregistré localement"
     }
   },
   "SpotlightSearchModal": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -3111,6 +3111,7 @@
       "wave": "手を振る"
     },
     "button": {
+      "saveToLocal": "ローカルに保存",
       "enableRotation": "回転を有効化",
       "disableRotation": "回転を無効化",
       "play": "再生",
@@ -3118,6 +3119,10 @@
     },
     "error": {
       "loadSkin": "スキンのロードに失敗"
+    },
+    "toast": {
+      "error": "スキンのローカル保存に失敗しました",
+      "success": "スキンをローカルに保存しました"
     }
   },
   "SpotlightSearchModal": {

--- a/src/locales/lzh.json
+++ b/src/locales/lzh.json
@@ -3111,6 +3111,7 @@
       "wave": "揮手"
     },
     "button": {
+      "saveToLocal": "存於本地",
       "enableRotation": "啟旋轉",
       "disableRotation": "禁旋轉",
       "play": "播放",
@@ -3118,6 +3119,10 @@
     },
     "error": {
       "loadSkin": "載入外觀未成"
+    },
+    "toast": {
+      "error": "存外觀於本地未成",
+      "success": "已存外觀於本地"
     }
   },
   "SpotlightSearchModal": {

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -3111,6 +3111,7 @@
       "wave": "挥手"
     },
     "button": {
+      "saveToLocal": "保存到本地",
       "enableRotation": "启用旋转",
       "disableRotation": "禁用旋转",
       "play": "播放",
@@ -3118,6 +3119,10 @@
     },
     "error": {
       "loadSkin": "加载皮肤失败"
+    },
+    "toast": {
+      "error": "保存皮肤到本地失败",
+      "success": "已将皮肤保存到本地"
     }
   },
   "SpotlightSearchModal": {

--- a/src/locales/zh-Hant.json
+++ b/src/locales/zh-Hant.json
@@ -3111,6 +3111,7 @@
       "wave": "揮手"
     },
     "button": {
+      "saveToLocal": "儲存至本機",
       "enableRotation": "啟用旋轉",
       "disableRotation": "停用旋轉",
       "play": "播放",
@@ -3118,6 +3119,10 @@
     },
     "error": {
       "loadSkin": "載入外觀失敗"
+    },
+    "toast": {
+      "error": "儲存外觀至本機失敗",
+      "success": "已將外觀儲存至本機"
     }
   },
   "SpotlightSearchModal": {


### PR DESCRIPTION
…odal

<!--
Thank you for contributing to this project! 🎉 We appreciate your efforts and time. 🥰
Please take a moment to fill out the information below to help us review your PR efficiently.
-->

### Checklist

<!-- Please ensure the following requirements are met before submitting your PR. -->

- [x] Changes have been tested locally and work as expected.
- [ ] All tests in workflows pass successfully.
- [ ] Documentation has been updated if necessary.
- [x] Code formatting and commit messages align with the project's conventions.
- [x] Comments have been added for any complex logic or functionality if possible.

### This PR is a ..

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 🛠 Refactoring
- [ ] ⚡️ Performance improvement
- [ ] 🌐 Internationalization
- [ ] 📄 Documentation improvement
- [ ] 🎨 Code style optimization
- [ ] ❓ Other (Please specify below)

### Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - e.g. close #xxxx, fix #xxxx

### Description

> - Please insert your description here and provide info about the "what" this PR is solving.

### Additional Context

> - Add any other relevant information or screenshots here.

## Summary by Sourcery

Enable users to export custom skins from the view-skin modal to local PNG files.

New Features:
- Add an option to save non-preset skin previews as PNG files locally.
- Provide localized labels and status messages for the skin export action.

Enhancements:
- Expose configurable save-button visibility in the skin preview component.